### PR TITLE
Add examples of marking up conformance statements

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -541,8 +541,9 @@ distinct axis tag must be disjoint.
 
 ### Objects ### {#objects}
 
-Objects are data structures comprised of key and value pairs. Objects are encoded via CBOR as maps
-(major type 5). Each key and value pair is encoded as a single map entry. Keys are always unsigned
+Objects are data structures comprised of key and value pairs.
+<span class="conform server client" id="conform-object">Objects are encoded via CBOR as maps (major
+type 5)</span>. Each key and value pair is encoded as a single map entry. Keys are always unsigned
 integers and are encoded using major type 0. Values are encoded using the encoding specified by the
 type of the value.
 
@@ -636,12 +637,17 @@ For a PatchRequest object to be well formed:
 </table>
 
 For a PatchResponse object to be well formed:
-*  <code>protocol_version</code> must be set to 0.
-*  <code>patch_format</code> can be any of the values listed [[#patch-formats]]
-*  Only one of <code>patch</code> or <code>replacement</code> may be set.
-*  If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>,
-     <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.
-*  If <code>codepoint_ordering</code> is set then <code>ordering_checksum</code> must be set.
+*  <span class="conform server" id="conform-response-protocol-version">
+     <code>protocol_version</code> must be set to 0.</span>
+*  <span class="conform server" id="conform-response-valid-format">
+     <code>patch_format</code> must be one of the values listed in [[#patch-formats]].</span>
+*  <span class="conform server" id="conform-response-patch-or-replacement">
+     Only one of <code>patch</code> or <code>replacement</code> must be set.</span>
+*  <span class="conform server" id="conform-response-font-checksums">
+     If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>,
+     <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.</span>
+*  <span class="conform server" id="conform-response-ordering-checksum">
+     If <code>codepoint_ordering</code> is set then <code>ordering_checksum</code> must be set.</span>
 
 Client {#client}
 ----------------
@@ -823,16 +829,16 @@ Otherwise when the response is applied by the client following the process in
 [[#handling-patch-response]] to a font subset with checksum <code>base_checksum</code> it must result
 in an extended font subset:
 
-*  That contains data for at least the union of the set of codepoints needed and the sets of
-    codepoints the client already has.
+*  <span class="conform server" id="conform-response-subset">That contains data for at least the union
+    of the set of codepoints needed and the sets of codepoints the client already has.</span>
 
 *  That contains a variation axis space that covers at least the union of the axis space the client
     has and the axis space the client needs.
 
 Additionally:
 
-*  The format of the patch in the either the <code>patch</code> or <code>replace</code> fields must be
-    one of those listed in <code>accept_patch_format</code>.
+*  <span class="conform server" id="conform-response-patch-format">The format of the patch in the either the <code>patch</code> or <code>replace</code> fields must be
+    one of those listed in <code>accept_patch_format</code></span>.
 
 *  The value of <code>original_font_checksum</code> must be set to the checksum of the original font.
     The checksum value must computed by the procedure in [[#computing-checksums]].

--- a/Overview.bs
+++ b/Overview.bs
@@ -75,6 +75,11 @@ Abstract: This specification defines two methods to incrementally transfer fonts
 	}
 </pre>
 
+<style>
+.conform:hover {background: #31668f}
+.conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
+</style>
+
 Introduction {#intro}
 =====================
 
@@ -778,11 +783,13 @@ If the checksum of the font subset computed by the client does not match the
 Server: Responding to a PatchRequest {#handling-patch-request}
 --------------------------------------------------------------
 
-If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
-HTTPS that was populated according to the requirements in [[#extend-subset]] then it should
-respond with HTTP status code 200. The first 4 bytes of the response must be set to 0x49, 0x46, 0x54,
-0x20 ("IFT " encoded as ASCII) followed by a single
-<a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.
+<span class="conform server" id="conform-succesful-response">If the server receives a well formed
+<a href="#PatchRequest"><code>PatchRequest</code></a> over HTTPS for a font the server has and that was
+populated according to the requirements in [[#extend-subset]] then it must respond with HTTP status
+code 200.</span>
+<span class="conform server" id="conform-magic-number">The first 4 bytes of the response must be set
+to 0x49, 0x46, 0x54, 0x20 ("IFT " encoded as ASCII) followed by a
+single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</span>
 
 The path in the request identifies the specific font that a patch is desired for. From the request
 object the server can produce two codepoint sets:

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="dc6e27d74a5290fbe173c84c14ee467fd2f8f1ea" name="document-revision">
+  <meta content="d5606c91e28e669d2621bd493455cfc4851bf88f" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -960,8 +960,8 @@ Encoded as a CBOR map (major type 5). The key in each pair is an <a href="https:
 pair is an <code>ArrayOf&lt;AxisInterval></code> <a href="#AxisInterval">§ 2.3.2 AxisInterval</a>. The list of intervals for a
 distinct axis tag must be disjoint.</p>
    <h4 class="heading settled" data-level="2.2.9" id="objects"><span class="secno">2.2.9. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>
-   <p>Objects are data structures comprised of key and value pairs. Objects are encoded via CBOR as maps
-(major type 5). Each key and value pair is encoded as a single map entry. Keys are always unsigned
+   <p>Objects are data structures comprised of key and value pairs. <span class="conform server client" id="conform-object">Objects are encoded via CBOR as maps (major
+type 5)</span>. Each key and value pair is encoded as a single map entry. Keys are always unsigned
 integers and are encoded using major type 0. Values are encoded using the encoding specified by the
 type of the value.</p>
    <p>All fields in an object are optional and do not need to have an associated value. Conversely when
@@ -1145,15 +1145,15 @@ then <code>ordering_checksum</code> must be set.</p>
    <p>For a PatchResponse object to be well formed:</p>
    <ul>
     <li data-md>
-     <p><code>protocol_version</code> must be set to 0.</p>
+     <p><span class="conform server" id="conform-response-protocol-version"> <code>protocol_version</code> must be set to 0.</span></p>
     <li data-md>
-     <p><code>patch_format</code> can be any of the values listed <a href="#patch-formats">§ 2.8 Patch Formats</a></p>
+     <p><span class="conform server" id="conform-response-valid-format"> <code>patch_format</code> must be one of the values listed in <a href="#patch-formats">§ 2.8 Patch Formats</a>.</span></p>
     <li data-md>
-     <p>Only one of <code>patch</code> or <code>replacement</code> may be set.</p>
+     <p><span class="conform server" id="conform-response-patch-or-replacement"> Only one of <code>patch</code> or <code>replacement</code> must be set.</span></p>
     <li data-md>
-     <p>If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>, <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.</p>
+     <p><span class="conform server" id="conform-response-font-checksums"> If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>, <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.</span></p>
     <li data-md>
-     <p>If <code>codepoint_ordering</code> is set then <code>ordering_checksum</code> must be set.</p>
+     <p><span class="conform server" id="conform-response-ordering-checksum"> If <code>codepoint_ordering</code> is set then <code>ordering_checksum</code> must be set.</span></p>
    </ul>
    <h3 class="heading settled" data-level="2.4" id="client"><span class="secno">2.4. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
    <h4 class="heading settled" data-level="2.4.1" id="client-state"><span class="secno">2.4.1. </span><span class="content">Client State</span><a class="self-link" href="#client-state"></a></h4>
@@ -1308,8 +1308,8 @@ That is the <code>patch</code> and <code>replacement</code> fields must not be s
 in an extended font subset:</p>
    <ul>
     <li data-md>
-     <p>That contains data for at least the union of the set of codepoints needed and the sets of
-codepoints the client already has.</p>
+     <p><span class="conform server" id="conform-response-subset">That contains data for at least the union
+of the set of codepoints needed and the sets of codepoints the client already has.</span></p>
     <li data-md>
      <p>That contains a variation axis space that covers at least the union of the axis space the client
 has and the axis space the client needs.</p>
@@ -1317,8 +1317,8 @@ has and the axis space the client needs.</p>
    <p>Additionally:</p>
    <ul>
     <li data-md>
-     <p>The format of the patch in the either the <code>patch</code> or <code>replace</code> fields must be
-one of those listed in <code>accept_patch_format</code>.</p>
+     <p><span class="conform server" id="conform-response-patch-format">The format of the patch in the either the <code>patch</code> or <code>replace</code> fields must be
+one of those listed in <code>accept_patch_format</code></span>.</p>
     <li data-md>
      <p>The value of <code>original_font_checksum</code> must be set to the checksum of the original font.
 The checksum value must computed by the procedure in <a href="#computing-checksums">§ 2.6 Computing Checksums</a>.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,11 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="d12e38bc00e6cdf8cc819e13838fced9d2af2766" name="document-revision">
+  <meta content="dc6e27d74a5290fbe173c84c14ee467fd2f8f1ea" name="document-revision">
+<style>
+.conform:hover {background: #31668f}
+.conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
+</style>
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -395,7 +399,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-11-26">26 November 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2021-12-03">3 December 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1270,10 +1274,11 @@ to the union of the codepoints in the discarded font subset and the set of code 
 that the previous request was trying to add.</p>
    </ol>
    <h3 class="heading settled" data-level="2.5" id="handling-patch-request"><span class="secno">2.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
-   <p>If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over
-HTTPS that was populated according to the requirements in <a href="#extend-subset">§ 2.4.2 Extending the Font Subset</a> then it should
-respond with HTTP status code 200. The first 4 bytes of the response must be set to 0x49, 0x46, 0x54,
-0x20 ("IFT " encoded as ASCII) followed by a single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</p>
+   <p><span class="conform server" id="conform-succesful-response">If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over HTTPS for a font the server has and that was
+populated according to the requirements in <a href="#extend-subset">§ 2.4.2 Extending the Font Subset</a> then it must respond with HTTP status
+code 200.</span> <span class="conform server" id="conform-magic-number">The first 4 bytes of the response must be set
+to 0x49, 0x46, 0x54, 0x20 ("IFT " encoded as ASCII) followed by a
+single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</span></p>
    <p>The path in the request identifies the specific font that a patch is desired for. From the request
 object the server can produce two codepoint sets:</p>
    <ol>


### PR DESCRIPTION
Adds several examples of marking conformance statements with <span> tags. This is being done so that these statements can be linked to from the conformance tests.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/55.html" title="Last updated on Dec 13, 2021, 7:08 PM UTC (509d878)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/55/79ee213...509d878.html" title="Last updated on Dec 13, 2021, 7:08 PM UTC (509d878)">Diff</a>