### PR TITLE
Expand patch subset overview section. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
-all: Overview.html RangeRequest.html
+all: Overview.html
 
 Overview.html: Overview.bs
 	bikeshed spec Overview.bs
-
-RangeRequest.html: RangeRequest.bs
-	bikeshed spec RangeRequest.bs
 
 clean:
 	rm Overview.html RangeRequest.html

--- a/Overview.bs
+++ b/Overview.bs
@@ -117,7 +117,7 @@ Range Request {#range-request}
 ------------------------------
 
 The second
-method, <a href="#range-request-incxfer">Range Request</a>, has no server-side requirements other than the server should be able to respond to byte-based range requests. The browser makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file.
+method, <a href="#range-request-incxfer">Range Request</a>, has no server-side requirements other than the server should be able to respond to byte-based range requests. The browser makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file to obtain all required font tables, and then calculates glyph coverage and required byte ranges using font character-to-glyph mapping and glyph substitution / layout tables.
 
 In order for the range request method to be as effective as possible, the font file itself should be internally arranged in a particular way, in order to decrease the number of requests the browser needs to make. Therefore, it is expected that web developers wishing to use the range request method will use font files that have had their contents already arranged optimally.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -102,8 +102,17 @@ There are two different methods which can be used to incrementally transfer font
 Patch Subset {#patch-subset}
 ----------------------------
 
-The first method,
-<a href="patch-incxfer">Patch Subset</a>, uses a server which can generate binary updates to an existing font file.
+In the the first method, <a href="patch-incxfer">Patch Subset</a> a server generates binary patches which a
+client applies to a subset of the font in order to extend the coverage of that subset. The server
+is stateless, it does not maintain any session data for clients between requests. Thus when a client
+requests the generation of a patch from the server it has to fully describe the current subset of the
+font that it has in a way which allows the server to recreate it.
+
+Generic binary patch algorithms are used which do not need to be aware of the specifics of the font
+format. Typically a server will produce a patch by generating two font subsets: one which matches what
+the client currently has and one which matches the extended subset the client desires. A binary patch
+is then produced between the two subsets.
+
 
 Range Request {#range-request}
 ------------------------------
@@ -188,21 +197,8 @@ This summarizes behaviors that result from the above method selection.
 Patch Based Incremental Transfer {#patch-incxfer}
 =================================================
 
-Overview {#patch-overview}
+Font Subset {#font-subset}
 --------------------------
-
-In the patch subset approach to incremental font transfer a server generates binary patches which a
-client applies to a subset of the font in order to extend the coverage of that font subset. The server
-is stateless, it does not maintain any session data for clients between requests. Thus when a client
-requests the generation of a patch from the server it has to fully describe the current subset of the
-font that it has in a way which allows the server to recreate it.
-
-Generic binary patch algorithms are used which do not need to be aware of the specifics of the font
-format. Typically a server will produce a patch by generating two font subsets: one which matches what
-the client currently has and one which matches the extended subset the client desires. A binary patch
-is then produced between the two subsets.
-
-### Font Subset ### {#font-subset}
 
 A subset of a font file is a modified version of the font that contains only the data needed to
 render a subset of the codepoints supported by the original font. When a subsetted font is used to

--- a/Overview.bs
+++ b/Overview.bs
@@ -113,12 +113,11 @@ format. Typically a server will produce a patch by generating two font subsets: 
 the client currently has and one which matches the extended subset the client desires. A binary patch
 is then produced between the two subsets.
 
-
 Range Request {#range-request}
 ------------------------------
 
 The second
-method, <a href="#range-request-incxfer">Range Request</a>, is a very simple method of incremental transfer, and has no server-side requirements (other than the server should be able to respond to byte-based range requests). The browser simply makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file.
+method, <a href="#range-request-incxfer">Range Request</a>, has no server-side requirements other than the server should be able to respond to byte-based range requests. The browser makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file.
 
 In order for the range request method to be as effective as possible, the font file itself should be internally arranged in a particular way, in order to decrease the number of requests the browser needs to make. Therefore, it is expected that web developers wishing to use the range request method will use font files that have had their contents already arranged optimally.
 

--- a/Overview.html
+++ b/Overview.html
@@ -514,11 +514,7 @@ dfn > a.self-link::before      { content: "#"; }
     <li>
      <a href="#patch-incxfer"><span class="secno">4</span> <span class="content">Patch Based Incremental Transfer</span></a>
      <ol class="toc">
-      <li>
-       <a href="#patch-overview"><span class="secno">4.1</span> <span class="content">Overview</span></a>
-       <ol class="toc">
-        <li><a href="#font-subset"><span class="secno">4.1.1</span> <span class="content">Font Subset</span></a>
-       </ol>
+      <li><a href="#font-subset"><span class="secno">4.1</span> <span class="content">Font Subset</span></a>
       <li>
        <a href="#data-types"><span class="secno">4.2</span> <span class="content">Data Types</span></a>
        <ol class="toc">
@@ -630,7 +626,15 @@ slow networks, very large fonts, or complex subsetting requirements currently pr
 example, even using WOFF 2 <a data-link-type="biblio" href="#biblio-woff2">[WOFF2]</a>, fonts for CJK languages are too large to be practical.</p>
    <p>There are two different methods which can be used to incrementally transfer fonts.</p>
    <h3 class="heading settled" data-level="1.1" id="patch-subset"><span class="secno">1.1. </span><span class="content">Patch Subset</span><a class="self-link" href="#patch-subset"></a></h3>
-   <p>The first method, <a href="patch-incxfer">Patch Subset</a>, uses a server which can generate binary updates to an existing font file.</p>
+   <p>In the the first method, <a href="patch-incxfer">Patch Subset</a> a server generates binary patches which a
+client applies to a subset of the font in order to extend the coverage of that subset. The server
+is stateless, it does not maintain any session data for clients between requests. Thus when a client
+requests the generation of a patch from the server it has to fully describe the current subset of the
+font that it has in a way which allows the server to recreate it.</p>
+   <p>Generic binary patch algorithms are used which do not need to be aware of the specifics of the font
+format. Typically a server will produce a patch by generating two font subsets: one which matches what
+the client currently has and one which matches the extended subset the client desires. A binary patch
+is then produced between the two subsets.</p>
    <h3 class="heading settled" data-level="1.2" id="range-request"><span class="secno">1.2. </span><span class="content">Range Request</span><a class="self-link" href="#range-request"></a></h3>
    <p>The second
 method, <a href="#range-request-incxfer">Range Request</a>, is a very simple method of incremental transfer, and has no server-side requirements (other than the server should be able to respond to byte-based range requests). The browser simply makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file.</p>
@@ -692,17 +696,7 @@ for many uses cases while still providing material improvments to loading perfor
       <td>Client makes initial request to server with query parameter. Server does not reply with the patch-subset magic number, and sends the full font file to the client from beginning to end. 
    </table>
    <h2 class="heading settled" data-level="4" id="patch-incxfer"><span class="secno">4. </span><span class="content">Patch Based Incremental Transfer</span><a class="self-link" href="#patch-incxfer"></a></h2>
-   <h3 class="heading settled" data-level="4.1" id="patch-overview"><span class="secno">4.1. </span><span class="content">Overview</span><a class="self-link" href="#patch-overview"></a></h3>
-   <p>In the patch subset approach to incremental font transfer a server generates binary patches which a
-client applies to a subset of the font in order to extend the coverage of that font subset. The server
-is stateless, it does not maintain any session data for clients between requests. Thus when a client
-requests the generation of a patch from the server it has to fully describe the current subset of the
-font that it has in a way which allows the server to recreate it.</p>
-   <p>Generic binary patch algorithms are used which do not need to be aware of the specifics of the font
-format. Typically a server will produce a patch by generating two font subsets: one which matches what
-the client currently has and one which matches the extended subset the client desires. A binary patch
-is then produced between the two subsets.</p>
-   <h4 class="heading settled" data-level="4.1.1" id="font-subset"><span class="secno">4.1.1. </span><span class="content">Font Subset</span><a class="self-link" href="#font-subset"></a></h4>
+   <h3 class="heading settled" data-level="4.1" id="font-subset"><span class="secno">4.1. </span><span class="content">Font Subset</span><a class="self-link" href="#font-subset"></a></h3>
    <p>A subset of a font file is a modified version of the font that contains only the data needed to
 render a subset of the codepoints supported by the original font. When a subsetted font is used to
 render text using any combination of the subset codepoints it must render identically to the original

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="6ca880947f8a0052c597ba7ee84f69329e3b44ae" name="document-revision">
+  <meta content="01391ffc9ddd03e7d00e2f333fd0cce470683755" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -446,7 +446,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2022-02-28">28 February 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2022-03-08">8 March 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -637,7 +637,7 @@ the client currently has and one which matches the extended subset the client de
 is then produced between the two subsets.</p>
    <h3 class="heading settled" data-level="1.2" id="range-request"><span class="secno">1.2. </span><span class="content">Range Request</span><a class="self-link" href="#range-request"></a></h3>
    <p>The second
-method, <a href="#range-request-incxfer">Range Request</a>, is a very simple method of incremental transfer, and has no server-side requirements (other than the server should be able to respond to byte-based range requests). The browser simply makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file.</p>
+method, <a href="#range-request-incxfer">Range Request</a>, has no server-side requirements other than the server should be able to respond to byte-based range requests. The browser makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file.</p>
    <p>In order for the range request method to be as effective as possible, the font file itself should be internally arranged in a particular way, in order to decrease the number of requests the browser needs to make. Therefore, it is expected that web developers wishing to use the range request method will use font files that have had their contents already arranged optimally.</p>
    <p>This method was modelled after video playback on the web, where seeking in a video causes the browser to send a range request to the server.</p>
    <h3 class="heading settled" data-level="1.3" id="evaluation-report"><span class="secno">1.3. </span><span class="content">Technical Motivation: Evaluation Report</span><a class="self-link" href="#evaluation-report"></a></h3>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="01391ffc9ddd03e7d00e2f333fd0cce470683755" name="document-revision">
+  <meta content="2ea43c58d3aa06d8ed6e8b330606ee09182d241a" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -637,7 +637,7 @@ the client currently has and one which matches the extended subset the client de
 is then produced between the two subsets.</p>
    <h3 class="heading settled" data-level="1.2" id="range-request"><span class="secno">1.2. </span><span class="content">Range Request</span><a class="self-link" href="#range-request"></a></h3>
    <p>The second
-method, <a href="#range-request-incxfer">Range Request</a>, has no server-side requirements other than the server should be able to respond to byte-based range requests. The browser makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file.</p>
+method, <a href="#range-request-incxfer">Range Request</a>, has no server-side requirements other than the server should be able to respond to byte-based range requests. The browser makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file to obtain all required font tables, and then calculates glyph coverage and required byte ranges using font character-to-glyph mapping and glyph substitution / layout tables.</p>
    <p>In order for the range request method to be as effective as possible, the font file itself should be internally arranged in a particular way, in order to decrease the number of requests the browser needs to make. Therefore, it is expected that web developers wishing to use the range request method will use font files that have had their contents already arranged optimally.</p>
    <p>This method was modelled after video playback on the web, where seeking in a video causes the browser to send a range request to the server.</p>
    <h3 class="heading settled" data-level="1.3" id="evaluation-report"><span class="secno">1.3. </span><span class="content">Technical Motivation: Evaluation Report</span><a class="self-link" href="#evaluation-report"></a></h3>


### PR DESCRIPTION
For the most part moves text fom the later intro section up to the patch subset overview section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/77.html" title="Last updated on Mar 8, 2022, 9:16 PM UTC (e729721)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/77/21043b6...e729721.html" title="Last updated on Mar 8, 2022, 9:16 PM UTC (e729721)">Diff</a>