### PR TITLE
Add the capability for a client to incrementally transfer vf axis space

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -385,7 +385,7 @@ For an <code>AxisInterval</code> object to be well formed:
 
 *  <code>start</code> must be set.
 
-*  <code>end</code> optional, must be greater than <code>start</code>. If <code>end</code> is not set
+*  <code>end</code> is optional, must be greater than <code>start</code>. If <code>end</code> is not set
     then this interval is a single point, <code>start</code>.
 
 #### PatchRequest #### {#PatchRequest}

--- a/Overview.bs
+++ b/Overview.bs
@@ -9,8 +9,8 @@ ED: https://w3c.github.io/PFE/Overview.html
 Editor: Chris Lilley, W3C, https://svgees.us/, w3cid 1438
 Editor: Myles C. Maxfield, Apple Inc., mmaxfield@apple.com, w3cid 77180
 Editor: Garret Rieger, Google Inc., grieger@google.com
-Abstract: Example example
-Status Text: This is a largely empty document because we have just started working on it.
+Abstract: TODO(garretrieger)
+Status Text: initial draft is in progress.
 </pre>
 
 <!--
@@ -42,6 +42,19 @@ Status Text: This is a largely empty document because we have just started worki
         "title": "Shared Brotli Compressed Data Format",
         "date": "27 Jul 2021"
     }
+	}
+</pre>
+
+<pre class=biblio>
+	{
+	    "OpenType-Variations": {
+            "href": "https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview",
+            "authors": [],
+            "status": "Note",
+            "publisher": "Microsoft",
+			"title": "OpenType Font Variations Overview",
+			"date": "23 October 2020"
+		}
 	}
 </pre>
 
@@ -291,9 +304,8 @@ significant bit in the byte and the bit with the largest index is the most signi
 
 ### AxisSpace ### {#AxisSpace}
 
-Stores a set of intervals on one or more
-<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview">open type variation
-axes</a>. Encoded as a CBOR map (major type 5). The key in each pair is an
+Stores a set of intervals on one or more open type variation axes [[opentype-variations]]</a>.
+Encoded as a CBOR map (major type 5). The key in each pair is an
 <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord">
 axis tag</a>. It is encoded as a ByteString containing exactly 4 ASCII characters. The value in each
 pair is an <a href="#AxisInterval"><code>AxisInterval</code></a>.

--- a/Overview.bs
+++ b/Overview.bs
@@ -112,6 +112,9 @@ should be encoded by CBOR are given in the definition of those data types.
     <td>Integer</td><td>An integer value range [-2^64 - 1, 2^64 - 1] inclusive.&nbsp;</td><td>0 or 1</td>
   </tr>
   <tr>
+    <td>Float</td><td>IEEE 754 Single-Precision Float.</td><td>7</td>
+  </tr>
+  <tr>
     <td>ByteString</td><td>Variable number of bytes.</td><td>2</td>
   </tr>
   <tr>
@@ -286,6 +289,15 @@ significant bit in the byte and the bit with the largest index is the most signi
 
 </div>
 
+### AxisSpace ### {#AxisSpace}
+
+Stores a set of intervals on one or more
+<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview">open type variation
+axes</a>. Encoded as a CBOR map (major type 5). The key in each pair is an
+<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord">
+axis tag</a>. It is encoded as a ByteString containing exactly 4 ASCII characters. The value in each
+pair is an <a href="#AxisInterval"><code>AxisInterval</code></a>.
+
 ### Objects ### {#objects}
 
 Objects are data structures comprised of key and value pairs. Objects are encoded via CBOR as maps
@@ -346,6 +358,24 @@ The list of ranges is encoded as a series of deltas. For example the ranges
   <tr><td>1</td><td>range_deltas</td><td>ArrayOf&lt;Integer&gt;</td></tr>
 </table>
 
+#### AxisInterval #### {#AxisInterval}
+
+<table>
+  <tr><th>ID</th><th>Field Name</th><th>Value Type</th></tr>
+  <tr><td>0</td><td>start</td><td>Float</td></tr>
+  <tr><td>1</td><td>end</td><td>Float</td></tr>
+</table>
+
+<code>AxisInterval</code> defines an interval (from <code>start</code> to <code>end</code>) on some
+variable axis in a font.
+
+For an <code>AxisInterval</code> object to be well formed:
+
+*  <code>start</code> must be set.
+
+*  <code>end</code> optional, must be greater than <code>start</code>. If <code>end</code> is not set
+    then this interval is a single point, <code>start</code>.
+
 #### PatchRequest #### {#PatchRequest}
 
 <table>
@@ -356,10 +386,12 @@ The list of ranges is encoded as a series of deltas. For example the ranges
   <tr><td>3</td><td>codepoints_needed</td><td>CompressedSet</td></tr>
   <tr><td>4</td><td>indices_have</td><td>CompressedSet</td></tr>
   <tr><td>5</td><td>indices_needed</td><td>CompressedSet</td></tr>
-  <tr><td>6</td><td>ordering_checksum</td><td>Integer</td></tr>
-  <tr><td>7</td><td>original_font_checksum</td><td>Integer</td></tr>
-  <tr><td>8</td><td>base_checksum</td><td>Integer</td></tr>
-  <tr><td>9</td><td>connection_speed</td><td>Integer</td></tr>
+  <tr><td>6</td><td>axis_space_have</td><td>AxisSpace</td></tr>
+  <tr><td>7</td><td>axis_space_needed</td><td>AxisSpace</td></tr>
+  <tr><td>8</td><td>ordering_checksum</td><td>Integer</td></tr>
+  <tr><td>9</td><td>original_font_checksum</td><td>Integer</td></tr>
+  <tr><td>10</td><td>base_checksum</td><td>Integer</td></tr>
+  <tr><td>11</td><td>connection_speed</td><td>Integer</td></tr>
 </table>
 
 For a PatchRequest object to be well formed:
@@ -380,12 +412,12 @@ For a PatchRequest object to be well formed:
   <tr><td>1</td><td>patch_format</td><td>Integer</td></tr>
   <tr><td>2</td><td>patch</td><td>ByteString</td></tr>
   <tr><td>3</td><td>replacement</td><td>ByteString</td></tr>
-
   <tr><td>4</td><td>original_font_checksum</td><td>Integer</td></tr>
   <tr><td>5</td><td>patched_checksum</td><td>Integer</td></tr>
-
   <tr><td>6</td><td>codepoint_ordering</td><td>CompressedList</td></tr>
   <tr><td>7</td><td>ordering_checksum</td><td>Integer</td></tr>
+  <tr><td>8</td><td>subset_axis_space</td><td>ArrayOf&lt;AxisInterval&gt;</td></tr>
+  <tr><td>9</td><td>original_axis_space</td><td>ArrayOf&lt;AxisInterval&gt;</td></tr>
 </table>
 
 For a PatchRequest object to be well formed:
@@ -400,6 +432,8 @@ Client {#client}
 ----------------
 
 ### Client State ### {#client-state}
+
+TODO(garretrieger): track subset axis space, original font axis space.
 
 The client will need to maintain at minimum the following state for each font file being incrementally
 transferred:
@@ -457,6 +491,13 @@ as follows:
     [[#codepoint-reordering]] to each codepoint value. If the client does not have a codepoint
     ordering for this font then this field should not be set.
 
+*  <code>axis_space_have</code>: set to the current value of <code>subset_axis_space</code>
+    saved in the state for this font.
+
+*  <code>axis_space_needed</code>: set to the intervals of each variable axis in the original
+    font that the client wants to add to its font subset. If the client wants an entire axis
+    from the original font then that axis should not be listed.
+
 *  <code>ordering_checksum</code>: If either of <code>indices_have</code> or
     <code>indices_needed</code> is set then this must be set to the current value of
     <code>ordering_checksum</code> saved in the state for this font.
@@ -474,6 +515,8 @@ as follows:
     that corresponds to the client's average round trip time.
 
 ### Handling PatchResponse ### {#handling-patch-response}
+
+TODO(garretrieger): update axes in client state.
 
 If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a>
 if will respond with HTTP status code 200 and the body of the response will be a
@@ -513,6 +556,9 @@ If the the checksum of the font subset computed by the client does not match the
 
 Server: Responding to a PatchRequest {#handling-patch-request}
 --------------------------------------------------------------
+
+TODO(garretrieger): axes stuff:
+- Must be superset of axes have, axes needed
 
 If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
 HTTPS that was populated according to the requirements in [[#extend-subset]] then it should

--- a/Overview.bs
+++ b/Overview.bs
@@ -672,22 +672,22 @@ The following connection speed values can be used:
     <th>Name</th><th>Value</th><th>Round Trip Times</th>
   </tr>
   <tr>
-    <td>Very Slow</td><td>1</td><td>&gt; 1000 ms.</td>
+    <td>Very Slow</td><td>0</td><td>&gt; 1000 ms.</td>
   </tr>
   <tr>
-    <td>Slow</td><td>2</td><td>[300 ms, 1000 ms)</td>
+    <td>Slow</td><td>1</td><td>[300 ms, 1000 ms)</td>
   </tr>
   <tr>
-    <td>Average</td><td>3</td><td>[150 ms, 300 ms)</td>
+    <td>Average</td><td>2</td><td>[150 ms, 300 ms)</td>
   </tr>
   <tr>
-    <td>Fast</td><td>4</td><td>[80 ms, 150 ms)</td>
+    <td>Fast</td><td>3</td><td>[80 ms, 150 ms)</td>
   </tr>
   <tr>
-    <td>Very Fast</td><td>5</td><td>[20 ms, 80 ms)</td>
+    <td>Very Fast</td><td>4</td><td>[20 ms, 80 ms)</td>
   </tr>
   <tr>
-    <td>Extremely Fast</td><td>6</td><td>[0 ms, 20 ms)</td>
+    <td>Extremely Fast</td><td>5</td><td>[0 ms, 20 ms)</td>
   </tr>
 </table>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -567,10 +567,6 @@ If the the checksum of the font subset computed by the client does not match the
 Server: Responding to a PatchRequest {#handling-patch-request}
 --------------------------------------------------------------
 
-TODO(garretrieger): axes stuff:
-- Must be superset of axes have, axes needed
-- Only send original axis space during a replacement
-
 If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
 HTTPS that was populated according to the requirements in [[#extend-subset]] then it should
 respond with HTTP status code 200. The body of the response should be a single
@@ -586,8 +582,18 @@ object the server can produce two codepoint sets:
 
 2.  Codepoints the client needs: formed by the union of the codepoint sets specified by
      <code>codepoints_needed</code> and <code>indices_needed</code>. The indices in
-     <code>indices_have</code> must be mapped to codepoints by the application of the
+     <code>indices_needed</code> must be mapped to codepoints by the application of the
      codepoint reordering with a checksum matching <code>ordering_checksum</code>.
+
+Likewise, the server can produce two variable axis spaces:
+
+1.  Axis space the client has: provided by <code>axis_space_have</code>. If any axes in the font are
+     not specified in <code>axis_space_have</code> then for those axes add their entire interval
+     from the original font.
+
+2. Axis space the client needs: provided by <code>axis_space_needed</code>. If any axes in the font are
+     not specified in <code>axis_space_needed</code> then for those axes add their entire interval
+     from the original font.
 
 If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it's codepoint ordering to one the server
@@ -596,21 +602,37 @@ That is the <code>patch</code> and <code>replacement</code> fields must not be s
 
 Otherwise when the response is applied by the client following the process in
 [[#handling-patch-response]] to a font subset with checksum <code>base_checksum</code> it must result
-in an extended font subset that contains data for at least the union of the set of codepoints needed
-and the sets of codepoints the client already has. The format of the patch in the either the
-<code>patch</code> or <code>replace</code> fields must be one of those listed in
-<code>accept_patch_format</code>.
+in an extended font subset:
 
-The value of <code>original_font_checksum</code> must be set to the checksum of the original font.
-The checksum value must computed by the procedure in [[#computing-checksums]].
+*  That contains data for at least the union of the set of codepoints needed and the sets of
+    codepoints the client already has.
 
-If the set of codepoints the client has is empty the response should set the
-<code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following
-[[#codepoint-reordering]].
+*  That contains a variation axis space that covers at least the union of the axis space the client
+    has and the axis space the client needs.
 
-If <code>accept_patch_format</code> contains any unrecognized patch formats the server should
-ignore the unrecognized ones. Likewise if <code>connection_speed</code> contains any unrecognized
-connection speeds the server should ignore the unrecognized ones.
+Additionally:
+    
+*  The format of the patch in the either the <code>patch</code> or <code>replace</code> fields must be
+    one of those listed in <code>accept_patch_format</code>.
+
+*  The value of <code>original_font_checksum</code> must be set to the checksum of the original font.
+    The checksum value must computed by the procedure in [[#computing-checksums]].
+
+*  If the set of codepoints the client has is empty the response must set the
+    <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following
+    [[#codepoint-reordering]].
+
+*  If the set of codepoints the client has is empty and the original font has variation axes, the
+    response must set the <code>original_axis_space</code> fields to the axis space covered by
+    the original font.
+
+*  If <code>patch</code> or <code>replacement</code> fields are set and the original font has
+    variation axes, the response must set the <code>subset_axis_space</code> field to the axis space
+    covered by the font subset.
+
+*  If <code>accept_patch_format</code> contains any unrecognized patch formats the server should
+    ignore the unrecognized ones. Likewise if <code>connection_speed</code> contains any unrecognized
+    connection speeds the server should ignore the unrecognized ones.
 
 Note: the server can optionally use the client's provided connection speed to inform how many extra
 codepoints should be sent. For example on slower connections it may be more performant to send extra

--- a/Overview.bs
+++ b/Overview.bs
@@ -511,10 +511,8 @@ If the the checksum of the font subset computed by the client does not match the
     to the union of the codepoints in the discarded font subset and the set of code points
     the the previous request was trying to add.
 
-Server {#server}
-----------------
-
-### Responding to a PatchRequest ### {#handling-patch-request}
+Server: Responding to a PatchRequest {#handling-patch-request}
+--------------------------------------------------------------
 
 If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
 HTTPS that was populated according to the requirements in [[#extend-subset]] then it should
@@ -546,6 +544,10 @@ and the sets of codepoints the client already has. The format of the patch in th
 <code>patch</code> or <code>replace</code> fields must be one of those listed in
 <code>accept_patch_format</code>.
 
+If <code>accept_patch_format</code> contains any unrecognized patch formats the server should
+ignore the unrecognized ones. Likewise if <code>connection_speed</code> contains any unrecognized
+connection speeds the server should ignore the unrecognized ones.
+
 Note: the server can optionally use the client's provided connection speed to inform how many extra
 codepoints should be sent. For example on slower connections it may be more performant to send extra
 codepoints if they can prevent a future request from needing to be sent.
@@ -562,10 +564,8 @@ Possible error responses:
 *  If the requested font is not recognized by the server it may respond with http status code 404 to
     indicate a not found error.
 
-Procedures {#procedures}
-------------------------
-
-### Computing Checksums ### {#computing-checksums}
+Computing Checksums {#computing-checksums}
+------------------------------------------
 
 64 bit checksums of byte strings are computed using the
 <a href="https://github.com/ztanml/fast-hash">fast hash</a> algorithm. A python like pseudo
@@ -601,7 +601,8 @@ fast_hash(byte[] data):
 Note: a C implementation of fast hash can be found
 <a href="https://github.com/ztanml/fast-hash">here</a>.
 
-### Codepoint Reordering ### {#codepoint-reordering}
+Codepoint Reordering {#codepoint-reordering}
+--------------------------------------------
 
 A codepoint reordering for a font defines a function which maps unicode codepoint values from the
 font to a continuous space of [0, number of codepoints in the font). This transformation is intended
@@ -614,7 +615,7 @@ the new value for that codepoint.
 A server is free to choose any codepoint ordering, but should try to pick one that will minimize the
 size of encoded codepoint sets for that font.
 
-#### Codepoint Reordering Checksum #### {#reordering-checksum}
+### Codepoint Reordering Checksum ### {#reordering-checksum}
 
 A checksum of a codepoint reordering can be computed as follows:
 
@@ -638,7 +639,8 @@ fast_hash_ordering(uint64[] ordering):
   return mix(hash)
 ```
 
-### Patch Formats ### {#patch-formats}
+Patch Formats {#patch-formats}
+------------------------------
 
 The following patch formats may be used by the server to create binary diffs between a source file
 and a target file:
@@ -660,7 +662,8 @@ and a target file:
   </tr>
 </table>
 
-### Connection Speeds ### {#connection-speeds}
+Connection Speeds {#connection-speeds}
+--------------------------------------
 
 The following connection speed values can be used:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -420,7 +420,7 @@ For a PatchRequest object to be well formed:
   <tr><td>9</td><td>original_axis_space</td><td>ArrayOf&lt;AxisInterval&gt;</td></tr>
 </table>
 
-For a PatchRequest object to be well formed:
+For a PatchResponse object to be well formed:
 *  <code>protocol_version</code> must be set to 0.
 *  <code>patch_format</code> can be any of the values listed [[#patch-formats]]
 *  Only one of <code>patch</code> or <code>replacement</code> may be set.
@@ -433,8 +433,6 @@ Client {#client}
 
 ### Client State ### {#client-state}
 
-TODO(garretrieger): track subset axis space, original font axis space.
-
 The client will need to maintain at minimum the following state for each font file being incrementally
 transferred:
 
@@ -443,11 +441,19 @@ transferred:
 *  Original font checksum: the most recent value of
     <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> received
     from the server for this font.
+    
 *  Codepoint Reordering Map: The most recent [[#codepoint-reordering]] received from the server
     for this font.
+    
 *  Codepoint Reordering Checksum: The most recent
     <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a>
     for this font.
+
+*  Original Font Axis Space: the variations axis space that the original font covers. Supplied
+    by <a href="#PatchResponse"><code>PatchResponse.original_axis_space</code></a>.
+
+*  Subset Axis Space: the most recent variations axis space that the subsetted font covers. Supplied by
+    <a href="#PatchResponse"><code>PatchResponse.subset_axis_space</code></a>.
 
 ### Extending the Font Subset ### {#extend-subset}
 
@@ -516,8 +522,6 @@ as follows:
 
 ### Handling PatchResponse ### {#handling-patch-response}
 
-TODO(garretrieger): update axes in client state.
-
 If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a>
 if will respond with HTTP status code 200 and the body of the response will be a
 <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via CBOR. The client
@@ -543,6 +547,12 @@ should interpret and process the fields of the object as follows:
     resend the request that triggered this response but use the new codepoint ordering provided in
     this response.
 
+5. If <code>original_axis_space</code> is set then update the saved original axis space with the value
+    specified in this field.
+
+6. If <code>subset_axis_space</code> is set then update the saved subset axis space with the value
+    specified in this field.
+
 ### Client Side Checksum Mismatch ### {#client-side-checksum-mismatch}
 
 If the the checksum of the font subset computed by the client does not match the
@@ -559,6 +569,7 @@ Server: Responding to a PatchRequest {#handling-patch-request}
 
 TODO(garretrieger): axes stuff:
 - Must be superset of axes have, axes needed
+- Only send original axis space during a replacement
 
 If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
 HTTPS that was populated according to the requirements in [[#extend-subset]] then it should
@@ -589,6 +600,13 @@ in an extended font subset that contains data for at least the union of the set 
 and the sets of codepoints the client already has. The format of the patch in the either the
 <code>patch</code> or <code>replace</code> fields must be one of those listed in
 <code>accept_patch_format</code>.
+
+The value of <code>original_font_checksum</code> must be set to the checksum of the original font.
+The checksum value must computed by the procedure in [[#computing-checksums]].
+
+If the set of codepoints the client has is empty the response should set the
+<code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following
+[[#codepoint-reordering]].
 
 If <code>accept_patch_format</code> contains any unrecognized patch formats the server should
 ignore the unrecognized ones. Likewise if <code>connection_speed</code> contains any unrecognized

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="cade5ffc86b3b9e0fedd6ec029787ebc16a0a51e" name="document-revision">
+  <meta content="802c531fe6d6a5305fad50778285885e27fb3de0" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1075,13 +1075,6 @@ to the union of the codepoints in the discarded font subset and the set of code 
 the the previous request was trying to add.</p>
    </ol>
    <h3 class="heading settled" data-level="2.4" id="handling-patch-request"><span class="secno">2.4. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
-   <p>TODO(garretrieger): axes stuff:</p>
-   <ul>
-    <li data-md>
-     <p>Must be superset of axes have, axes needed</p>
-    <li data-md>
-     <p>Only send original axis space during a replacement</p>
-   </ul>
    <p>If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
 HTTPS that was populated according to the requirements in <a href="#extend-subset">§ 2.3.2 Extending the Font Subset</a> then it should
 respond with HTTP status code 200. The body of the response should be a single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</p>
@@ -1092,22 +1085,57 @@ object the server can produce two codepoint sets:</p>
      <p>Codepoints the client has: formed by the union of the codepoint sets specified by <code>codepoints_have</code> and <code>indices_have</code>. The indices in <code>indices_have</code> must be mapped to codepoints by the application of the
  codepoint reordering with a checksum matching <code>ordering_checksum</code>.</p>
     <li data-md>
-     <p>Codepoints the client needs: formed by the union of the codepoint sets specified by <code>codepoints_needed</code> and <code>indices_needed</code>. The indices in <code>indices_have</code> must be mapped to codepoints by the application of the
+     <p>Codepoints the client needs: formed by the union of the codepoint sets specified by <code>codepoints_needed</code> and <code>indices_needed</code>. The indices in <code>indices_needed</code> must be mapped to codepoints by the application of the
  codepoint reordering with a checksum matching <code>ordering_checksum</code>.</p>
+   </ol>
+   <p>Likewise, the server can produce two variable axis spaces:</p>
+   <ol>
+    <li data-md>
+     <p>Axis space the client has: provided by <code>axis_space_have</code>. If any axes in the font are
+ not specified in <code>axis_space_have</code> then for those axes add their entire interval
+ from the original font.</p>
+    <li data-md>
+     <p>Axis space the client needs: provided by <code>axis_space_needed</code>. If any axes in the font are
+ not specified in <code>axis_space_needed</code> then for those axes add their entire interval
+ from the original font.</p>
    </ol>
    <p>If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
 will recognize via the process described in <a href="#handling-patch-response">§ 2.3.3 Handling PatchResponse</a> and not include any patch.
 That is the <code>patch</code> and <code>replacement</code> fields must not be set.</p>
    <p>Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 2.3.3 Handling PatchResponse</a> to a font subset with checksum <code>base_checksum</code> it must result
-in an extended font subset that contains data for at least the union of the set of codepoints needed
-and the sets of codepoints the client already has. The format of the patch in the either the <code>patch</code> or <code>replace</code> fields must be one of those listed in <code>accept_patch_format</code>.</p>
-   <p>The value of <code>original_font_checksum</code> must be set to the checksum of the original font.
+in an extended font subset:</p>
+   <ul>
+    <li data-md>
+     <p>That contains data for at least the union of the set of codepoints needed and the sets of
+codepoints the client already has.</p>
+    <li data-md>
+     <p>That contains a variation axis space that covers at least the union of the axis space the client
+has and the axis space the client needs.</p>
+   </ul>
+   <p>Additionally:</p>
+   <ul>
+    <li data-md>
+     <p>The format of the patch in the either the <code>patch</code> or <code>replace</code> fields must be
+one of those listed in <code>accept_patch_format</code>.</p>
+    <li data-md>
+     <p>The value of <code>original_font_checksum</code> must be set to the checksum of the original font.
 The checksum value must computed by the procedure in <a href="#computing-checksums">§ 2.5 Computing Checksums</a>.</p>
-   <p>If the set of codepoints the client has is empty the response should set the <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following <a href="#codepoint-reordering">§ 2.6 Codepoint Reordering</a>.</p>
-   <p>If <code>accept_patch_format</code> contains any unrecognized patch formats the server should
+    <li data-md>
+     <p>If the set of codepoints the client has is empty the response must set the <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following <a href="#codepoint-reordering">§ 2.6 Codepoint Reordering</a>.</p>
+    <li data-md>
+     <p>If the set of codepoints the client has is empty and the original font has variation axes, the
+response must set the <code>original_axis_space</code> fields to the axis space covered by
+the original font.</p>
+    <li data-md>
+     <p>If <code>patch</code> or <code>replacement</code> fields are set and the original font has
+variation axes, the response must set the <code>subset_axis_space</code> field to the axis space
+covered by the font subset.</p>
+    <li data-md>
+     <p>If <code>accept_patch_format</code> contains any unrecognized patch formats the server should
 ignore the unrecognized ones. Likewise if <code>connection_speed</code> contains any unrecognized
 connection speeds the server should ignore the unrecognized ones.</p>
+   </ul>
    <p class="note" role="note"><span>Note:</span> the server can optionally use the client’s provided connection speed to inform how many extra
 codepoints should be sent. For example on slower connections it may be more performant to send extra
 codepoints if they can prevent a future request from needing to be sent.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="5fa30128ddcfbd7e5bbafdd25c051a819b2807d5" name="document-revision">
+  <meta content="cade5ffc86b3b9e0fedd6ec029787ebc16a0a51e" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -944,7 +944,7 @@ then <code>ordering_checksum</code> must be set.</p>
       <td>original_axis_space
       <td>ArrayOf&lt;AxisInterval>
    </table>
-   <p>For a PatchRequest object to be well formed:</p>
+   <p>For a PatchResponse object to be well formed:</p>
    <ul>
     <li data-md>
      <p><code>protocol_version</code> must be set to 0.</p>
@@ -959,7 +959,6 @@ then <code>ordering_checksum</code> must be set.</p>
    </ul>
    <h3 class="heading settled" data-level="2.3" id="client"><span class="secno">2.3. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
    <h4 class="heading settled" data-level="2.3.1" id="client-state"><span class="secno">2.3.1. </span><span class="content">Client State</span><a class="self-link" href="#client-state"></a></h4>
-   <p>TODO(garretrieger): track subset axis space, original font axis space.</p>
    <p>The client will need to maintain at minimum the following state for each font file being incrementally
 transferred:</p>
    <ul>
@@ -974,6 +973,11 @@ from the server for this font.</p>
 for this font.</p>
     <li data-md>
      <p>Codepoint Reordering Checksum: The most recent <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> for this font.</p>
+    <li data-md>
+     <p>Original Font Axis Space: the variations axis space that the original font covers. Supplied
+by <a href="#PatchResponse"><code>PatchResponse.original_axis_space</code></a>.</p>
+    <li data-md>
+     <p>Subset Axis Space: the most recent variations axis space that the subsetted font covers. Supplied by <a href="#PatchResponse"><code>PatchResponse.subset_axis_space</code></a>.</p>
    </ul>
    <h4 class="heading settled" data-level="2.3.2" id="extend-subset"><span class="secno">2.3.2. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
    <p>A client extends its font subset to cover additional codepoints by making HTTP requests to
@@ -1032,7 +1036,6 @@ Can be optionally set by the client to a value from <a href="#connection-speeds"
 that corresponds to the client’s average round trip time.</p>
    </ul>
    <h4 class="heading settled" data-level="2.3.3" id="handling-patch-response"><span class="secno">2.3.3. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h4>
-   <p>TODO(garretrieger): update axes in client state.</p>
    <p>If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a> if will respond with HTTP status code 200 and the body of the response will be a <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via CBOR. The client
 should interpret and process the fields of the object as follows:</p>
    <ol>
@@ -1054,6 +1057,12 @@ the saved codepoint ordering and checksum with the new values specified by these
 If neither <code>replacement</code> nor <code>patch</code> are set, then the client should
 resend the request that triggered this response but use the new codepoint ordering provided in
 this response.</p>
+    <li data-md>
+     <p>If <code>original_axis_space</code> is set then update the saved original axis space with the value
+specified in this field.</p>
+    <li data-md>
+     <p>If <code>subset_axis_space</code> is set then update the saved subset axis space with the value
+specified in this field.</p>
    </ol>
    <h4 class="heading settled" data-level="2.3.4" id="client-side-checksum-mismatch"><span class="secno">2.3.4. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h4>
    <p>If the the checksum of the font subset computed by the client does not match the <code>patched_checksum</code> in the server’s response then the client should:</p>
@@ -1070,6 +1079,8 @@ the the previous request was trying to add.</p>
    <ul>
     <li data-md>
      <p>Must be superset of axes have, axes needed</p>
+    <li data-md>
+     <p>Only send original axis space during a replacement</p>
    </ul>
    <p>If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
 HTTPS that was populated according to the requirements in <a href="#extend-subset">§ 2.3.2 Extending the Font Subset</a> then it should
@@ -1091,6 +1102,9 @@ That is the <code>patch</code> and <code>replacement</code> fields must not be s
    <p>Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 2.3.3 Handling PatchResponse</a> to a font subset with checksum <code>base_checksum</code> it must result
 in an extended font subset that contains data for at least the union of the set of codepoints needed
 and the sets of codepoints the client already has. The format of the patch in the either the <code>patch</code> or <code>replace</code> fields must be one of those listed in <code>accept_patch_format</code>.</p>
+   <p>The value of <code>original_font_checksum</code> must be set to the checksum of the original font.
+The checksum value must computed by the procedure in <a href="#computing-checksums">§ 2.5 Computing Checksums</a>.</p>
+   <p>If the set of codepoints the client has is empty the response should set the <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following <a href="#codepoint-reordering">§ 2.6 Codepoint Reordering</a>.</p>
    <p>If <code>accept_patch_format</code> contains any unrecognized patch formats the server should
 ignore the unrecognized ones. Likewise if <code>connection_speed</code> contains any unrecognized
 connection speeds the server should ignore the unrecognized ones.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="fd9279f38e49b5f53fb24f30920596af85285f6d" name="document-revision">
+  <meta content="412d84b4ab26404441d240bfc7cc046d7e5aefb7" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1132,27 +1132,27 @@ and a target file:</p>
       <th>Round Trip Times
      <tr>
       <td>Very Slow
-      <td>1
+      <td>0
       <td>> 1000 ms.
      <tr>
       <td>Slow
-      <td>2
+      <td>1
       <td>[300 ms, 1000 ms)
      <tr>
       <td>Average
-      <td>3
+      <td>2
       <td>[150 ms, 300 ms)
      <tr>
       <td>Fast
-      <td>4
+      <td>3
       <td>[80 ms, 150 ms)
      <tr>
       <td>Very Fast
-      <td>5
+      <td>4
       <td>[20 ms, 80 ms)
      <tr>
       <td>Extremely Fast
-      <td>6
+      <td>5
       <td>[0 ms, 20 ms)
    </table>
    <h2 class="heading settled" data-level="3" id="range-request-incxfer"><span class="secno">3. </span><span class="content">Range Request Incremental Transfer</span><a class="self-link" href="#range-request-incxfer"></a></h2>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="412d84b4ab26404441d240bfc7cc046d7e5aefb7" name="document-revision">
+  <meta content="5fa30128ddcfbd7e5bbafdd25c051a819b2807d5" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -457,14 +457,16 @@ dfn > a.self-link::before      { content: "#"; }
         <li><a href="#encoding"><span class="secno">2.2.1</span> <span class="content">Encoding</span></a>
         <li><a href="#primitives"><span class="secno">2.2.2</span> <span class="content">Primitives</span></a>
         <li><a href="#sparsebitset"><span class="secno">2.2.3</span> <span class="content">SparseBitSet</span></a>
-        <li><a href="#objects"><span class="secno">2.2.4</span> <span class="content">Objects</span></a>
+        <li><a href="#AxisSpace"><span class="secno">2.2.4</span> <span class="content">AxisSpace</span></a>
+        <li><a href="#objects"><span class="secno">2.2.5</span> <span class="content">Objects</span></a>
         <li>
-         <a href="#schemas"><span class="secno">2.2.5</span> <span class="content">Object Schemas</span></a>
+         <a href="#schemas"><span class="secno">2.2.6</span> <span class="content">Object Schemas</span></a>
          <ol class="toc">
-          <li><a href="#CompressedList"><span class="secno">2.2.5.1</span> <span class="content">CompressedList</span></a>
-          <li><a href="#CompressedSet"><span class="secno">2.2.5.2</span> <span class="content">CompressedSet</span></a>
-          <li><a href="#PatchRequest"><span class="secno">2.2.5.3</span> <span class="content">PatchRequest</span></a>
-          <li><a href="#PatchResponse"><span class="secno">2.2.5.4</span> <span class="content">PatchResponse</span></a>
+          <li><a href="#CompressedList"><span class="secno">2.2.6.1</span> <span class="content">CompressedList</span></a>
+          <li><a href="#CompressedSet"><span class="secno">2.2.6.2</span> <span class="content">CompressedSet</span></a>
+          <li><a href="#AxisInterval"><span class="secno">2.2.6.3</span> <span class="content">AxisInterval</span></a>
+          <li><a href="#PatchRequest"><span class="secno">2.2.6.4</span> <span class="content">PatchRequest</span></a>
+          <li><a href="#PatchResponse"><span class="secno">2.2.6.5</span> <span class="content">PatchResponse</span></a>
          </ol>
        </ol>
       <li>
@@ -558,6 +560,10 @@ should be encoded by CBOR are given in the definition of those data types.</p>
       <td>Integer
       <td>An integer value range [-2^64 - 1, 2^64 - 1] inclusive. 
       <td>0 or 1
+     <tr>
+      <td>Float
+      <td>IEEE 754 Single-Precision Float.
+      <td>7
      <tr>
       <td>ByteString
       <td>Variable number of bytes.
@@ -728,7 +734,11 @@ significant bit in the byte and the bit with the largest index is the most signi
       <p>n<sub>3</sub> append 0011. Bit 0 set for value 16, bit 1 set for value 17.</p>
     </ul>
    </div>
-   <h4 class="heading settled" data-level="2.2.4" id="objects"><span class="secno">2.2.4. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>
+   <h4 class="heading settled" data-level="2.2.4" id="AxisSpace"><span class="secno">2.2.4. </span><span class="content">AxisSpace</span><a class="self-link" href="#AxisSpace"></a></h4>
+   <p>Stores a set of intervals on one or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview">open type variation
+axes</a>. Encoded as a CBOR map (major type 5). The key in each pair is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord"> axis tag</a>. It is encoded as a ByteString containing exactly 4 ASCII characters. The value in each
+pair is an <a href="#AxisInterval"><code>AxisInterval</code></a>.</p>
+   <h4 class="heading settled" data-level="2.2.5" id="objects"><span class="secno">2.2.5. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>
    <p>Objects are data structures comprised of key and value pairs. Objects are encoded via CBOR as maps
 (major type 5). Each key and value pair is encoded as a single map entry. Keys are always unsigned
 integers and are encoded using major type 0. Values are encoded using the encoding specified by the
@@ -736,7 +746,7 @@ type of the value.</p>
    <p>All fields in an object are optional and do not need to have an associated value. Conversely when
 decoding and object fields may be present which are not specified in the schema. The decoder must
 ignore without error any key and value pairs where the key is not recognized.</p>
-   <p>There are several types of object used, each type is defined by a schema in <a href="#schemas">§ 2.2.5 Object Schemas</a>. The schema
+   <p>There are several types of object used, each type is defined by a schema in <a href="#schemas">§ 2.2.6 Object Schemas</a>. The schema
 for a type specifies for each field:</p>
    <ul>
     <li data-md>
@@ -746,8 +756,8 @@ for a type specifies for each field:</p>
     <li data-md>
      <p>The type of the value stored in this field. Can be any of the types defined in <a href="#data-types">§ 2.2 Data Types</a> including object types.</p>
    </ul>
-   <h4 class="heading settled" data-level="2.2.5" id="schemas"><span class="secno">2.2.5. </span><span class="content">Object Schemas</span><a class="self-link" href="#schemas"></a></h4>
-   <h5 class="heading settled" data-level="2.2.5.1" id="CompressedList"><span class="secno">2.2.5.1. </span><span class="content">CompressedList</span><a class="self-link" href="#CompressedList"></a></h5>
+   <h4 class="heading settled" data-level="2.2.6" id="schemas"><span class="secno">2.2.6. </span><span class="content">Object Schemas</span><a class="self-link" href="#schemas"></a></h4>
+   <h5 class="heading settled" data-level="2.2.6.1" id="CompressedList"><span class="secno">2.2.6.1. </span><span class="content">CompressedList</span><a class="self-link" href="#CompressedList"></a></h5>
    <table>
     <tbody>
      <tr>
@@ -768,7 +778,7 @@ if length(L) > 0:
     value_deltas[i] = L[i] - L[i-1]
 </pre>
    <div class="example" id="example-6e146a01"><a class="self-link" href="#example-6e146a01"></a> The list [2, 2, 5, 1, 3, 7] would be encoded as [2, 0, 3, -4, 2, 4]. </div>
-   <h5 class="heading settled" data-level="2.2.5.2" id="CompressedSet"><span class="secno">2.2.5.2. </span><span class="content">CompressedSet</span><a class="self-link" href="#CompressedSet"></a></h5>
+   <h5 class="heading settled" data-level="2.2.6.2" id="CompressedSet"><span class="secno">2.2.6.2. </span><span class="content">CompressedSet</span><a class="self-link" href="#CompressedSet"></a></h5>
    <p>Encodes a set of unsigned integers. The set is not ordered and does not
 allow duplicates. Members of the set are encoded into either a sparse bit
 set or a list of ranges. To obtain the final set the members of the sparse
@@ -790,7 +800,33 @@ bit set and the list of ranges are unioned together.</p>
       <td>range_deltas
       <td>ArrayOf&lt;Integer>
    </table>
-   <h5 class="heading settled" data-level="2.2.5.3" id="PatchRequest"><span class="secno">2.2.5.3. </span><span class="content">PatchRequest</span><a class="self-link" href="#PatchRequest"></a></h5>
+   <h5 class="heading settled" data-level="2.2.6.3" id="AxisInterval"><span class="secno">2.2.6.3. </span><span class="content">AxisInterval</span><a class="self-link" href="#AxisInterval"></a></h5>
+   <table>
+    <tbody>
+     <tr>
+      <th>ID
+      <th>Field Name
+      <th>Value Type
+     <tr>
+      <td>0
+      <td>start
+      <td>Float
+     <tr>
+      <td>1
+      <td>end
+      <td>Float
+   </table>
+   <p><code>AxisInterval</code> defines an interval (from <code>start</code> to <code>end</code>) on some
+variable axis in a font.</p>
+   <p>For an <code>AxisInterval</code> object to be well formed:</p>
+   <ul>
+    <li data-md>
+     <p><code>start</code> must be set.</p>
+    <li data-md>
+     <p><code>end</code> optional, must be greater than <code>start</code>. If <code>end</code> is not set
+then this interval is a single point, <code>start</code>.</p>
+   </ul>
+   <h5 class="heading settled" data-level="2.2.6.4" id="PatchRequest"><span class="secno">2.2.6.4. </span><span class="content">PatchRequest</span><a class="self-link" href="#PatchRequest"></a></h5>
    <table>
     <tbody>
      <tr>
@@ -823,18 +859,26 @@ bit set and the list of ranges are unioned together.</p>
       <td>CompressedSet
      <tr>
       <td>6
+      <td>axis_space_have
+      <td>AxisSpace
+     <tr>
+      <td>7
+      <td>axis_space_needed
+      <td>AxisSpace
+     <tr>
+      <td>8
       <td>ordering_checksum
       <td>Integer
      <tr>
-      <td>7
+      <td>9
       <td>original_font_checksum
       <td>Integer
      <tr>
-      <td>8
+      <td>10
       <td>base_checksum
       <td>Integer
      <tr>
-      <td>9
+      <td>11
       <td>connection_speed
       <td>Integer
    </table>
@@ -852,7 +896,7 @@ then <code>ordering_checksum</code> must be set.</p>
     <li data-md>
      <p><code>connection_speed</code> can be any of the values listed in <a href="#connection-speeds">§ 2.8 Connection Speeds</a>.</p>
    </ul>
-   <h5 class="heading settled" data-level="2.2.5.4" id="PatchResponse"><span class="secno">2.2.5.4. </span><span class="content">PatchResponse</span><a class="self-link" href="#PatchResponse"></a></h5>
+   <h5 class="heading settled" data-level="2.2.6.5" id="PatchResponse"><span class="secno">2.2.6.5. </span><span class="content">PatchResponse</span><a class="self-link" href="#PatchResponse"></a></h5>
    <table>
     <tbody>
      <tr>
@@ -891,6 +935,14 @@ then <code>ordering_checksum</code> must be set.</p>
       <td>7
       <td>ordering_checksum
       <td>Integer
+     <tr>
+      <td>8
+      <td>subset_axis_space
+      <td>ArrayOf&lt;AxisInterval>
+     <tr>
+      <td>9
+      <td>original_axis_space
+      <td>ArrayOf&lt;AxisInterval>
    </table>
    <p>For a PatchRequest object to be well formed:</p>
    <ul>
@@ -907,6 +959,7 @@ then <code>ordering_checksum</code> must be set.</p>
    </ul>
    <h3 class="heading settled" data-level="2.3" id="client"><span class="secno">2.3. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
    <h4 class="heading settled" data-level="2.3.1" id="client-state"><span class="secno">2.3.1. </span><span class="content">Client State</span><a class="self-link" href="#client-state"></a></h4>
+   <p>TODO(garretrieger): track subset axis space, original font axis space.</p>
    <p>The client will need to maintain at minimum the following state for each font file being incrementally
 transferred:</p>
    <ul>
@@ -959,6 +1012,12 @@ ordering for this font then this field should not be set.</p>
 font subset. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.6 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
 ordering for this font then this field should not be set.</p>
     <li data-md>
+     <p><code>axis_space_have</code>: set to the current value of <code>subset_axis_space</code> saved in the state for this font.</p>
+    <li data-md>
+     <p><code>axis_space_needed</code>: set to the intervals of each variable axis in the original
+font that the client wants to add to its font subset. If the client wants an entire axis
+from the original font then that axis should not be listed.</p>
+    <li data-md>
      <p><code>ordering_checksum</code>: If either of <code>indices_have</code> or <code>indices_needed</code> is set then this must be set to the current value of <code>ordering_checksum</code> saved in the state for this font.</p>
     <li data-md>
      <p><code>original_font_checksum</code>:
@@ -973,6 +1032,7 @@ Can be optionally set by the client to a value from <a href="#connection-speeds"
 that corresponds to the client’s average round trip time.</p>
    </ul>
    <h4 class="heading settled" data-level="2.3.3" id="handling-patch-response"><span class="secno">2.3.3. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h4>
+   <p>TODO(garretrieger): update axes in client state.</p>
    <p>If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a> if will respond with HTTP status code 200 and the body of the response will be a <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via CBOR. The client
 should interpret and process the fields of the object as follows:</p>
    <ol>
@@ -1006,6 +1066,11 @@ to the union of the codepoints in the discarded font subset and the set of code 
 the the previous request was trying to add.</p>
    </ol>
    <h3 class="heading settled" data-level="2.4" id="handling-patch-request"><span class="secno">2.4. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
+   <p>TODO(garretrieger): axes stuff:</p>
+   <ul>
+    <li data-md>
+     <p>Must be superset of axes have, axes needed</p>
+   </ul>
    <p>If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
 HTTPS that was populated according to the requirements in <a href="#extend-subset">§ 2.3.2 Extending the Font Subset</a> then it should
 respond with HTTP status code 200. The body of the response should be a single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="70d79b67d2629d3f1f137cf31f0cc6089ae35eb9" name="document-revision">
+  <meta content="eaa911bd642975e0f770fa5b30f3b411fb4c4ebf" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -823,7 +823,7 @@ variable axis in a font.</p>
     <li data-md>
      <p><code>start</code> must be set.</p>
     <li data-md>
-     <p><code>end</code> optional, must be greater than <code>start</code>. If <code>end</code> is not set
+     <p><code>end</code> is optional, must be greater than <code>start</code>. If <code>end</code> is not set
 then this interval is a single point, <code>start</code>.</p>
    </ul>
    <h5 class="heading settled" data-level="2.2.6.4" id="PatchRequest"><span class="secno">2.2.6.4. </span><span class="content">PatchRequest</span><a class="self-link" href="#PatchRequest"></a></h5>

--- a/Overview.html
+++ b/Overview.html
@@ -5,9 +5,9 @@
   <title>Incremental Font Transfer</title>
   <meta content="w3c/ED" name="w3c-status">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
-  <meta content="Bikeshed version bb6b91100, updated Mon Jul 12 16:52:37 2021 -0700" name="generator">
+  <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="3f85c8513c64e2232dad5c7327babb1931e369fc" name="document-revision">
+  <meta content="fd9279f38e49b5f53fb24f30920596af85285f6d" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -114,9 +114,9 @@ pre .property::before, pre .property::after {
     --ins-bg: transparent;
 
     --a-normal-text: #034575;
-    --a-normal-underline: #bbb;
+    --a-normal-underline: #707070;
     --a-visited-text: var(--a-normal-text);
-    --a-visited-underline: #707070;
+    --a-visited-underline: #bbb;
     --a-hover-bg: rgba(75%, 75%, 75%, .25);
     --a-active-text: #c00;
     --a-active-underline: #c00;
@@ -395,7 +395,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-07-27">27 July 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-07-30">30 July 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -475,23 +475,15 @@ dfn > a.self-link::before      { content: "#"; }
         <li><a href="#handling-patch-response"><span class="secno">2.3.3</span> <span class="content">Handling PatchResponse</span></a>
         <li><a href="#client-side-checksum-mismatch"><span class="secno">2.3.4</span> <span class="content">Client Side Checksum Mismatch</span></a>
        </ol>
+      <li><a href="#handling-patch-request"><span class="secno">2.4</span> <span class="content">Server: Responding to a PatchRequest</span></a>
+      <li><a href="#computing-checksums"><span class="secno">2.5</span> <span class="content">Computing Checksums</span></a>
       <li>
-       <a href="#server"><span class="secno">2.4</span> <span class="content">Server</span></a>
+       <a href="#codepoint-reordering"><span class="secno">2.6</span> <span class="content">Codepoint Reordering</span></a>
        <ol class="toc">
-        <li><a href="#handling-patch-request"><span class="secno">2.4.1</span> <span class="content">Responding to a PatchRequest</span></a>
+        <li><a href="#reordering-checksum"><span class="secno">2.6.1</span> <span class="content">Codepoint Reordering Checksum</span></a>
        </ol>
-      <li>
-       <a href="#procedures"><span class="secno">2.5</span> <span class="content">Procedures</span></a>
-       <ol class="toc">
-        <li><a href="#computing-checksums"><span class="secno">2.5.1</span> <span class="content">Computing Checksums</span></a>
-        <li>
-         <a href="#codepoint-reordering"><span class="secno">2.5.2</span> <span class="content">Codepoint Reordering</span></a>
-         <ol class="toc">
-          <li><a href="#reordering-checksum"><span class="secno">2.5.2.1</span> <span class="content">Codepoint Reordering Checksum</span></a>
-         </ol>
-        <li><a href="#patch-formats"><span class="secno">2.5.3</span> <span class="content">Patch Formats</span></a>
-        <li><a href="#connection-speeds"><span class="secno">2.5.4</span> <span class="content">Connection Speeds</span></a>
-       </ol>
+      <li><a href="#patch-formats"><span class="secno">2.7</span> <span class="content">Patch Formats</span></a>
+      <li><a href="#connection-speeds"><span class="secno">2.8</span> <span class="content">Connection Speeds</span></a>
      </ol>
     <li><a href="#range-request-incxfer"><span class="secno">3</span> <span class="content">Range Request Incremental Transfer</span></a>
     <li><a href="#negotiating-transfer-type"><span class="secno">4</span> <span class="content">Using Incremental Font Transfer in HTML</span></a>
@@ -851,14 +843,14 @@ bit set and the list of ranges are unioned together.</p>
     <li data-md>
      <p><code>protocol_version</code> must be set to 0.</p>
     <li data-md>
-     <p><code>accept_patch_format</code> can include any of the values listed in <a href="#patch-formats">§ 2.5.3 Patch Formats</a>.</p>
+     <p><code>accept_patch_format</code> can include any of the values listed in <a href="#patch-formats">§ 2.7 Patch Formats</a>.</p>
     <li data-md>
      <p>If either of <code>indices_have</code> or <code>indices_needed</code> is set to a non-empty set
 then <code>ordering_checksum</code> must be set.</p>
     <li data-md>
      <p>If <code>codepoints_have</code> or <code>indices_have</code> is set to a non-empty set then <code>original_font_checksum</code> and <code>base_checksum</code> must be set.</p>
     <li data-md>
-     <p><code>connection_speed</code> can be any of the values listed in <a href="#connection-speeds">§ 2.5.4 Connection Speeds</a>.</p>
+     <p><code>connection_speed</code> can be any of the values listed in <a href="#connection-speeds">§ 2.8 Connection Speeds</a>.</p>
    </ul>
    <h5 class="heading settled" data-level="2.2.5.4" id="PatchResponse"><span class="secno">2.2.5.4. </span><span class="content">PatchResponse</span><a class="self-link" href="#PatchResponse"></a></h5>
    <table>
@@ -905,7 +897,7 @@ then <code>ordering_checksum</code> must be set.</p>
     <li data-md>
      <p><code>protocol_version</code> must be set to 0.</p>
     <li data-md>
-     <p><code>patch_format</code> can be any of the values listed <a href="#patch-formats">§ 2.5.3 Patch Formats</a></p>
+     <p><code>patch_format</code> can be any of the values listed <a href="#patch-formats">§ 2.7 Patch Formats</a></p>
     <li data-md>
      <p>Only one of <code>patch</code> or <code>replacement</code> may be set.</p>
     <li data-md>
@@ -925,7 +917,7 @@ the font being incrementally transferred. For a new font this is initialized to 
      <p>Original font checksum: the most recent value of <a href="#PatchResponse"><code>PatchResponse.original_font_checksum</code></a> received
 from the server for this font.</p>
     <li data-md>
-     <p>Codepoint Reordering Map: The most recent <a href="#codepoint-reordering">§ 2.5.2 Codepoint Reordering</a> received from the server
+     <p>Codepoint Reordering Map: The most recent <a href="#codepoint-reordering">§ 2.6 Codepoint Reordering</a> received from the server
 for this font.</p>
     <li data-md>
      <p>Codepoint Reordering Checksum: The most recent <a href="#PatchResponse"><code>PatchResponse.ordering_checksum</code></a> for this font.</p>
@@ -948,7 +940,7 @@ as follows:</p>
     <li data-md>
      <p><code>protocol_version</code>: set to 0.</p>
     <li data-md>
-     <p><code>accept_patch_format</code>: set to the list of <a href="#patch-formats">§ 2.5.3 Patch Formats</a> that this client is
+     <p><code>accept_patch_format</code>: set to the list of <a href="#patch-formats">§ 2.7 Patch Formats</a> that this client is
 capable of decoding. Must contain at least one format.</p>
     <li data-md>
      <p><code>codepoints_have</code>: set to exactly the set of codepoints that the current font subset
@@ -960,11 +952,11 @@ add to its font subset. If the client has a codepoint ordering for this font the
 field should not be set.</p>
     <li data-md>
      <p><code>indices_have</code>: encodes the set of additional codepoints that the current
-font subset contains data for. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.5.2 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
+font subset contains data for. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.6 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
 ordering for this font then this field should not be set.</p>
     <li data-md>
      <p><code>indices_needed</code>: encodes the set of codepoints that the client wants to add to its
-font subset. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.5.2 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
+font subset. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 2.6 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
 ordering for this font then this field should not be set.</p>
     <li data-md>
      <p><code>ordering_checksum</code>: If either of <code>indices_have</code> or <code>indices_needed</code> is set then this must be set to the current value of <code>ordering_checksum</code> saved in the state for this font.</p>
@@ -974,10 +966,10 @@ Set to saved value for <code>original_font_checksum</code> in the state for this
 there is no saved value leave this field unset.</p>
     <li data-md>
      <p><code>base_checksum</code>:
-Set to the checksum of the font subset byte array saved in the state for this font. See: <a href="#computing-checksums">§ 2.5.1 Computing Checksums</a>.</p>
+Set to the checksum of the font subset byte array saved in the state for this font. See: <a href="#computing-checksums">§ 2.5 Computing Checksums</a>.</p>
     <li data-md>
      <p><code>connection_speed</code>:
-Can be optionally set by the client to a value from <a href="#connection-speeds">§ 2.5.4 Connection Speeds</a> by finding the value
+Can be optionally set by the client to a value from <a href="#connection-speeds">§ 2.8 Connection Speeds</a> by finding the value
 that corresponds to the client’s average round trip time.</p>
    </ul>
    <h4 class="heading settled" data-level="2.3.3" id="handling-patch-response"><span class="secno">2.3.3. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h4>
@@ -1013,8 +1005,7 @@ this response.</p>
 to the union of the codepoints in the discarded font subset and the set of code points
 the the previous request was trying to add.</p>
    </ol>
-   <h3 class="heading settled" data-level="2.4" id="server"><span class="secno">2.4. </span><span class="content">Server</span><a class="self-link" href="#server"></a></h3>
-   <h4 class="heading settled" data-level="2.4.1" id="handling-patch-request"><span class="secno">2.4.1. </span><span class="content">Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h4>
+   <h3 class="heading settled" data-level="2.4" id="handling-patch-request"><span class="secno">2.4. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
    <p>If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
 HTTPS that was populated according to the requirements in <a href="#extend-subset">§ 2.3.2 Extending the Font Subset</a> then it should
 respond with HTTP status code 200. The body of the response should be a single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</p>
@@ -1035,6 +1026,9 @@ That is the <code>patch</code> and <code>replacement</code> fields must not be s
    <p>Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 2.3.3 Handling PatchResponse</a> to a font subset with checksum <code>base_checksum</code> it must result
 in an extended font subset that contains data for at least the union of the set of codepoints needed
 and the sets of codepoints the client already has. The format of the patch in the either the <code>patch</code> or <code>replace</code> fields must be one of those listed in <code>accept_patch_format</code>.</p>
+   <p>If <code>accept_patch_format</code> contains any unrecognized patch formats the server should
+ignore the unrecognized ones. Likewise if <code>connection_speed</code> contains any unrecognized
+connection speeds the server should ignore the unrecognized ones.</p>
    <p class="note" role="note"><span>Note:</span> the server can optionally use the client’s provided connection speed to inform how many extra
 codepoints should be sent. For example on slower connections it may be more performant to send extra
 codepoints if they can prevent a future request from needing to be sent.</p>
@@ -1050,8 +1044,7 @@ error.</p>
      <p>If the requested font is not recognized by the server it may respond with http status code 404 to
 indicate a not found error.</p>
    </ul>
-   <h3 class="heading settled" data-level="2.5" id="procedures"><span class="secno">2.5. </span><span class="content">Procedures</span><a class="self-link" href="#procedures"></a></h3>
-   <h4 class="heading settled" data-level="2.5.1" id="computing-checksums"><span class="secno">2.5.1. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h4>
+   <h3 class="heading settled" data-level="2.5" id="computing-checksums"><span class="secno">2.5. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h3>
    <p>64 bit checksums of byte strings are computed using the <a href="https://github.com/ztanml/fast-hash">fast hash</a> algorithm. A python like pseudo
 code version of the algorithm is presented below:</p>
 <pre># Constant values come fast hash: https://github.com/ztanml/fast-hash
@@ -1080,7 +1073,7 @@ fast_hash(byte[] data):
   return mix((hash ^ mix(last_value)) * M)
 </pre>
    <p class="note" role="note"><span>Note:</span> a C implementation of fast hash can be found <a href="https://github.com/ztanml/fast-hash">here</a>.</p>
-   <h4 class="heading settled" data-level="2.5.2" id="codepoint-reordering"><span class="secno">2.5.2. </span><span class="content">Codepoint Reordering</span><a class="self-link" href="#codepoint-reordering"></a></h4>
+   <h3 class="heading settled" data-level="2.6" id="codepoint-reordering"><span class="secno">2.6. </span><span class="content">Codepoint Reordering</span><a class="self-link" href="#codepoint-reordering"></a></h3>
    <p>A codepoint reordering for a font defines a function which maps unicode codepoint values from the
 font to a continuous space of [0, number of codepoints in the font). This transformation is intended
 to reduce the cost of representing codepoint sets.</p>
@@ -1089,7 +1082,7 @@ codepoints that are supported by the font. The index of a particular unicode cod
 the new value for that codepoint.</p>
    <p>A server is free to choose any codepoint ordering, but should try to pick one that will minimize the
 size of encoded codepoint sets for that font.</p>
-   <h5 class="heading settled" data-level="2.5.2.1" id="reordering-checksum"><span class="secno">2.5.2.1. </span><span class="content">Codepoint Reordering Checksum</span><a class="self-link" href="#reordering-checksum"></a></h5>
+   <h4 class="heading settled" data-level="2.6.1" id="reordering-checksum"><span class="secno">2.6.1. </span><span class="content">Codepoint Reordering Checksum</span><a class="self-link" href="#reordering-checksum"></a></h4>
    <p>A checksum of a codepoint reordering can be computed as follows:</p>
 <pre>SEED = 0x11743e80f437ffe6
 M = 0x880355f21e6d1965
@@ -1109,7 +1102,7 @@ fast_hash_ordering(uint64[] ordering):
 
   return mix(hash)
 </pre>
-   <h4 class="heading settled" data-level="2.5.3" id="patch-formats"><span class="secno">2.5.3. </span><span class="content">Patch Formats</span><a class="self-link" href="#patch-formats"></a></h4>
+   <h3 class="heading settled" data-level="2.7" id="patch-formats"><span class="secno">2.7. </span><span class="content">Patch Formats</span><a class="self-link" href="#patch-formats"></a></h3>
    <p>The following patch formats may be used by the server to create binary diffs between a source file
 and a target file:</p>
    <table>
@@ -1129,7 +1122,7 @@ and a target file:</p>
       <td>Uses brotli compression <a data-link-type="biblio" href="#biblio-rfc7932">[rfc7932]</a> to produce the patch. The source file is used as a shared
     dictionary <a data-link-type="biblio" href="#biblio-shared-brotli">[Shared-Brotli]</a> given to the brotli compressor and decompressor.
    </table>
-   <h4 class="heading settled" data-level="2.5.4" id="connection-speeds"><span class="secno">2.5.4. </span><span class="content">Connection Speeds</span><a class="self-link" href="#connection-speeds"></a></h4>
+   <h3 class="heading settled" data-level="2.8" id="connection-speeds"><span class="secno">2.8. </span><span class="content">Connection Speeds</span><a class="self-link" href="#connection-speeds"></a></h3>
    <p>The following connection speed values can be used:</p>
    <table>
     <tbody>
@@ -1239,11 +1232,11 @@ extension requests should be sent according the the Range Request specificiation
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-rfc3284">[RFC3284]
-   <dd>D. Korn; et al. <a href="https://www.rfc-editor.org/rfc/rfc3284">The VCDIFF Generic Differencing and Compression Data Format</a>. June 2002. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3284">https://www.rfc-editor.org/rfc/rfc3284</a>
+   <dd>D. Korn; et al. <a href="https://datatracker.ietf.org/doc/html/rfc3284">The VCDIFF Generic Differencing and Compression Data Format</a>. June 2002. Proposed Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc3284">https://datatracker.ietf.org/doc/html/rfc3284</a>
    <dt id="biblio-rfc7932">[RFC7932]
-   <dd>J. Alakuijala; Z. Szabadka. <a href="https://www.rfc-editor.org/rfc/rfc7932">Brotli Compressed Data Format</a>. July 2016. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc7932">https://www.rfc-editor.org/rfc/rfc7932</a>
+   <dd>J. Alakuijala; Z. Szabadka. <a href="https://datatracker.ietf.org/doc/html/rfc7932">Brotli Compressed Data Format</a>. July 2016. Informational. URL: <a href="https://datatracker.ietf.org/doc/html/rfc7932">https://datatracker.ietf.org/doc/html/rfc7932</a>
    <dt id="biblio-rfc8949">[RFC8949]
-   <dd>C. Bormann; P. Hoffman. <a href="https://www.rfc-editor.org/rfc/rfc8949">Concise Binary Object Representation (CBOR)</a>. December 2020. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc8949">https://www.rfc-editor.org/rfc/rfc8949</a>
+   <dd>C. Bormann; P. Hoffman. <a href="https://datatracker.ietf.org/doc/html/rfc8949">Concise Binary Object Representation (CBOR)</a>. December 2020. Internet Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc8949">https://datatracker.ietf.org/doc/html/rfc8949</a>
    <dt id="biblio-shared-brotli">[Shared-Brotli]
    <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-08">Shared Brotli Compressed Data Format</a>. 27 Jul 2021. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-08">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-08</a>
   </dl>
@@ -1252,9 +1245,9 @@ extension requests should be sent according the the Range Request specificiation
    <dt id="biblio-pfe-report">[PFE-report]
    <dd>Chris Lilley. <a href="https://www.w3.org/TR/PFE-evaluation/">Progressive Font Enrichment: Evaluation Report</a>. 15 October 2020. Note. URL: <a href="https://www.w3.org/TR/PFE-evaluation/">https://www.w3.org/TR/PFE-evaluation/</a>
    <dt id="biblio-rfc4648">[RFC4648]
-   <dd>S. Josefsson. <a href="https://www.rfc-editor.org/rfc/rfc4648">The Base16, Base32, and Base64 Data Encodings</a>. October 2006. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc4648">https://www.rfc-editor.org/rfc/rfc4648</a>
+   <dd>S. Josefsson. <a href="https://datatracker.ietf.org/doc/html/rfc4648">The Base16, Base32, and Base64 Data Encodings</a>. October 2006. Proposed Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc4648">https://datatracker.ietf.org/doc/html/rfc4648</a>
    <dt id="biblio-woff2">[WOFF2]
-   <dd>Vladimir Levantovsky; Raph Levien. <a href="https://www.w3.org/TR/WOFF2/">WOFF File Format 2.0</a>. 6 July 2021. REC. URL: <a href="https://www.w3.org/TR/WOFF2/">https://www.w3.org/TR/WOFF2/</a>
+   <dd>Vladimir Levantovsky; Raph Levien. <a href="https://www.w3.org/TR/WOFF2/">WOFF File Format 2.0</a>. 1 March 2018. REC. URL: <a href="https://www.w3.org/TR/WOFF2/">https://www.w3.org/TR/WOFF2/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="802c531fe6d6a5305fad50778285885e27fb3de0" name="document-revision">
+  <meta content="70d79b67d2629d3f1f137cf31f0cc6089ae35eb9" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -419,7 +419,7 @@ dfn > a.self-link::before      { content: "#"; }
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
-   <p>Example example</p>
+   <p>TODO(garretrieger)</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
@@ -436,7 +436,7 @@ dfn > a.self-link::before      { content: "#"; }
   An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
    <p> This document is governed by the <a href="https://www.w3.org/2020/Process-20200915/" id="w3c_process_revision">15 September 2020 W3C Process Document</a>. </p>
    <p></p>
-   <p>This is a largely empty document because we have just started working on it.</p>
+   <p>initial draft is in progress.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -735,8 +735,8 @@ significant bit in the byte and the bit with the largest index is the most signi
     </ul>
    </div>
    <h4 class="heading settled" data-level="2.2.4" id="AxisSpace"><span class="secno">2.2.4. </span><span class="content">AxisSpace</span><a class="self-link" href="#AxisSpace"></a></h4>
-   <p>Stores a set of intervals on one or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview">open type variation
-axes</a>. Encoded as a CBOR map (major type 5). The key in each pair is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord"> axis tag</a>. It is encoded as a ByteString containing exactly 4 ASCII characters. The value in each
+   <p>Stores a set of intervals on one or more open type variation axes <a data-link-type="biblio" href="#biblio-opentype-variations">[opentype-variations]</a>.
+Encoded as a CBOR map (major type 5). The key in each pair is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord"> axis tag</a>. It is encoded as a ByteString containing exactly 4 ASCII characters. The value in each
 pair is an <a href="#AxisInterval"><code>AxisInterval</code></a>.</p>
    <h4 class="heading settled" data-level="2.2.5" id="objects"><span class="secno">2.2.5. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>
    <p>Objects are data structures comprised of key and value pairs. Objects are encoded via CBOR as maps
@@ -1349,6 +1349,8 @@ extension requests should be sent according the the Range Request specificiation
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
+   <dt id="biblio-opentype-variations">[OPENTYPE-VARIATIONS]
+   <dd><a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview">OpenType Font Variations Overview</a>. 23 October 2020. Note. URL: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview">https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview</a>
    <dt id="biblio-pfe-report">[PFE-report]
    <dd>Chris Lilley. <a href="https://www.w3.org/TR/PFE-evaluation/">Progressive Font Enrichment: Evaluation Report</a>. 15 October 2020. Note. URL: <a href="https://www.w3.org/TR/PFE-evaluation/">https://www.w3.org/TR/PFE-evaluation/</a>
    <dt id="biblio-rfc4648">[RFC4648]

--- a/RangeRequest.html
+++ b/RangeRequest.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="3e60812e982dd44aa349e5bd9fb1a31ad9b6aaa0" name="document-revision">
+  <meta content="12c734147bac92cd6060d119b5bf657b64740408" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -395,7 +395,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer via Range Request</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-06-28">28 June 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-07-19">19 July 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:

--- a/RangeRequest.html
+++ b/RangeRequest.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/example/" rel="canonical">
-  <meta content="12c734147bac92cd6060d119b5bf657b64740408" name="document-revision">
+  <meta content="70d79b67d2629d3f1f137cf31f0cc6089ae35eb9" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {


### PR DESCRIPTION
Similar to codepoints this adds an axis space have and axis space needed to the request. This allows a client to get a subset of the font with a reduced axis space and then later on expand the axis space via a patch.