### PR TITLE
Provide guidance on how a client may choose to integrate with it's HTTP cache.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -217,6 +217,11 @@ the use of any optional typographic features that a renderer may choose to use f
 such as hinting instructions.
 </span>
 
+### Font Subset Definition ### {#font-subset-definition}
+
+A font subset definition describes the minimum data (codepoints, layout features, variation axis
+space) that a <a href="#font-subset">font subset</a> must possess.
+
 Data Types {#data-types}
 ------------------------
 
@@ -848,95 +853,126 @@ Additionally, the client can optionally store:
 
 ### Extending the Font Subset ### {#extend-subset}
 
-A client extends its font subset to cover additional codepoints by making requests to a Patch Subset
-server. For this algorithm the user agent provides a HTTP fetching algorithm, such as [[fetch]].
-The text below describes the inputs to the fetch in terms of [[fetch#fetching]]. If the implementing
-user agent provides a different fetching algorithm, then the request should be made using the
-equivalent inputs to the provided fetch algorithm.
+This algorithm is used by the client to extends its font subset to cover additional codepoints,
+features, and/or design-variation space. The inputs to this algorithm are:
 
-* The request [=request/method=] must be either "GET" or "POST".
+* Font URL: a URL where the font to be extended is located.
 
-* The request [=request/destination=] must be "font".
+* Client State (optional): previously saved <a href="#client-state">client state</a> for the given
+    font url, or null.
 
-* The request CORS [=request/mode=] must be "cors".
+* Desired Subset Definition: a <a href="#font-subset-definition">description</a> of the desired
+    minimum font subset.
 
-* The request URL [=url/scheme=] must be "https".
+* Fetch Algorithm: algorithm for fetching HTTP resources, such as [[fetch]]. The remainder of this
+    section is desribed in terms of [[fetch#fetching]], but it is allowed to substitute whatever
+    HTTP fetching algorithm the user agent supports.
 
-* The request URL [=url/path=] is used to identify the font specific to be loaded.
+The algorithm outputs:
 
-* If [=request/method=] is "POST" then, request [=request/body=] must be a single
-    <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR.
+* Client State: client state that has been updated to contain a font subset which covers at least
+    the requested subset definition.
 
-* Otherwise if [=request/method=] is "GET" then, URL [=url/query=] must contain a
-    parameter "request" whose value is a single <a href="#PatchRequest"><code>PatchRequest</code></a>
-    object encoded via CBOR and then base64url encoding [[rfc4648]].
+* Cache headers: HTTP Cache headers [[RFC7234#header.field.definitions]] describing how client state
+    can be cached, or null.
 
-Any request and/or url parameters which are not specified here should be set based on
-the user agent's normal handling for font requests. For example if this font load is
-from a CSS font face, then [[css-fonts-4#font-fetching-requirements]] should be followed.
+Extend font subset algorithm:
 
-The fields of the <a href="#PatchRequest"><code>PatchRequest</code></a> object should be set
-as follows:
+1. Compare the input font subset definition to the input client state. If the input client state
+     already satisifies the font subset definition. Then return client state, and null for the
+     cache headers.
 
-*  <code>protocol_version</code>: set to 0.
+2. Otherwise make an HTTP request using the input fetching algorithm:
 
-*  <code>accept_patch_format</code>: set to the list of [[#patch-formats]] that this client is
-    capable of decoding. Must contain at least one format.
+     * The request [=request/method=] must be either "GET" or "POST".
 
-*  <code>codepoints_have</code>: set to exactly the set of codepoints that the current font subset
-    contains data for. If the current font subset is an empty byte array this field is left unset.
-    If the client has a codepoint ordering for this font then this field should not be set.
+     * The request [=request/destination=] must be "font".
 
-*  <code>codepoints_needed</code>: set to the set of codepoints that the client wants to
-    add to its font subset. If the client has a codepoint ordering for this font then this
-    field should not be set.
+     * The request CORS [=request/mode=] must be "cors".
 
-*  <code>indices_have</code>: encodes the set of additional codepoints that the current
-    font subset contains data for. The codepoint values are transformed to indices by applying
-    [[#codepoint-reordering]] to each codepoint value. If the client does not have a codepoint
-    ordering for this font then this field should not be set.
+     * The request URL [=url/scheme=] must be "https".
 
-*  <code>indices_needed</code>: encodes the set of codepoints that the client wants to add to its
-    font subset. The codepoint values are transformed to indices by applying
-    [[#codepoint-reordering]] to each codepoint value. If the client does not have a codepoint
-    ordering for this font then this field should not be set.
+     * The request URL [=url/path=] is set to the input font URL.
 
-* <code>features_have</code>: set to the list of
-    <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a>
-    that the current font subset has data for. If the current font subset is an empty byte array this
-    field is left unset. Additionally, if the current font subset has all data for features present in
-    the original font then this field can be unset.
+     * If [=request/method=] is "POST" then, request [=request/body=] must be a single
+         <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR.
 
-* <code>features_needed</code>: set to the list of feature tags that the client wants to add
-    to the current font subset. Alternatively, if the client wishes to add all features from
-    the original font to it's subset then this field should be unset.
+     * Otherwise if [=request/method=] is "GET" then, URL [=url/query=] must contain a
+          parameter "request" whose value is a single
+          <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then
+          base64url encoding [[rfc4648]].
 
-*  <code>axis_space_have</code>: set to the current value of <code>subset_axis_space</code>
-    saved in the state for this font.
+     TODO(garretrieger): how is cache mode set?
 
-*  <code>axis_space_needed</code>: set to the intervals of each variable axis in the original
-    font that the client wants to add to its font subset. If the client wants an entire axis
-    from the original font then that axis should not be listed.
+     Any request and/or url parameters which are not specified here should be set based on
+     the user agent's normal handling for font requests. For example if this font load is
+     from a CSS font face, then [[css-fonts-4#font-fetching-requirements]] should be followed.
 
-*  <code>ordering_checksum</code>: If either of <code>indices_have</code> or
-    <code>indices_needed</code> is set then this must be set to the current value of
-    <code>ordering_checksum</code> saved in the state for this font.
+     The fields of the <a href="#PatchRequest"><code>PatchRequest</code></a> object should be set
+     as follows:
 
-*  <code>original_font_checksum</code>:
-    Set to saved value for <code>original_font_checksum</code> in the state for this font. If
-    there is no saved value leave this field unset.
+     *  <code>protocol_version</code>: set to 0.
 
-*  <code>base_checksum</code>:
-    Set to the checksum of the font subset byte array saved in the state for this font. See:
-    [[#computing-checksums]].
+     *  <code>accept_patch_format</code>: set to the list of [[#patch-formats]] that this client is
+         capable of decoding. Must contain at least one format.
+
+     *  <code>codepoints_have</code>: set to exactly the set of codepoints that the current font subset
+         contains data for. If the current font subset is an empty byte array this field is left unset.
+         If the client has a codepoint ordering for this font then this field should not be set.
+
+     *  <code>codepoints_needed</code>: set to the set of codepoints that the client wants to
+         add to its font subset. If the client has a codepoint ordering for this font then this
+         field should not be set.
+
+     *  <code>indices_have</code>: encodes the set of additional codepoints that the current
+         font subset contains data for. The codepoint values are transformed to indices by applying
+         [[#codepoint-reordering]] to each codepoint value. If the client does not have a codepoint
+         ordering for this font then this field should not be set.
+
+     *  <code>indices_needed</code>: encodes the set of codepoints that the client wants to add to its
+         font subset. The codepoint values are transformed to indices by applying
+         [[#codepoint-reordering]] to each codepoint value. If the client does not have a codepoint
+         ordering for this font then this field should not be set.
+
+     *  <code>features_have</code>: set to the list of
+         <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">
+         opentype layout feature tags</a> that the current font subset has data for. If the current
+         font subset is an empty byte array this
+         field is left unset. Additionally, if the current font subset has all data for features
+         present in the original font then this field can be unset.
+
+     *  <code>features_needed</code>: set to the list of feature tags that the client wants to add
+         to the current font subset. Alternatively, if the client wishes to add all features from
+         the original font to it's subset then this field should be unset.
+
+     *  <code>axis_space_have</code>: set to the current value of <code>subset_axis_space</code>
+         saved in the state for this font.
+
+     *  <code>axis_space_needed</code>: set to the intervals of each variable axis in the original
+         font that the client wants to add to its font subset. If the client wants an entire axis
+         from the original font then that axis should not be listed.
+
+     *  <code>ordering_checksum</code>: If either of <code>indices_have</code> or
+         <code>indices_needed</code> is set then this must be set to the current value of
+         <code>ordering_checksum</code> saved in the state for this font.
+
+     *  <code>original_font_checksum</code>:
+         Set to saved value for <code>original_font_checksum</code> in the state for this font. If
+         there is no saved value leave this field unset.
+
+     *  <code>base_checksum</code>:
+         Set to the checksum of the font subset byte array saved in the state for this font. See:
+         [[#computing-checksums]].
 
 
-Note: It is allowed for the client to request more codepoints then it strictly needs. For
-example, on slower connections it may be more performant to request extra codepoints if
-that is likely to prevent a future request from needing to be sent.
+     Note: It is allowed for the client to request more codepoints then it strictly needs. For
+     example, on slower connections it may be more performant to request extra codepoints if
+     that is likely to prevent a future request from needing to be sent.
+
+3. Goto [[#handling-patch-response]].
 
 
-### Handling PatchResponse ### {#handling-patch-response}
+#### Handling PatchResponse #### {#handling-patch-response}
 
 If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a>
 it will respond with HTTP [=response/status=] code 200 and the [=response/body=] of the response will
@@ -946,40 +982,46 @@ should interpret and process the fields of the object as follows:
 
 1.  If field <code>replacement</code> is set then: the byte array in this field is a binary patch
      in the format specified by <code>patch_format</code>. Apply the binary patch to a base which
-     is an empty byte array. Replace the saved font subset with the result of the patch application.
+     is an empty byte array. Replace the font subset in the input client state with the result of the
+     patch application.
 
 2. If field <code>patch</code> is set then:  the byte array in this field is a binary patch
-    in the format specified by <code>patch_format</code>. Apply the binary patch to the saved font
-    subset. Replace the saved font subset with the result of the patch application.
+    in the format specified by <code>patch_format</code>. Apply the binary patch to the font
+    subset from the input client state. Replace the font subset in the input client state with the
+    result of the patch application.
 
 3. If either <code>replacement</code> or <code>patch</code> is set then:
     <a href="#computing-checksums">compute the checksum</a> of the font subset produced by the patch
     application in steps 1 or 2. If the computed checksum is not equal to <code>patched_checksum</code>
     this is a recoverable error. Follow the procedure in [[#client-side-checksum-mismatch]]. Otherwise
-    update the saved original font checksum with the value in <code>original_font_checksum</code>.
+    update the original font checksum in the input client state with the value in
+    <code>original_font_checksum</code>.
 
 4. If fields <code>codepoint_ordering</code> and <code>ordering_checksum</code> are set then update
-    the saved codepoint ordering and checksum with the new values specified by these two fields.
-    If neither <code>replacement</code> nor <code>patch</code> are set, then the client should
-    resend the request that triggered this response but use the new codepoint ordering provided in
-    this response.
+    the codepoint ordering and checksum in the input client state with the new values specified by
+    these two fields. If neither <code>replacement</code> nor <code>patch</code> are set, then the
+    client should resend the request that triggered this response but use the new codepoint ordering
+    provided in this response.
 
 5. If <code>original_features</code> is set and the client has opted to save them then replace the 
-    original feature list in the client's saved state with the value from the response.
+    original feature in the input client state with the value from the response.
 
-6. If <code>original_axis_space</code> is set then update the saved original axis space with the value
-    specified in this field.
+6. If <code>original_axis_space</code> is set then update the original axis space in the input client
+    state with the value specified in this field.
 
-7. If <code>subset_axis_space</code> is set then update the saved subset axis space with the value
-    specified in this field.
+7. If <code>subset_axis_space</code> is set then update the subset axis space in the input client
+    state with the value specified in this field.
 
-### Handling Invalid Response from the Server ### {#invalid-server-response}
+After processing the response, return the updated input client state and any cache headers that were
+set on the response.
+
+#### Handling Invalid Response from the Server #### {#invalid-server-response}
 
 
 If the response a client receives from the server has a [=response/status=] code other than 200:
 
 *  If it is a redirect [=status=]: follow normal redirect handling, such as
-     [[fetch#http-redirect-fetch]].
+     [[fetch#http-redirect-fetch]] and then go back to [[#handling-patch-response]].
 
 *  All other statuses, the font subset extension has failed. Follow [[#font-load-failed]].
 
@@ -989,12 +1031,12 @@ is malformed. That is, it is missing the magic number, not decodable with CBOR, 
 
 *  This is an error. Follow [[#font-load-failed]].
 
-### Client Side Checksum Mismatch ### {#client-side-checksum-mismatch}
+#### Client Side Checksum Mismatch #### {#client-side-checksum-mismatch}
 
 If the checksum of the font subset computed by the client does not match the
 <code>patched_checksum</code> in the server's response then the client should:
 
-1. Discard all currently saved state for this font.
+1. Discard the input client state for this font.
 
 2. <a href="#extend-subset">Resend the request</a>. Set the <code>codepoints_needed</code> field
     to the union of the codepoints in the discarded font subset and the set of code points
@@ -1003,7 +1045,7 @@ If the checksum of the font subset computed by the client does not match the
     If the resent request also results in a checksum mismatch then this is an error. The client
     must not resend the request again and should follow [[#font-load-failed]]
 
-### Font Load Failed ### {#font-load-failed}
+#### Font Load Failed #### {#font-load-failed}
 
 If the font load or extension has failed the client should choose one of the following options:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1066,7 +1066,7 @@ discarded.
 The previous section [[#extend-subset]] provides no guidance on how a user agent should handle
 saving client state between invocations of the subset extension algorithm. This section provides an
 algorithm that user agents which implement [[fetch]] should use to save client state to the user
-agents HTTP cache ([[RFC7234]]).
+agent's HTTP cache ([[RFC7234]]).
 
 The inputs to this algorithm:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1004,7 +1004,7 @@ should interpret and process the fields of the object as follows:
     provided in this response.
 
 5. If <code>original_features</code> is set and the client has opted to save them then replace the 
-    original feature in the input client state with the value from the response.
+    original feature list in the input client state with the value from the response.
 
 6. If <code>original_axis_space</code> is set then update the original axis space in the input client
     state with the value specified in this field.

--- a/Overview.bs
+++ b/Overview.bs
@@ -1114,7 +1114,7 @@ The algorithm:
 
      *  Font url set to the input font url.
 
-     *  Client state set to the response.
+     *  Client state set to null.
 
      *  Desired subset definition set to the input subset definition.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -849,9 +849,10 @@ Additionally, the client can optionally store:
 ### Extending the Font Subset ### {#extend-subset}
 
 A client extends its font subset to cover additional codepoints by making requests to a Patch Subset
-server. The request requirements are described here in terms of a fetch according to
-[[fetch#fetching]]. If the implementing user agent does not support fetch, then the request
-should be made using an equivalent HTTP request.
+server. For this algorithm the user agent provides a HTTP fetching algorithm, such as [[fetch]].
+The text below describes the inputs to the fetch in terms of [[fetch#fetching]]. If the implementing
+user agent provides a different fetching algorithm, then the request should be made using the
+equivalent inputs to the provided fetch algorithm.
 
 * The request [=request/method=] must be either "GET" or "POST".
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1063,12 +1063,10 @@ discarded.
 
 ### Load a Font in a User Agent with a HTTP Cache ### {#load-a-font}
 
-<em>This section is not normative.</em>
-
 The previous section [[#extend-subset]] provides no guidance on how a user agent should handle
 saving client state between invocations of the subset extension algorithm. This section provides an
-algorithm that user agents which implement [[fetch]] may choose to use to save client
-state to the user agents HTTP cache ([[RFC7234]]).
+algorithm that user agents which implement [[fetch]] should use to save client state to the user
+agents HTTP cache ([[RFC7234]]).
 
 The inputs to this algorithm:
 
@@ -1110,7 +1108,7 @@ The algorithm:
 
      Once that returns go to step 4.
 
-3.  Otherwise:
+3.  Otherwise, invoke [[#extend-subset]] with:
 
      *  Font url set to the input font url.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -890,6 +890,8 @@ Extend font subset algorithm:
 
      * The request CORS [=request/mode=] must be "cors".
 
+     * The request [=request/cache mode=] should be "no-store".
+
      * The request URL [=url/scheme=] must be "https".
 
      * The request URL [=url/path=] is set to the input font URL.
@@ -901,8 +903,6 @@ Extend font subset algorithm:
           parameter "request" whose value is a single
           <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then
           base64url encoding [[rfc4648]].
-
-     TODO(garretrieger): how is cache mode set?
 
      Any request and/or url parameters which are not specified here should be set based on
      the user agent's normal handling for font requests. For example if this font load is
@@ -1060,6 +1060,73 @@ If the font load or extension has failed the client should choose one of the fol
 
 Regardless of which of the above options are used, the saved client state for this font must be
 discarded.
+
+### Load a Font in a User Agent with a HTTP Cache ### {#load-a-font}
+
+<em>This section is not normative.</em>
+
+The previous section [[#extend-subset]] provides no guidance on how a user agent should handle
+saving client state between invocations of the subset extension algorithm. This section provides an
+algorithm that user agents which implement [[fetch]] may choose to use to save client
+state to the user agents HTTP cache ([[RFC7234]]).
+
+The inputs to this algorithm:
+
+*  Font URL: a URL where the font to be extended is located.
+
+*  Desired Subset Definition: a <a href="#font-subset-definition">description</a> of the desired
+    minimum font subset.
+
+The algorithm outputs:
+
+*  A <a href="#font-subset">Font Subset</a> which covers at minimum the input subset definition.
+
+The algorithm:
+
+1.  Make a HTTP fetch:
+
+     * The request [=request/method=] is "GET".
+
+     * The request [=request/destination=] must be "font".
+
+     * The request CORS [=request/mode=] must be "cors".
+
+     * The request URL [=url/scheme=] must be "https".
+
+     * The request URL [=url/path=] is set to the input font URL.
+
+     * The request [=request/cache mode=] is "only-if-cached".
+
+2.  If the request is successful and the response is "fresh" ([[RFC7234#expiration.model]])
+     then invoke [[#extend-subset]] with:
+
+     *  Font url set to the input font url.
+
+     *  Client state set to the response.
+
+     *  Desired subset definition set to the input subset definition.
+
+     *  Fetch algorithm set to [[fetch]].
+
+     Once that returns go to step 4.
+
+3.  Otherwise:
+
+     *  Font url set to the input font url.
+
+     *  Client state set to the response.
+
+     *  Desired subset definition set to the input subset definition.
+
+     *  Fetch algorithm set to [[fetch]].
+
+     Once that returns go to step 4.
+
+4.  If the returned cache headers are non-null update the cache entry for the input
+     font url with the returned client state and returned cache headers.
+
+5.  Return the font subset contained in the returned client state.
+
 
 Server: Responding to a PatchRequest {#handling-patch-request}
 --------------------------------------------------------------

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="9653eb3f13b1f4fec5b3ed97b9363d7ff2432de3" name="document-revision">
+  <meta content="71ea7593fed40c7a06a5dcbd0f5170f0cc89738a" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1592,11 +1592,10 @@ must not resend the request again and should follow <a href="#font-load-failed">
    <p>Regardless of which of the above options are used, the saved client state for this font must be
 discarded.</p>
    <h4 class="heading settled" data-level="4.4.3" id="load-a-font"><span class="secno">4.4.3. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
-   <p><em>This section is not normative.</em></p>
    <p>The previous section <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> provides no guidance on how a user agent should handle
 saving client state between invocations of the subset extension algorithm. This section provides an
-algorithm that user agents which implement <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a> may choose to use to save client
-state to the user agents HTTP cache (<a data-link-type="biblio" href="#biblio-rfc7234">[RFC7234]</a>).</p>
+algorithm that user agents which implement <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a> should use to save client state to the user
+agents HTTP cache (<a data-link-type="biblio" href="#biblio-rfc7234">[RFC7234]</a>).</p>
    <p>The inputs to this algorithm:</p>
    <ul>
     <li data-md>
@@ -1643,7 +1642,7 @@ minimum font subset.</p>
      </ul>
      <p>Once that returns go to step 4.</p>
     <li data-md>
-     <p>Otherwise:</p>
+     <p>Otherwise, invoke <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> with:</p>
      <ul>
       <li data-md>
        <p>Font url set to the input font url.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="ad41c00db9850c8cdafb299aa56d6b02f135eb0a" name="document-revision">
+  <meta content="b8da6392edf5de815564e605f08022cc55b50d3b" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -569,6 +569,7 @@ dfn > a.self-link::before      { content: "#"; }
           <li><a href="#client-side-checksum-mismatch"><span class="secno">4.4.2.3</span> <span class="content">Client Side Checksum Mismatch</span></a>
           <li><a href="#font-load-failed"><span class="secno">4.4.2.4</span> <span class="content">Font Load Failed</span></a>
          </ol>
+        <li><a href="#load-a-font"><span class="secno">4.4.3</span> <span class="content">Load a Font in a User Agent with a HTTP Cache</span></a>
        </ol>
       <li>
        <a href="#handling-patch-request"><span class="secno">4.5</span> <span class="content">Server: Responding to a PatchRequest</span></a>
@@ -1444,6 +1445,8 @@ can be cached, or null.</p>
       <li data-md>
        <p>The request CORS <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> must be "cors".</p>
       <li data-md>
+       <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode" id="ref-for-concept-request-cache-mode">cache mode</a> should be "no-store".</p>
+      <li data-md>
        <p>The request URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> must be "https".</p>
       <li data-md>
        <p>The request URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path">path</a> is set to the input font URL.</p>
@@ -1454,7 +1457,6 @@ can be cached, or null.</p>
   parameter "request" whose value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then
   base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>.</p>
      </ul>
-     <p>TODO(garretrieger): how is cache mode set?</p>
      <p>Any request and/or url parameters which are not specified here should be set based on
  the user agent’s normal handling for font requests. For example if this font load is
  from a CSS font face, then <a href="https://www.w3.org/TR/css-fonts-4/#font-fetching-requirements"><cite>CSS Fonts 4</cite> § 4.8.2 Font fetching requirements</a> should be followed.</p>
@@ -1589,11 +1591,81 @@ must not resend the request again and should follow <a href="#font-load-failed">
    </ol>
    <p>Regardless of which of the above options are used, the saved client state for this font must be
 discarded.</p>
+   <h4 class="heading settled" data-level="4.4.3" id="load-a-font"><span class="secno">4.4.3. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
+   <p><em>This section is not normative.</em></p>
+   <p>The previous section <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> provides no guidance on how a user agent should handle
+saving client state between invocations of the subset extension algorithm. This section provides an
+algorithm that user agents which implement <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a> may choose to use to save client
+state to the user agents HTTP cache (<a data-link-type="biblio" href="#biblio-rfc7234">[RFC7234]</a>).</p>
+   <p>The inputs to this algorithm:</p>
+   <ul>
+    <li data-md>
+     <p>Font URL: a URL where the font to be extended is located.</p>
+    <li data-md>
+     <p>Desired Subset Definition: a <a href="#font-subset-definition">description</a> of the desired
+minimum font subset.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p>A <a href="#font-subset">Font Subset</a> which covers at minimum the input subset definition.</p>
+   </ul>
+   <p>The algorithm:</p>
+   <ol>
+    <li data-md>
+     <p>Make a HTTP fetch:</p>
+     <ul>
+      <li data-md>
+       <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method③">method</a> is "GET".</p>
+      <li data-md>
+       <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination①">destination</a> must be "font".</p>
+      <li data-md>
+       <p>The request CORS <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode①">mode</a> must be "cors".</p>
+      <li data-md>
+       <p>The request URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme①">scheme</a> must be "https".</p>
+      <li data-md>
+       <p>The request URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path②">path</a> is set to the input font URL.</p>
+      <li data-md>
+       <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode" id="ref-for-concept-request-cache-mode①">cache mode</a> is "only-if-cached".</p>
+     </ul>
+    <li data-md>
+     <p>If the request is successful and the response is "fresh" (<a href="https://httpwg.org/specs/rfc7234.html#expiration.model">Hypertext Transfer Protocol (HTTP/1.1): Caching § expiration.model</a>)
+ then invoke <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> with:</p>
+     <ul>
+      <li data-md>
+       <p>Font url set to the input font url.</p>
+      <li data-md>
+       <p>Client state set to the response.</p>
+      <li data-md>
+       <p>Desired subset definition set to the input subset definition.</p>
+      <li data-md>
+       <p>Fetch algorithm set to <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>.</p>
+     </ul>
+     <p>Once that returns go to step 4.</p>
+    <li data-md>
+     <p>Otherwise:</p>
+     <ul>
+      <li data-md>
+       <p>Font url set to the input font url.</p>
+      <li data-md>
+       <p>Client state set to the response.</p>
+      <li data-md>
+       <p>Desired subset definition set to the input subset definition.</p>
+      <li data-md>
+       <p>Fetch algorithm set to <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>.</p>
+     </ul>
+     <p>Once that returns go to step 4.</p>
+    <li data-md>
+     <p>If the returned cache headers are non-null update the cache entry for the input
+ font url with the returned client state and returned cache headers.</p>
+    <li data-md>
+     <p>Return the font subset contained in the returned client state.</p>
+   </ol>
    <h3 class="heading settled" data-level="4.5" id="handling-patch-request"><span class="secno">4.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
    <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a href="#PatchRequest"><code>PatchRequest</code></a> over HTTPS for a font the server has and that was
 populated according to the requirements in <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> then it must respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status③">status</a> code 200.</span> <span class="conform server" id="conform-magic-number">The first 4 bytes of the response <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body②">body</a> must be set to 0x49, 0x46, 0x54, 0x20 ("IFT " encoded as ASCII) followed by a
 single <a href="#PatchRequest"><code>PatchResponse</code></a> object encoded via CBOR.</span></p>
-   <p>The <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path②">path</a> in the request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a> identifies the specific font that a patch is desired
+   <p>The <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path③">path</a> in the request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a> identifies the specific font that a patch is desired
 for. From the request object the server can produce two codepoint sets:</p>
    <ol>
     <li data-md>
@@ -2348,22 +2420,32 @@ which carry different types of glyph outlines:</p>
     <li><a href="#ref-for-concept-response-body②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-cache-mode">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-cache-mode">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-request-cache-mode①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-destination">
    <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-request-destination①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-method">
    <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">4.4.2. Extending the Font Subset</a> <a href="#ref-for-concept-request-method①">(2)</a> <a href="#ref-for-concept-request-method②">(3)</a>
+    <li><a href="#ref-for-concept-request-method③">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-mode">
    <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-request-mode①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-status">
@@ -2385,7 +2467,8 @@ which carry different types of glyph outlines:</p>
    <ul>
     <li><a href="#ref-for-concept-url-path">4.4.2. Extending the Font Subset</a>
     <li><a href="#ref-for-concept-url-path①">4.4.2.4. Font Load Failed</a>
-    <li><a href="#ref-for-concept-url-path②">4.5. Server: Responding to a PatchRequest</a>
+    <li><a href="#ref-for-concept-url-path②">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-url-path③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-query">
@@ -2398,6 +2481,7 @@ which carry different types of glyph outlines:</p>
    <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-url-scheme①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2411,6 +2495,7 @@ which carry different types of glyph outlines:</p>
     <a data-link-type="biblio">[fetch]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-concept-response-body">body <small>(for response)</small></span>
+     <li><span class="dfn-paneled" id="term-for-concept-request-cache-mode">cache mode</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-destination">destination</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-method">method</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-mode">mode</span>
@@ -2471,6 +2556,8 @@ which carry different types of glyph outlines:</p>
    <dd>Chris Lilley. <a href="https://www.w3.org/TR/PFE-evaluation/"><cite>Progressive Font Enrichment: Evaluation Report</cite></a>. 15 October 2020. Note. URL: <a href="https://www.w3.org/TR/PFE-evaluation/">https://www.w3.org/TR/PFE-evaluation/</a>
    <dt id="biblio-rfc4648">[RFC4648]
    <dd>S. Josefsson. <a href="https://www.rfc-editor.org/rfc/rfc4648"><cite>The Base16, Base32, and Base64 Data Encodings</cite></a>. October 2006. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc4648">https://www.rfc-editor.org/rfc/rfc4648</a>
+   <dt id="biblio-rfc7234">[RFC7234]
+   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://httpwg.org/specs/rfc7234.html"><cite>Hypertext Transfer Protocol (HTTP/1.1): Caching</cite></a>. June 2014. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc7234.html">https://httpwg.org/specs/rfc7234.html</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="ad0eb125afbc254f331d712a78ba0c2b9851dff0" name="document-revision">
+  <meta content="a29c9f11eab9883ac00ee9461cb08790ec7f0a80" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1394,8 +1394,10 @@ unnecessary requests for features which the original font does not contain. Supp
    </ul>
    <h4 class="heading settled" data-level="4.4.2" id="extend-subset"><span class="secno">4.4.2. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
    <p>A client extends its font subset to cover additional codepoints by making requests to a Patch Subset
-server. The request requirements are described here in terms of a fetch according to <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>. If the implementing user agent does not support fetch, then the request
-should be made using an equivalent HTTP request.</p>
+server. For this algorithm the user agent provides a HTTP fetching algorithm, such as <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>.
+The text below describes the inputs to the fetch in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>. If the implementing
+user agent provides a different fetching algorithm, then the request should be made using the
+equivalent inputs to the provided fetch algorithm.</p>
    <ul>
     <li data-md>
      <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a> must be either "GET" or "POST".</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="a29c9f11eab9883ac00ee9461cb08790ec7f0a80" name="document-revision">
+  <meta content="ad41c00db9850c8cdafb299aa56d6b02f135eb0a" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -524,7 +524,11 @@ dfn > a.self-link::before      { content: "#"; }
     <li>
      <a href="#patch-incxfer"><span class="secno">4</span> <span class="content">Patch Based Incremental Transfer</span></a>
      <ol class="toc">
-      <li><a href="#font-subset"><span class="secno">4.1</span> <span class="content">Font Subset</span></a>
+      <li>
+       <a href="#font-subset"><span class="secno">4.1</span> <span class="content">Font Subset</span></a>
+       <ol class="toc">
+        <li><a href="#font-subset-definition"><span class="secno">4.1.1</span> <span class="content">Font Subset Definition</span></a>
+       </ol>
       <li>
        <a href="#data-types"><span class="secno">4.2</span> <span class="content">Data Types</span></a>
        <ol class="toc">
@@ -557,11 +561,14 @@ dfn > a.self-link::before      { content: "#"; }
        <a href="#client"><span class="secno">4.4</span> <span class="content">Client</span></a>
        <ol class="toc">
         <li><a href="#client-state"><span class="secno">4.4.1</span> <span class="content">Client State</span></a>
-        <li><a href="#extend-subset"><span class="secno">4.4.2</span> <span class="content">Extending the Font Subset</span></a>
-        <li><a href="#handling-patch-response"><span class="secno">4.4.3</span> <span class="content">Handling PatchResponse</span></a>
-        <li><a href="#invalid-server-response"><span class="secno">4.4.4</span> <span class="content">Handling Invalid Response from the Server</span></a>
-        <li><a href="#client-side-checksum-mismatch"><span class="secno">4.4.5</span> <span class="content">Client Side Checksum Mismatch</span></a>
-        <li><a href="#font-load-failed"><span class="secno">4.4.6</span> <span class="content">Font Load Failed</span></a>
+        <li>
+         <a href="#extend-subset"><span class="secno">4.4.2</span> <span class="content">Extending the Font Subset</span></a>
+         <ol class="toc">
+          <li><a href="#handling-patch-response"><span class="secno">4.4.2.1</span> <span class="content">Handling PatchResponse</span></a>
+          <li><a href="#invalid-server-response"><span class="secno">4.4.2.2</span> <span class="content">Handling Invalid Response from the Server</span></a>
+          <li><a href="#client-side-checksum-mismatch"><span class="secno">4.4.2.3</span> <span class="content">Client Side Checksum Mismatch</span></a>
+          <li><a href="#font-load-failed"><span class="secno">4.4.2.4</span> <span class="content">Font Load Failed</span></a>
+         </ol>
        </ol>
       <li>
        <a href="#handling-patch-request"><span class="secno">4.5</span> <span class="content">Server: Responding to a PatchRequest</span></a>
@@ -724,6 +731,9 @@ features</a>,</p>
 or <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a> it must render identically to the original font. This includes rendering with
 the use of any optional typographic features that a renderer may choose to use from the original font,
 such as hinting instructions. </span></p>
+   <h4 class="heading settled" data-level="4.1.1" id="font-subset-definition"><span class="secno">4.1.1. </span><span class="content">Font Subset Definition</span><a class="self-link" href="#font-subset-definition"></a></h4>
+   <p>A font subset definition describes the minimum data (codepoints, layout features, variation axis
+space) that a <a href="#font-subset">font subset</a> must possess.</p>
    <h3 class="heading settled" data-level="4.2" id="data-types"><span class="secno">4.2. </span><span class="content">Data Types</span><a class="self-link" href="#data-types"></a></h3>
    <p>This section lists all of the data types that are used to form the request and response messages
 sent between the client and server.</p>
@@ -1393,83 +1403,117 @@ by <a href="#PatchResponse"><code>PatchResponse.original_axis_space</code></a>.<
 unnecessary requests for features which the original font does not contain. Supplied by <a href="#PatchResponse"><code>PatchResponse.original_features</code></a>.</p>
    </ul>
    <h4 class="heading settled" data-level="4.4.2" id="extend-subset"><span class="secno">4.4.2. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
-   <p>A client extends its font subset to cover additional codepoints by making requests to a Patch Subset
-server. For this algorithm the user agent provides a HTTP fetching algorithm, such as <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>.
-The text below describes the inputs to the fetch in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>. If the implementing
-user agent provides a different fetching algorithm, then the request should be made using the
-equivalent inputs to the provided fetch algorithm.</p>
+   <p>This algorithm is used by the client to extends its font subset to cover additional codepoints,
+features, and/or design-variation space. The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a> must be either "GET" or "POST".</p>
+     <p>Font URL: a URL where the font to be extended is located.</p>
     <li data-md>
-     <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a> must be "font".</p>
+     <p>Client State (optional): previously saved <a href="#client-state">client state</a> for the given
+font url, or null.</p>
     <li data-md>
-     <p>The request CORS <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> must be "cors".</p>
+     <p>Desired Subset Definition: a <a href="#font-subset-definition">description</a> of the desired
+minimum font subset.</p>
     <li data-md>
-     <p>The request URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> must be "https".</p>
-    <li data-md>
-     <p>The request URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path">path</a> is used to identify the font specific to be loaded.</p>
-    <li data-md>
-     <p>If <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method①">method</a> is "POST" then, request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-body" id="ref-for-concept-request-body">body</a> must be a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR.</p>
-    <li data-md>
-     <p>Otherwise if <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method②">method</a> is "GET" then, URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-query" id="ref-for-concept-url-query">query</a> must contain a
-parameter "request" whose value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>.</p>
+     <p>Fetch Algorithm: algorithm for fetching HTTP resources, such as <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>. The remainder of this
+section is desribed in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>, but it is allowed to substitute whatever
+HTTP fetching algorithm the user agent supports.</p>
    </ul>
-   <p>Any request and/or url parameters which are not specified here should be set based on
-the user agent’s normal handling for font requests. For example if this font load is
-from a CSS font face, then <a href="https://www.w3.org/TR/css-fonts-4/#font-fetching-requirements"><cite>CSS Fonts 4</cite> § 4.8.2 Font fetching requirements</a> should be followed.</p>
-   <p>The fields of the <a href="#PatchRequest"><code>PatchRequest</code></a> object should be set
-as follows:</p>
+   <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><code>protocol_version</code>: set to 0.</p>
+     <p>Client State: client state that has been updated to contain a font subset which covers at least
+the requested subset definition.</p>
     <li data-md>
-     <p><code>accept_patch_format</code>: set to the list of <a href="#patch-formats">§ 4.8 Patch Formats</a> that this client is
-capable of decoding. Must contain at least one format.</p>
-    <li data-md>
-     <p><code>codepoints_have</code>: set to exactly the set of codepoints that the current font subset
-contains data for. If the current font subset is an empty byte array this field is left unset.
-If the client has a codepoint ordering for this font then this field should not be set.</p>
-    <li data-md>
-     <p><code>codepoints_needed</code>: set to the set of codepoints that the client wants to
-add to its font subset. If the client has a codepoint ordering for this font then this
-field should not be set.</p>
-    <li data-md>
-     <p><code>indices_have</code>: encodes the set of additional codepoints that the current
-font subset contains data for. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
-ordering for this font then this field should not be set.</p>
-    <li data-md>
-     <p><code>indices_needed</code>: encodes the set of codepoints that the client wants to add to its
-font subset. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
-ordering for this font then this field should not be set.</p>
-    <li data-md>
-     <p><code>features_have</code>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a> that the current font subset has data for. If the current font subset is an empty byte array this
-field is left unset. Additionally, if the current font subset has all data for features present in
-the original font then this field can be unset.</p>
-    <li data-md>
-     <p><code>features_needed</code>: set to the list of feature tags that the client wants to add
-to the current font subset. Alternatively, if the client wishes to add all features from
-the original font to it’s subset then this field should be unset.</p>
-    <li data-md>
-     <p><code>axis_space_have</code>: set to the current value of <code>subset_axis_space</code> saved in the state for this font.</p>
-    <li data-md>
-     <p><code>axis_space_needed</code>: set to the intervals of each variable axis in the original
-font that the client wants to add to its font subset. If the client wants an entire axis
-from the original font then that axis should not be listed.</p>
-    <li data-md>
-     <p><code>ordering_checksum</code>: If either of <code>indices_have</code> or <code>indices_needed</code> is set then this must be set to the current value of <code>ordering_checksum</code> saved in the state for this font.</p>
-    <li data-md>
-     <p><code>original_font_checksum</code>:
-Set to saved value for <code>original_font_checksum</code> in the state for this font. If
-there is no saved value leave this field unset.</p>
-    <li data-md>
-     <p><code>base_checksum</code>:
-Set to the checksum of the font subset byte array saved in the state for this font. See: <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</p>
+     <p>Cache headers: HTTP Cache headers <a href="https://httpwg.org/specs/rfc7234.html#header.field.definitions">Hypertext Transfer Protocol (HTTP/1.1): Caching § header.field.definitions</a> describing how client state
+can be cached, or null.</p>
    </ul>
-   <p class="note" role="note"><span>Note:</span> It is allowed for the client to request more codepoints then it strictly needs. For
-example, on slower connections it may be more performant to request extra codepoints if
-that is likely to prevent a future request from needing to be sent.</p>
-   <h4 class="heading settled" data-level="4.4.3" id="handling-patch-response"><span class="secno">4.4.3. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h4>
+   <p>Extend font subset algorithm:</p>
+   <ol>
+    <li data-md>
+     <p>Compare the input font subset definition to the input client state. If the input client state
+ already satisifies the font subset definition. Then return client state, and null for the
+ cache headers.</p>
+    <li data-md>
+     <p>Otherwise make an HTTP request using the input fetching algorithm:</p>
+     <ul>
+      <li data-md>
+       <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a> must be either "GET" or "POST".</p>
+      <li data-md>
+       <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-destination" id="ref-for-concept-request-destination">destination</a> must be "font".</p>
+      <li data-md>
+       <p>The request CORS <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-mode" id="ref-for-concept-request-mode">mode</a> must be "cors".</p>
+      <li data-md>
+       <p>The request URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> must be "https".</p>
+      <li data-md>
+       <p>The request URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path">path</a> is set to the input font URL.</p>
+      <li data-md>
+       <p>If <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method①">method</a> is "POST" then, request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-body" id="ref-for-concept-request-body">body</a> must be a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR.</p>
+      <li data-md>
+       <p>Otherwise if <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method②">method</a> is "GET" then, URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-query" id="ref-for-concept-url-query">query</a> must contain a
+  parameter "request" whose value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then
+  base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>.</p>
+     </ul>
+     <p>TODO(garretrieger): how is cache mode set?</p>
+     <p>Any request and/or url parameters which are not specified here should be set based on
+ the user agent’s normal handling for font requests. For example if this font load is
+ from a CSS font face, then <a href="https://www.w3.org/TR/css-fonts-4/#font-fetching-requirements"><cite>CSS Fonts 4</cite> § 4.8.2 Font fetching requirements</a> should be followed.</p>
+     <p>The fields of the <a href="#PatchRequest"><code>PatchRequest</code></a> object should be set
+ as follows:</p>
+     <ul>
+      <li data-md>
+       <p><code>protocol_version</code>: set to 0.</p>
+      <li data-md>
+       <p><code>accept_patch_format</code>: set to the list of <a href="#patch-formats">§ 4.8 Patch Formats</a> that this client is
+ capable of decoding. Must contain at least one format.</p>
+      <li data-md>
+       <p><code>codepoints_have</code>: set to exactly the set of codepoints that the current font subset
+ contains data for. If the current font subset is an empty byte array this field is left unset.
+ If the client has a codepoint ordering for this font then this field should not be set.</p>
+      <li data-md>
+       <p><code>codepoints_needed</code>: set to the set of codepoints that the client wants to
+ add to its font subset. If the client has a codepoint ordering for this font then this
+ field should not be set.</p>
+      <li data-md>
+       <p><code>indices_have</code>: encodes the set of additional codepoints that the current
+ font subset contains data for. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
+ ordering for this font then this field should not be set.</p>
+      <li data-md>
+       <p><code>indices_needed</code>: encodes the set of codepoints that the client wants to add to its
+ font subset. The codepoint values are transformed to indices by applying <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> to each codepoint value. If the client does not have a codepoint
+ ordering for this font then this field should not be set.</p>
+      <li data-md>
+       <p><code>features_have</code>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"> opentype layout feature tags</a> that the current font subset has data for. If the current
+ font subset is an empty byte array this
+ field is left unset. Additionally, if the current font subset has all data for features
+ present in the original font then this field can be unset.</p>
+      <li data-md>
+       <p><code>features_needed</code>: set to the list of feature tags that the client wants to add
+ to the current font subset. Alternatively, if the client wishes to add all features from
+ the original font to it’s subset then this field should be unset.</p>
+      <li data-md>
+       <p><code>axis_space_have</code>: set to the current value of <code>subset_axis_space</code> saved in the state for this font.</p>
+      <li data-md>
+       <p><code>axis_space_needed</code>: set to the intervals of each variable axis in the original
+ font that the client wants to add to its font subset. If the client wants an entire axis
+ from the original font then that axis should not be listed.</p>
+      <li data-md>
+       <p><code>ordering_checksum</code>: If either of <code>indices_have</code> or <code>indices_needed</code> is set then this must be set to the current value of <code>ordering_checksum</code> saved in the state for this font.</p>
+      <li data-md>
+       <p><code>original_font_checksum</code>:
+ Set to saved value for <code>original_font_checksum</code> in the state for this font. If
+ there is no saved value leave this field unset.</p>
+      <li data-md>
+       <p><code>base_checksum</code>:
+ Set to the checksum of the font subset byte array saved in the state for this font. See: <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</p>
+     </ul>
+     <p class="note" role="note"><span>Note:</span> It is allowed for the client to request more codepoints then it strictly needs. For
+ example, on slower connections it may be more performant to request extra codepoints if
+ that is likely to prevent a future request from needing to be sent.</p>
+    <li data-md>
+     <p>Goto <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a>.</p>
+   </ol>
+   <h5 class="heading settled" data-level="4.4.2.1" id="handling-patch-response"><span class="secno">4.4.2.1. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h5>
    <p>If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a> it will respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> code 200 and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body">body</a> of the response will
 be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via CBOR. The client
 should interpret and process the fields of the object as follows:</p>
@@ -1477,57 +1521,61 @@ should interpret and process the fields of the object as follows:</p>
     <li data-md>
      <p>If field <code>replacement</code> is set then: the byte array in this field is a binary patch
  in the format specified by <code>patch_format</code>. Apply the binary patch to a base which
- is an empty byte array. Replace the saved font subset with the result of the patch application.</p>
+ is an empty byte array. Replace the font subset in the input client state with the result of the
+ patch application.</p>
     <li data-md>
      <p>If field <code>patch</code> is set then:  the byte array in this field is a binary patch
-in the format specified by <code>patch_format</code>. Apply the binary patch to the saved font
-subset. Replace the saved font subset with the result of the patch application.</p>
+in the format specified by <code>patch_format</code>. Apply the binary patch to the font
+subset from the input client state. Replace the font subset in the input client state with the
+result of the patch application.</p>
     <li data-md>
      <p>If either <code>replacement</code> or <code>patch</code> is set then: <a href="#computing-checksums">compute the checksum</a> of the font subset produced by the patch
-application in steps 1 or 2. If the computed checksum is not equal to <code>patched_checksum</code> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 4.4.5 Client Side Checksum Mismatch</a>. Otherwise
-update the saved original font checksum with the value in <code>original_font_checksum</code>.</p>
+application in steps 1 or 2. If the computed checksum is not equal to <code>patched_checksum</code> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 4.4.2.3 Client Side Checksum Mismatch</a>. Otherwise
+update the original font checksum in the input client state with the value in <code>original_font_checksum</code>.</p>
     <li data-md>
      <p>If fields <code>codepoint_ordering</code> and <code>ordering_checksum</code> are set then update
-the saved codepoint ordering and checksum with the new values specified by these two fields.
-If neither <code>replacement</code> nor <code>patch</code> are set, then the client should
-resend the request that triggered this response but use the new codepoint ordering provided in
-this response.</p>
+the codepoint ordering and checksum in the input client state with the new values specified by
+these two fields. If neither <code>replacement</code> nor <code>patch</code> are set, then the
+client should resend the request that triggered this response but use the new codepoint ordering
+provided in this response.</p>
     <li data-md>
      <p>If <code>original_features</code> is set and the client has opted to save them then replace the
-original feature list in the client’s saved state with the value from the response.</p>
+original feature in the input client state with the value from the response.</p>
     <li data-md>
-     <p>If <code>original_axis_space</code> is set then update the saved original axis space with the value
-specified in this field.</p>
+     <p>If <code>original_axis_space</code> is set then update the original axis space in the input client
+state with the value specified in this field.</p>
     <li data-md>
-     <p>If <code>subset_axis_space</code> is set then update the saved subset axis space with the value
-specified in this field.</p>
+     <p>If <code>subset_axis_space</code> is set then update the subset axis space in the input client
+state with the value specified in this field.</p>
    </ol>
-   <h4 class="heading settled" data-level="4.4.4" id="invalid-server-response"><span class="secno">4.4.4. </span><span class="content">Handling Invalid Response from the Server</span><a class="self-link" href="#invalid-server-response"></a></h4>
+   <p>After processing the response, return the updated input client state and any cache headers that were
+set on the response.</p>
+   <h5 class="heading settled" data-level="4.4.2.2" id="invalid-server-response"><span class="secno">4.4.2.2. </span><span class="content">Handling Invalid Response from the Server</span><a class="self-link" href="#invalid-server-response"></a></h5>
    <p>If the response a client receives from the server has a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> code other than 200:</p>
    <ul>
     <li data-md>
-     <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a>.</p>
+     <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a>.</p>
     <li data-md>
-     <p>All other statuses, the font subset extension has failed. Follow <a href="#font-load-failed">§ 4.4.6 Font Load Failed</a>.</p>
+     <p>All other statuses, the font subset extension has failed. Follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a>.</p>
    </ul>
    <p>If the response the client receives has a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> code of 200, but the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a> is malformed. That is, it is missing the magic number, not decodable with CBOR, or the <a href="#PatchResponse"><code>PatchResponse</code></a> is not well formed:</p>
    <ul>
     <li data-md>
-     <p>This is an error. Follow <a href="#font-load-failed">§ 4.4.6 Font Load Failed</a>.</p>
+     <p>This is an error. Follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a>.</p>
    </ul>
-   <h4 class="heading settled" data-level="4.4.5" id="client-side-checksum-mismatch"><span class="secno">4.4.5. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h4>
+   <h5 class="heading settled" data-level="4.4.2.3" id="client-side-checksum-mismatch"><span class="secno">4.4.2.3. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h5>
    <p>If the checksum of the font subset computed by the client does not match the <code>patched_checksum</code> in the server’s response then the client should:</p>
    <ol>
     <li data-md>
-     <p>Discard all currently saved state for this font.</p>
+     <p>Discard the input client state for this font.</p>
     <li data-md>
      <p><a href="#extend-subset">Resend the request</a>. Set the <code>codepoints_needed</code> field
 to the union of the codepoints in the discarded font subset and the set of code points
 that the previous request was trying to add.</p>
      <p>If the resent request also results in a checksum mismatch then this is an error. The client
-must not resend the request again and should follow <a href="#font-load-failed">§ 4.4.6 Font Load Failed</a></p>
+must not resend the request again and should follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a></p>
    </ol>
-   <h4 class="heading settled" data-level="4.4.6" id="font-load-failed"><span class="secno">4.4.6. </span><span class="content">Font Load Failed</span><a class="self-link" href="#font-load-failed"></a></h4>
+   <h5 class="heading settled" data-level="4.4.2.4" id="font-load-failed"><span class="secno">4.4.2.4. </span><span class="content">Font Load Failed</span><a class="self-link" href="#font-load-failed"></a></h5>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
    <ol>
     <li data-md>
@@ -1577,9 +1625,9 @@ for. From the request object the server can produce two codepoint sets:</p>
    </ol>
    <p><span class="conform server" id="conform-bad-reordering"> If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
-will recognize via the process described in <a href="#handling-patch-response">§ 4.4.3 Handling PatchResponse</a> and not include any patch.
+will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a> and not include any patch.
 That is the <code>patch</code> and <code>replacement</code> fields must not be set. </span></p>
-   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.3 Handling PatchResponse</a> to a font subset with checksum <code>base_checksum</code> it must result
+   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a> to a font subset with checksum <code>base_checksum</code> it must result
 in an extended font subset: </span></p>
    <ul>
     <li data-md>
@@ -2295,8 +2343,8 @@ which carry different types of glyph outlines:</p>
   <aside class="dfn-panel" data-for="term-for-concept-response-body">
    <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-body">4.4.3. Handling PatchResponse</a>
-    <li><a href="#ref-for-concept-response-body①">4.4.4. Handling Invalid Response from the Server</a>
+    <li><a href="#ref-for-concept-response-body">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-concept-response-body①">4.4.2.2. Handling Invalid Response from the Server</a>
     <li><a href="#ref-for-concept-response-body②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2321,8 +2369,8 @@ which carry different types of glyph outlines:</p>
   <aside class="dfn-panel" data-for="term-for-concept-response-status">
    <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-status">4.4.3. Handling PatchResponse</a>
-    <li><a href="#ref-for-concept-response-status①">4.4.4. Handling Invalid Response from the Server</a> <a href="#ref-for-concept-response-status②">(2)</a>
+    <li><a href="#ref-for-concept-response-status">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-concept-response-status①">4.4.2.2. Handling Invalid Response from the Server</a> <a href="#ref-for-concept-response-status②">(2)</a>
     <li><a href="#ref-for-concept-response-status③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-response-status④">(2)</a> <a href="#ref-for-concept-response-status⑤">(3)</a>
    </ul>
   </aside>
@@ -2336,7 +2384,7 @@ which carry different types of glyph outlines:</p>
    <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-url-path①">4.4.6. Font Load Failed</a>
+    <li><a href="#ref-for-concept-url-path①">4.4.2.4. Font Load Failed</a>
     <li><a href="#ref-for-concept-url-path②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="88ea8bd3a3e14b743a137436c7fdf8031bfed5bb" name="document-revision">
+  <meta content="fa16e53db0d9c263fa360e16c46bda1b328ee558" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1542,7 +1542,7 @@ client should resend the request that triggered this response but use the new co
 provided in this response.</p>
     <li data-md>
      <p>If <code>original_features</code> is set and the client has opted to save them then replace the
-original feature in the input client state with the value from the response.</p>
+original feature list in the input client state with the value from the response.</p>
     <li data-md>
      <p>If <code>original_axis_space</code> is set then update the original axis space in the input client
 state with the value specified in this field.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="b8da6392edf5de815564e605f08022cc55b50d3b" name="document-revision">
+  <meta content="9653eb3f13b1f4fec5b3ed97b9363d7ff2432de3" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1648,7 +1648,7 @@ minimum font subset.</p>
       <li data-md>
        <p>Font url set to the input font url.</p>
       <li data-md>
-       <p>Client state set to the response.</p>
+       <p>Client state set to null.</p>
       <li data-md>
        <p>Desired subset definition set to the input subset definition.</p>
       <li data-md>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="71ea7593fed40c7a06a5dcbd0f5170f0cc89738a" name="document-revision">
+  <meta content="88ea8bd3a3e14b743a137436c7fdf8031bfed5bb" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1595,7 +1595,7 @@ discarded.</p>
    <p>The previous section <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> provides no guidance on how a user agent should handle
 saving client state between invocations of the subset extension algorithm. This section provides an
 algorithm that user agents which implement <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a> should use to save client state to the user
-agents HTTP cache (<a data-link-type="biblio" href="#biblio-rfc7234">[RFC7234]</a>).</p>
+agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc7234">[RFC7234]</a>).</p>
    <p>The inputs to this algorithm:</p>
    <ul>
     <li data-md>


### PR DESCRIPTION
This PR does a couple of things:

- Reword the extend a font subset section to have explicit inputs and outputs. Adds the HTTP fetch algorithm as an input (see: #63, https://github.com/w3c/IFT/issues/69#issuecomment-995236057)
- Adds new section "Load a Font in a User Agent with a HTTP Cache" which provides a suggested algorithm for how to interact with and save client state into the HTTP cache. Addresses #72


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/98.html" title="Last updated on Jun 13, 2022, 9:34 PM UTC (3791bd3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/98/a29c9f1...3791bd3.html" title="Last updated on Jun 13, 2022, 9:34 PM UTC (3791bd3)">Diff</a>