### PR TITLE
Tags some additional server conformance requirements.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -751,14 +751,15 @@ For a PatchRequest object to be well formed:
 
 For a PatchResponse object to be well formed:
 *  <span class="conform server" id="conform-response-protocol-version">
-     <code>protocol_version</code> must be set to 0.</span>
-*  <span class="conform server" id="conform-response-valid-format">
-     <code>patch_format</code> must be one of the values listed in [[#patch-formats]].</span>
+     <code>protocol_version</code> must be set to 0.</span>     
 *  <span class="conform server" id="conform-response-patch-or-replacement">
      Only one of <code>patch</code> or <code>replacement</code> must be set.</span>
 *  <span class="conform server" id="conform-response-font-checksums">
      If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>,
      <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.</span>
+*  <span class="conform server" id="conform-response-valid-format">
+     If <code>patch_format</code> is set then it must be one of the values listed in
+     [[#patch-formats]].</span>
 *  <span class="conform server" id="conform-response-ordering-checksum">
      If <code>codepoint_ordering</code> is set then <code>ordering_checksum</code> must be set.</span>
 
@@ -963,14 +964,16 @@ The [=url/path=] in the request [=request/url=] identifies the specific font tha
 for. From the request object the server can produce two codepoint sets:
 
 1.  Codepoints the client has: formed by the union of the codepoint sets specified by
-     <code>codepoints_have</code> and <code>indices_have</code>. The indices in
+     <code>codepoints_have</code> and <code>indices_have</code>.
+     <span class="conform server" id="conform-remap-codepoints-have">The indices in
      <code>indices_have</code> must be mapped to codepoints by the application of the
-     codepoint reordering with a checksum matching <code>ordering_checksum</code>.
+     codepoint reordering with a checksum matching <code>ordering_checksum</code>.</span>
 
 2.  Codepoints the client needs: formed by the union of the codepoint sets specified by
-     <code>codepoints_needed</code> and <code>indices_needed</code>. The indices in
+     <code>codepoints_needed</code> and <code>indices_needed</code>.
+     <span class="conform server" id="conform-remap-codepoints-needed">The indices in
      <code>indices_needed</code> must be mapped to codepoints by the application of the
-     codepoint reordering with a checksum matching <code>ordering_checksum</code>.
+     codepoint reordering with a checksum matching <code>ordering_checksum</code>.</span>
 
 Likewise, the server can produce two variable axis spaces:
 
@@ -981,11 +984,13 @@ Likewise, the server can produce two variable axis spaces:
 2. Axis space the client needs: provided by <code>axis_space_needed</code>. If any axes in the font are
      not specified in <code>axis_space_needed</code> then for those axes add their entire interval
      from the original font.
-
+     
+<span class="conform server" id="conform-bad-reordering">
 If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it's codepoint ordering to one the server
 will recognize via the process described in [[#handling-patch-response]] and not include any patch.
 That is the <code>patch</code> and <code>replacement</code> fields must not be set.
+</span>
 
 <span class="conform server" id="conform-response-valid-patch">
 Otherwise when the response is applied by the client following the process in
@@ -1014,9 +1019,10 @@ Additionally:
      <code>patched_checksum</code> must be set to the checksum of the extended font subset.
      The checksum value must computed by the procedure in [[#computing-checksums]].</span>
 
-*  If the set of codepoints the client has is empty the response must set the
+*  <span class="conform server" id="conform-response-codepoint-ordering">
+    If the set of codepoints the client has is empty the response must set the
     <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following
-    [[#codepoint-reordering]].
+    [[#codepoint-reordering]].</span>
 
 *  If the set of codepoints the client has is empty and the original font has variation axes, the
     response must set the <code>original_axis_space</code> fields to the axis space covered by

--- a/Overview.bs
+++ b/Overview.bs
@@ -547,12 +547,12 @@ the most significant bit of byte is false.
 UIntBase128 encoding format allows a possibility of sub-optimal encoding, where e.g.
 the same numerical value can be represented with variable number of bytes (utilizing
 leading zeros). For example, the value 63 could be encoded as either one byte 0x3F
-or two (or more) bytes: [0x80, 0x3f]. An encoder must not allow this to happen and
-*MUST* produce shortest possible encoding. A decoder *MUST* reject the font file
-if it encounters a UIntBase128-encoded value with
-leading zeros (a value that starts with the byte 0x80), if UIntBase128-encoded
-sequence is longer than 5 bytes, or if a UIntBase128-encoded value exceeds
-2<sup>32</sup>-1. Pseudo-code:
+or two (or more) bytes: [0x80, 0x3f].
+<span class="conform server client" id="conform-uintbase128-illegal">An encoder must not allow this
+to happen and must produce shortest possible encoding. A decoder must reject the response/request
+if it encounters a UIntBase128-encoded value with leading zeros (a value that starts with the byte
+0x80), if UIntBase128-encoded sequence is longer than 5 bytes, or if a UIntBase128-encoded value
+exceeds 2<sup>32</sup>-1.</span> Pseudo-code:
 
 ```
 bool ReadUIntBase128( data, *result ) {
@@ -567,7 +567,7 @@ bool ReadUIntBase128( data, *result ) {
     // If any of top 7 bits are set then << 7 would overflow
     if (accum & 0xFE000000) return false;
 
-    *accum = (accum << 7) | (data_byte & 0x7F);
+    accum = (accum << 7) | (data_byte & 0x7F);
 
     // Spin until most significant bit of data byte is false
     if ((data_byte & 0x80) == 0) {

--- a/Overview.bs
+++ b/Overview.bs
@@ -726,12 +726,15 @@ For an <code>AxisInterval</code> object to be well formed:
 
 For a PatchRequest object to be well formed:
 
-*  <code>protocol_version</code> must be set to 0.
+*  <span class="conform client server" id="conform-request-protocol-version">
+    <code>protocol_version</code> must be set to 0.</span>
 *  <code>accept_patch_format</code> can include any of the values listed in [[#patch-formats]].
-*  If either of <code>indices_have</code> or <code>indices_needed</code> is set to a non-empty set
-    then <code>ordering_checksum</code> must be set.
-*  If <code>codepoints_have</code> or <code>indices_have</code> is set to a non-empty set then
-    <code>original_font_checksum</code> and <code>base_checksum</code> must be set.
+*  <span class="conform client server" id="conform-request-ordering-checksum">
+    If either of <code>indices_have</code> or <code>indices_needed</code> is set to a non-empty set
+    then <code>ordering_checksum</code> must be set.</span>
+*  <span class="conform client server" id="conform-request-base-checksum">
+    If <code>codepoints_have</code> or <code>indices_have</code> is set to a non-empty set then
+    <code>original_font_checksum</code> and <code>base_checksum</code> must be set.</span>
 
 ### PatchResponse ### {#PatchResponse}
 
@@ -1050,8 +1053,10 @@ same client to the same server task.
 
 Possible error responses:
 
-*  If the request is malformed the server must instead respond with http [=response/status=] code 400
-     to indicate an error.
+
+*  <span class="conform server" id="conform-reject-malformed-request">
+     If the request is malformed the server must instead respond with http [=response/status=] code 400
+     to indicate an error.</span>
 
 *  If the requested font is not recognized by the server it should respond with http [=response/status=]
      code 404 to indicate a not found error.

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="69391ea6091055c9047fdc2f1f4c72fc2242e64c" name="document-revision">
+  <meta content="5021b6961684df998afe6ab01472769f31825aee" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -446,7 +446,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2022-03-21">21 March 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2022-03-24">24 March 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1304,11 +1304,11 @@ then <code>ordering_checksum</code> must be set.</p>
     <li data-md>
      <p><span class="conform server" id="conform-response-protocol-version"> <code>protocol_version</code> must be set to 0.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-valid-format"> <code>patch_format</code> must be one of the values listed in <a href="#patch-formats">§ 4.8 Patch Formats</a>.</span></p>
-    <li data-md>
      <p><span class="conform server" id="conform-response-patch-or-replacement"> Only one of <code>patch</code> or <code>replacement</code> must be set.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-font-checksums"> If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>, <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.</span></p>
+    <li data-md>
+     <p><span class="conform server" id="conform-response-valid-format"> If <code>patch_format</code> is set then it must be one of the values listed in <a href="#patch-formats">§ 4.8 Patch Formats</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-ordering-checksum"> If <code>codepoint_ordering</code> is set then <code>ordering_checksum</code> must be set.</span></p>
    </ul>
@@ -1478,11 +1478,11 @@ single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via
 for. From the request object the server can produce two codepoint sets:</p>
    <ol>
     <li data-md>
-     <p>Codepoints the client has: formed by the union of the codepoint sets specified by <code>codepoints_have</code> and <code>indices_have</code>. The indices in <code>indices_have</code> must be mapped to codepoints by the application of the
- codepoint reordering with a checksum matching <code>ordering_checksum</code>.</p>
+     <p>Codepoints the client has: formed by the union of the codepoint sets specified by <code>codepoints_have</code> and <code>indices_have</code>. <span class="conform server" id="conform-remap-codepoints-have">The indices in <code>indices_have</code> must be mapped to codepoints by the application of the
+ codepoint reordering with a checksum matching <code>ordering_checksum</code>.</span></p>
     <li data-md>
-     <p>Codepoints the client needs: formed by the union of the codepoint sets specified by <code>codepoints_needed</code> and <code>indices_needed</code>. The indices in <code>indices_needed</code> must be mapped to codepoints by the application of the
- codepoint reordering with a checksum matching <code>ordering_checksum</code>.</p>
+     <p>Codepoints the client needs: formed by the union of the codepoint sets specified by <code>codepoints_needed</code> and <code>indices_needed</code>. <span class="conform server" id="conform-remap-codepoints-needed">The indices in <code>indices_needed</code> must be mapped to codepoints by the application of the
+ codepoint reordering with a checksum matching <code>ordering_checksum</code>.</span></p>
    </ol>
    <p>Likewise, the server can produce two variable axis spaces:</p>
    <ol>
@@ -1495,10 +1495,10 @@ for. From the request object the server can produce two codepoint sets:</p>
  not specified in <code>axis_space_needed</code> then for those axes add their entire interval
  from the original font.</p>
    </ol>
-   <p>If the server does not recognize the codepoint ordering used by the client, it must respond
+   <p><span class="conform server" id="conform-bad-reordering"> If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
 will recognize via the process described in <a href="#handling-patch-response">§ 4.4.3 Handling PatchResponse</a> and not include any patch.
-That is the <code>patch</code> and <code>replacement</code> fields must not be set.</p>
+That is the <code>patch</code> and <code>replacement</code> fields must not be set. </span></p>
    <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.3 Handling PatchResponse</a> to a font subset with checksum <code>base_checksum</code> it must result
 in an extended font subset: </span></p>
    <ul>
@@ -1521,7 +1521,7 @@ The checksum value must computed by the procedure in <a href="#computing-checksu
      <p><span class="conform server" id="conform-response-patched-checksum"> If <code>patch</code> or <code>replacement</code> fields are set the value of <code>patched_checksum</code> must be set to the checksum of the extended font subset.
  The checksum value must computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
     <li data-md>
-     <p>If the set of codepoints the client has is empty the response must set the <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a>.</p>
+     <p><span class="conform server" id="conform-response-codepoint-ordering"> If the set of codepoints the client has is empty the response must set the <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a>.</span></p>
     <li data-md>
      <p>If the set of codepoints the client has is empty and the original font has variation axes, the
 response must set the <code>original_axis_space</code> fields to the axis space covered by

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="4d7ac04811faa6a5101d56d28e9cfcb277365be5" name="document-revision">
+  <meta content="69391ea6091055c9047fdc2f1f4c72fc2242e64c" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -446,7 +446,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2022-03-16">16 March 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2022-03-21">21 March 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1036,12 +1036,11 @@ the most significant bit of byte is false.</p>
    <p>UIntBase128 encoding format allows a possibility of sub-optimal encoding, where e.g.
 the same numerical value can be represented with variable number of bytes (utilizing
 leading zeros). For example, the value 63 could be encoded as either one byte 0x3F
-or two (or more) bytes: [0x80, 0x3f]. An encoder must not allow this to happen and
-*MUST* produce shortest possible encoding. A decoder *MUST* reject the font file
-if it encounters a UIntBase128-encoded value with
-leading zeros (a value that starts with the byte 0x80), if UIntBase128-encoded
-sequence is longer than 5 bytes, or if a UIntBase128-encoded value exceeds
-2<sup>32</sup>-1. Pseudo-code:</p>
+or two (or more) bytes: [0x80, 0x3f]. <span class="conform server client" id="conform-uintbase128-illegal">An encoder must not allow this
+to happen and must produce shortest possible encoding. A decoder must reject the response/request
+if it encounters a UIntBase128-encoded value with leading zeros (a value that starts with the byte
+0x80), if UIntBase128-encoded sequence is longer than 5 bytes, or if a UIntBase128-encoded value
+exceeds 2<sup>32</sup>-1.</span> Pseudo-code:</p>
 <pre>bool ReadUIntBase128( data, *result ) {
   UInt32 accum = 0;
 
@@ -1054,7 +1053,7 @@ sequence is longer than 5 bytes, or if a UIntBase128-encoded value exceeds
     // If any of top 7 bits are set then &lt;&lt; 7 would overflow
     if (accum &amp; 0xFE000000) return false;
 
-    *accum = (accum &lt;&lt; 7) | (data_byte &amp; 0x7F);
+    accum = (accum &lt;&lt; 7) | (data_byte &amp; 0x7F);
 
     // Spin until most significant bit of data byte is false
     if ((data_byte &amp; 0x80) == 0) {

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version c5fd42b86, updated Mon Apr 5 16:27:33 2021 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="5021b6961684df998afe6ab01472769f31825aee" name="document-revision">
+  <meta content="81e58c6fbb18bbdecd3f06d651db6668b40ee598" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -446,7 +446,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2022-03-24">24 March 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2022-03-25">25 March 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1242,14 +1242,14 @@ then this interval is a single point, <code>start</code>.</p>
    <p>For a PatchRequest object to be well formed:</p>
    <ul>
     <li data-md>
-     <p><code>protocol_version</code> must be set to 0.</p>
+     <p><span class="conform client server" id="conform-request-protocol-version"> <code>protocol_version</code> must be set to 0.</span></p>
     <li data-md>
      <p><code>accept_patch_format</code> can include any of the values listed in <a href="#patch-formats">§ 4.8 Patch Formats</a>.</p>
     <li data-md>
-     <p>If either of <code>indices_have</code> or <code>indices_needed</code> is set to a non-empty set
-then <code>ordering_checksum</code> must be set.</p>
+     <p><span class="conform client server" id="conform-request-ordering-checksum"> If either of <code>indices_have</code> or <code>indices_needed</code> is set to a non-empty set
+then <code>ordering_checksum</code> must be set.</span></p>
     <li data-md>
-     <p>If <code>codepoints_have</code> or <code>indices_have</code> is set to a non-empty set then <code>original_font_checksum</code> and <code>base_checksum</code> must be set.</p>
+     <p><span class="conform client server" id="conform-request-base-checksum"> If <code>codepoints_have</code> or <code>indices_have</code> is set to a non-empty set then <code>original_font_checksum</code> and <code>base_checksum</code> must be set.</span></p>
    </ul>
    <h4 class="heading settled" data-level="4.3.4" id="PatchResponse"><span class="secno">4.3.4. </span><span class="content">PatchResponse</span><a class="self-link" href="#PatchResponse"></a></h4>
    <table>
@@ -1548,8 +1548,8 @@ same client to the same server task.</p>
    <p>Possible error responses:</p>
    <ul>
     <li data-md>
-     <p>If the request is malformed the server must instead respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status④">status</a> code 400
- to indicate an error.</p>
+     <p><span class="conform server" id="conform-reject-malformed-request"> If the request is malformed the server must instead respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status④">status</a> code 400
+ to indicate an error.</span></p>
     <li data-md>
      <p>If the requested font is not recognized by the server it should respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status⑤">status</a> code 404 to indicate a not found error.</p>
    </ul>


### PR DESCRIPTION
Adds tags used by https://github.com/w3c/ift-server-tests/pull/7


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/86.html" title="Last updated on Mar 26, 2022, 12:51 AM UTC (b41b3a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/86/69391ea...b41b3a6.html" title="Last updated on Mar 26, 2022, 12:51 AM UTC (b41b3a6)">Diff</a>