### PR TITLE
Re-work when original_font_checksum, original_features, original_axis_space, and codepoint_ordering are sent.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -804,7 +804,7 @@ For a PatchResponse object to be well formed:
      Only one of <code>patch</code> or <code>replacement</code> must be set.</span>
 *  <span class="conform server" id="conform-response-font-checksums">
      If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>,
-     <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.</span>
+     and <code>patched_checksum</code> must be set.</span>
 *  <span class="conform server" id="conform-response-valid-format">
      If <code>patch_format</code> is set then it must be one of the values listed in
      [[#patch-formats]].</span>
@@ -843,7 +843,8 @@ Additionally, the client can optionally store:
 *  Original font feature list: a list of the
     <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a>
     that the original font has data for. This information can be used by the client to avoid sending
-    unnecessary requests for features which the original font does not contain.
+    unnecessary requests for features which the original font does not contain. Supplied by
+    <a href="#PatchResponse"><code>PatchResponse.original_features</code></a>.
 
 ### Extending the Font Subset ### {#extend-subset}
 
@@ -962,10 +963,13 @@ should interpret and process the fields of the object as follows:
     resend the request that triggered this response but use the new codepoint ordering provided in
     this response.
 
-5. If <code>original_axis_space</code> is set then update the saved original axis space with the value
+5. If <code>original_features</code> is set and the client has opted to save them then update the saved
+    original feature list with the value specified in this field.
+
+6. If <code>original_axis_space</code> is set then update the saved original axis space with the value
     specified in this field.
 
-6. If <code>subset_axis_space</code> is set then update the saved subset axis space with the value
+7. If <code>subset_axis_space</code> is set then update the saved subset axis space with the value
     specified in this field.
 
 ### Handling Invalid Response from the Server ### {#invalid-server-response}
@@ -1081,35 +1085,39 @@ in an extended font subset:
     space that covers at least the union of the axis space the client has and the axis space the
     client needs.</span>
 
+If the checksum of the original font computed by the procedure in [[#computing-checksums]] does not
+match the checksum in <code>PatchRequest.original_font_checksum</code> or
+<code>PatchRequest.original_font_checksum</code> is unset, then:
+
+*  <span class="conform server" id="conform-response-original-checksum">The value of
+    <code>original_font_checksum</code> must be set to the checksum of the original font
+    computed by the procedure in [[#computing-checksums]].</span>
+
+*  <span class="conform server" id="conform-response-codepoint-ordering">
+    The response must set the
+    <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following
+    [[#codepoint-reordering]].</span>
+
+*  <span class="conform server" id="conform-response-original-features">
+    The response must set the <code>original_features</code> field to the list of
+    <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a>
+    that the original font has data for.</span>
+
+*  <span class="conform server" id="conform-response-original-axis-space">
+    If the original font has variation axes, the
+    response must set the <code>original_axis_space</code> field to the axis space covered by
+    the original font.</span>
+
 Additionally:
 
 *  <span class="conform server" id="conform-response-patch-format">The format of the patch in the
     either the <code>patch</code> or <code>replace</code> fields must be one of those listed in
     <code>accept_patch_format</code></span>.
 
-*  <span class="conform server" id="conform-response-original-checksum">The value of
-    <code>original_font_checksum</code> must be set to the checksum of the original font.
-    The checksum value must computed by the procedure in [[#computing-checksums]].</span>
-
 *  <span class="conform server" id="conform-response-patched-checksum">
      If <code>patch</code> or <code>replacement</code> fields are set the value of
      <code>patched_checksum</code> must be set to the checksum of the extended font subset.
      The checksum value must computed by the procedure in [[#computing-checksums]].</span>
-
-*  <span class="conform server" id="conform-response-codepoint-ordering">
-    If the set of codepoints the client has is empty the response must set the
-    <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following
-    [[#codepoint-reordering]].</span>
-
-*  <span class="conform server" id="conform-response-original-features">
-    If the <code>patch</code> or <code>replacement</code> fields are set then the
-    <code>original_features</code> field should be set to the list of feature tags that the original
-    font has data for.</span>
-
-*  <span class="conform server" id="conform-response-original-axis-space">
-    If the set of codepoints the client has is empty and the original font has variation axes, the
-    response must set the <code>original_axis_space</code> fields to the axis space covered by
-    the original font.</span>
 
 *  <span class="conform server" id="conform-response-subset-axis-space-field">
     If <code>patch</code> or <code>replacement</code> fields are set and the original font has

--- a/Overview.bs
+++ b/Overview.bs
@@ -963,8 +963,8 @@ should interpret and process the fields of the object as follows:
     resend the request that triggered this response but use the new codepoint ordering provided in
     this response.
 
-5. If <code>original_features</code> is set and the client has opted to save them then update the saved
-    original feature list with the value specified in this field.
+5. If <code>original_features</code> is set and the client has opted to save them then replace the 
+    original feature list in the client's saved state with the value from the response.
 
 6. If <code>original_axis_space</code> is set then update the saved original axis space with the value
     specified in this field.
@@ -1117,7 +1117,7 @@ Additionally:
 *  <span class="conform server" id="conform-response-patched-checksum">
      If <code>patch</code> or <code>replacement</code> fields are set the value of
      <code>patched_checksum</code> must be set to the checksum of the extended font subset.
-     The checksum value must computed by the procedure in [[#computing-checksums]].</span>
+     The checksum value must be computed by the procedure in [[#computing-checksums]].</span>
 
 *  <span class="conform server" id="conform-response-subset-axis-space-field">
     If <code>patch</code> or <code>replacement</code> fields are set and the original font has

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="d14f06db2efa4c19fd0c4d4bcd36d62c2a9cfcde" name="document-revision">
+  <meta content="ad0eb125afbc254f331d712a78ba0c2b9851dff0" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -456,7 +456,7 @@ dfn > a.self-link::before      { content: "#"; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2022-06-03">3 June 2022</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2022-06-13">13 June 2022</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1491,8 +1491,8 @@ If neither <code>replacement</code> nor <code>patch</code> are set, then the cli
 resend the request that triggered this response but use the new codepoint ordering provided in
 this response.</p>
     <li data-md>
-     <p>If <code>original_features</code> is set and the client has opted to save them then update the saved
-original feature list with the value specified in this field.</p>
+     <p>If <code>original_features</code> is set and the client has opted to save them then replace the
+original feature list in the client’s saved state with the value from the response.</p>
     <li data-md>
      <p>If <code>original_axis_space</code> is set then update the saved original axis space with the value
 specified in this field.</p>
@@ -1613,7 +1613,7 @@ the original font.</span></p>
 either the <code>patch</code> or <code>replace</code> fields must be one of those listed in <code>accept_patch_format</code></span>.</p>
     <li data-md>
      <p><span class="conform server" id="conform-response-patched-checksum"> If <code>patch</code> or <code>replacement</code> fields are set the value of <code>patched_checksum</code> must be set to the checksum of the extended font subset.
- The checksum value must computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
+ The checksum value must be computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <code>patch</code> or <code>replacement</code> fields are set and the original font has
 variation axes, the response must set the <code>subset_axis_space</code> field to the axis space

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="8281cb364318dc5184209fd1afdc30433dbc8c2a" name="document-revision">
+  <meta content="d14f06db2efa4c19fd0c4d4bcd36d62c2a9cfcde" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1357,7 +1357,8 @@ then <code>ordering_checksum</code> must be set.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-patch-or-replacement"> Only one of <code>patch</code> or <code>replacement</code> must be set.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-font-checksums"> If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>, <code>patched_checksum</code>, and <code>original_font_checksum</code> must be set.</span></p>
+     <p><span class="conform server" id="conform-response-font-checksums"> If either <code>patch</code> or <code>replacement</code> is set then <code>patch_format</code>,
+ and <code>patched_checksum</code> must be set.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-valid-format"> If <code>patch_format</code> is set then it must be one of the values listed in <a href="#patch-formats">§ 4.8 Patch Formats</a>.</span></p>
     <li data-md>
@@ -1389,7 +1390,7 @@ by <a href="#PatchResponse"><code>PatchResponse.original_axis_space</code></a>.<
    <ul>
     <li data-md>
      <p>Original font feature list: a list of the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a> that the original font has data for. This information can be used by the client to avoid sending
-unnecessary requests for features which the original font does not contain.</p>
+unnecessary requests for features which the original font does not contain. Supplied by <a href="#PatchResponse"><code>PatchResponse.original_features</code></a>.</p>
    </ul>
    <h4 class="heading settled" data-level="4.4.2" id="extend-subset"><span class="secno">4.4.2. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
    <p>A client extends its font subset to cover additional codepoints by making requests to a Patch Subset
@@ -1490,6 +1491,9 @@ If neither <code>replacement</code> nor <code>patch</code> are set, then the cli
 resend the request that triggered this response but use the new codepoint ordering provided in
 this response.</p>
     <li data-md>
+     <p>If <code>original_features</code> is set and the client has opted to save them then update the saved
+original feature list with the value specified in this field.</p>
+    <li data-md>
      <p>If <code>original_axis_space</code> is set then update the saved original axis space with the value
 specified in this field.</p>
     <li data-md>
@@ -1587,26 +1591,29 @@ the union of the set of features needed and the sets of features the client alre
 space that covers at least the union of the axis space the client has and the axis space the
 client needs.</span></p>
    </ul>
+   <p>If the checksum of the original font computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a> does not
+match the checksum in <code>PatchRequest.original_font_checksum</code> or <code>PatchRequest.original_font_checksum</code> is unset, then:</p>
+   <ul>
+    <li data-md>
+     <p><span class="conform server" id="conform-response-original-checksum">The value of <code>original_font_checksum</code> must be set to the checksum of the original font
+computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
+    <li data-md>
+     <p><span class="conform server" id="conform-response-codepoint-ordering"> The response must set the <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a>.</span></p>
+    <li data-md>
+     <p><span class="conform server" id="conform-response-original-features"> The response must set the <code>original_features</code> field to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a> that the original font has data for.</span></p>
+    <li data-md>
+     <p><span class="conform server" id="conform-response-original-axis-space"> If the original font has variation axes, the
+response must set the <code>original_axis_space</code> field to the axis space covered by
+the original font.</span></p>
+   </ul>
    <p>Additionally:</p>
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-patch-format">The format of the patch in the
 either the <code>patch</code> or <code>replace</code> fields must be one of those listed in <code>accept_patch_format</code></span>.</p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-original-checksum">The value of <code>original_font_checksum</code> must be set to the checksum of the original font.
-The checksum value must computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
-    <li data-md>
      <p><span class="conform server" id="conform-response-patched-checksum"> If <code>patch</code> or <code>replacement</code> fields are set the value of <code>patched_checksum</code> must be set to the checksum of the extended font subset.
  The checksum value must computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
-    <li data-md>
-     <p><span class="conform server" id="conform-response-codepoint-ordering"> If the set of codepoints the client has is empty the response must set the <code>codepoint_ordering</code> and <code>ordering_checksum</code> fields following <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a>.</span></p>
-    <li data-md>
-     <p><span class="conform server" id="conform-response-original-features"> If the <code>patch</code> or <code>replacement</code> fields are set then the <code>original_features</code> field should be set to the list of feature tags that the original
-font has data for.</span></p>
-    <li data-md>
-     <p><span class="conform server" id="conform-response-original-axis-space"> If the set of codepoints the client has is empty and the original font has variation axes, the
-response must set the <code>original_axis_space</code> fields to the axis space covered by
-the original font.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <code>patch</code> or <code>replacement</code> fields are set and the original font has
 variation axes, the response must set the <code>subset_axis_space</code> field to the axis space


### PR DESCRIPTION
Change to have these font derived fields sent whenever the server sees a mismatch between the client reported original font checksum and the servers original font checksum. This allows the fields to be updated in the client's state during a font version upgrade. Such as when a server is patching a client to a new version of the original font.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/97.html" title="Last updated on Jun 13, 2022, 9:26 PM UTC (aa8dc8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/97/9fc60c1...aa8dc8f.html" title="Last updated on Jun 13, 2022, 9:26 PM UTC (aa8dc8f)">Diff</a>