### PR TITLE
Make HTTP RFC references more specific.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -162,7 +162,7 @@ IFT Method Selection {#method-selection}
 When a page has indicated that a particular font should utilize IFT technology, the browser must determine which method to use. Different browsers may support different IFT methods, and different servers may support different IFT methods, so a negotation occurs as such:
 
 1. The browser makes the first request to the server. If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant [=query parameter=]. If the client prefers the range-request method, it does not send the query parameter.
-2. If the server receives the patch-subset query parameter and wishes to honor it, the server must reply with a valid <a href="#PatchResponse">patch subset response</a> which includes the <a href="#handling-patch-response">patch-subset magic number</a>. Otherwise, the server must reply with the [[!RFC9110]] <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a> header, if it supports HTTP Range Requests.
+2. If the server receives the patch-subset query parameter and wishes to honor it, the server must reply with a valid <a href="#PatchResponse">patch subset response</a> which includes the <a href="#handling-patch-response">patch-subset magic number</a>. Otherwise, the server must reply with the [[RFC9110#range.requests]] <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a> header, if it supports HTTP Range Requests.
 3. If the client receives the patch-subset magic number, it commences using the patch-subset method. Otherwise, if the client receives the <code>Accept-Ranges: bytes</code> header, it commences using the range-request method. Otherwise, the whole font file is downloaded, and the current non-incremental loading behavior is used.
 
 IFT Method Fallback {#fallback}
@@ -879,14 +879,14 @@ The algorithm outputs:
 * Client State: client state that has been updated to contain a font subset which covers at least
     the requested subset definition.
 
-* Cache headers: HTTP Cache headers [[rfc9111#name-cache-control]] describing how client state
+* Cache fields: HTTP cache fields [[rfc9111#name-field-definitions]] describing how client state
     can be cached, or null.
 
 Extend font subset algorithm:
 
 1. Compare the input font subset definition to the input client state. If the input client state
      already satisifies the font subset definition. Then return client state, and null for the
-     cache headers.
+     cache fields.
 
 2. Otherwise make an HTTP request using the input fetching algorithm:
 
@@ -1131,8 +1131,8 @@ The algorithm:
 
      Once that returns go to step 4.
 
-4.  If the returned cache headers are non-null update the cache entry for the input
-     font url with the returned client state and returned cache headers.
+4.  If the returned cache fields are non-null update the cache entry for the input
+     font url with the returned client state and returned cache fields.
 
 5.  Return the font subset contained in the returned client state.
 
@@ -1279,7 +1279,7 @@ Possible error responses:
 
 A patch subset support server must also support incremental transfer via [[#range-request-incxfer]].
 To support range request incremental tranfser the patch subset server must support HTTP range requests
-[[!RFC9110]] against the font files it provides via patch subset.
+([[RFC9110#range.requests]]) against the font files it provides via patch subset.
 
 
 Computing Checksums {#computing-checksums}
@@ -1456,7 +1456,7 @@ Note: There are no <code>MUST</code>-level requirements on the organization of a
 
 ### Compression ### {#font-organization-compression}
 
-Servers supporting the range-request IFT method should support compression via the [[!RFC9110]] <code>Content-Encoding</code> header or the [[!RFC9112]] <code>Transfer-Encoding</code> header, rather than having the font file itself be statically compressed.
+Servers supporting the range-request IFT method should support compression via the <code>Content-Encoding</code> header ([[RFC9110#name-content-encoding]]) or the <code>Transfer-Encoding</code> header ([[RFC9112#section-6.1]]), rather than having the font file itself be statically compressed.
 
 A [=range-request optimized font=] file (the file itself) should not use any kind of compression other than [[!RFC7932]] (commonly referred to as "Brotli") compression.
 
@@ -1543,13 +1543,13 @@ Note: The first request does not have to be a range request. If the browser expe
 
 Once all the data before the [=range-request threshold=] has been loaded by the browser, the browser may either close this connection to the server, or it may choose to leave the connection open and let the font data continue loading in the background.
 
-A browser may choose to add a [[!RFC9110]] <code>Range</code> header to the initial request during the IFT method selection if it has reason to believe the range it requests will be large enough and it prefers to not close this connection to the server.
+A browser may choose to add a <code>Range</code> header ([[RFC9110#name-range]]) to the initial request during the IFT method selection if it has reason to believe the range it requests will be large enough and it prefers to not close this connection to the server.
 
 Note: Different browsers may choose different [=range-request thresholds=]. Some browsers may treat this threshold as occuring at the end of the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">sfnt tableDirectory</a>. Other browsers may treat this threshold as occurring just before any outline data, provided the outline data appears at the end of the font. Other browsers may place this threshold at the very beginning of the file, thereby treating the whole file as able to be downloaded with range-requests.
 
 ### Subsequent Requests ### {#browser-behaviors-subsequent-requests}
 
-After all the data before the [=range-request threshold=] has been loaded by the browser, the browser will determine which additional byte ranges in the file are necessary to load. It will then issue [[!RFC9110]] HTTP Range Requests for at least those ranges.
+After all the data before the [=range-request threshold=] has been loaded by the browser, the browser will determine which additional byte ranges in the file are necessary to load. It will then issue HTTP Range Requests ([[RFC9110#range.requests]]) for at least those ranges.
 
 Note: Browsers are encouraged to coalesce range requests for nearby areas of the file, to minimize the amount of range-request overhead required. Browsers are encouraged to inform these coalescing decisions from network configuration parameters and bandwidth / latency observations.
 
@@ -1560,9 +1560,12 @@ Note: Another valid alternative is to treat the entire font as residing on an as
 Server Behaviors {#server-behaviors}
 ------------------------------------
 
-Servers supporting the range-request IFT method must support [[!RFC9110]] range requests.
+Servers supporting the range-request IFT method must support range requests ([[RFC9110#range.requests]]).
 
-Servers supporting the range-request IFT method should support compression via the [[!RFC9110]] <code>Content-Encoding</code> header or the [[!RFC9112]] <code>Transfer-Encoding</code> header, rather than having the font file itself be statically compressed.
+Servers supporting the range-request IFT method should support compression via the
+<code>Content-Encoding</code> ([[RFC9110#name-content-encoding]]) header or the
+<code>Transfer-Encoding</code> header ([[RFC9112#section-6.1]]), rather than having the font file
+itself be statically compressed.
 
 <h2 class=no-num id=priv>Privacy Considerations</h2>
 

--- a/Overview.html
+++ b/Overview.html
@@ -4,9 +4,9 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Incremental Font Transfer</title>
   <meta content="WD" name="w3c-status">
-  <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
+  <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="16c72f442b5ce6c8aaf534b304e86ea5938f7de7" name="document-revision">
+  <meta content="497c2d45af635e32687790511475b7abb4962a8b" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -245,7 +245,7 @@ dfn > a.self-link::before      { content: "#"; }
     </div>
    </details>
    <div data-fill-with="warning"></div>
-   <p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2022 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software">permissive document license</a> rules apply.</p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2022 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -269,11 +269,11 @@ dfn > a.self-link::before      { content: "#"; }
    <p> Publication as a Working Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. This is a draft document and may be updated, replaced or
   obsoleted by other documents at any time. It is inappropriate to cite this
   document as other than work in progress. </p>
-   <p>This document was produced by a group operating under
-  the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+   <p> This document was produced by groups operating under
+  the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
   W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
-  An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
+  An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
    <p> This document is governed by the <a href="https://www.w3.org/2021/Process-20211102/" id="w3c_process_revision">2 November 2021 W3C Process Document</a>. </p>
    <p></p>
   </div>
@@ -390,11 +390,10 @@ dfn > a.self-link::before      { content: "#"; }
     <li><a href="#suggested-glyph-character-ordering"><span class="secno"></span> <span class="content"> Appendix A: Suggested glyph/character ordering</span></a>
     <li><a href="#feature-tag-list"><span class="secno"></span> <span class="content"> Appendix B: Default Feature Tags and Encoding IDs</span></a>
     <li>
-     <a href="#conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
+     <a href="#w3c-conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
      <ol class="toc">
-      <li><a href="#conventions"><span class="secno"></span> <span class="content">Document conventions</span></a>
-      <li><a href="#conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
-      <li><a href="#conformance-classes"><span class="secno"></span> <span class="content">Conformance Classes</span></a>
+      <li><a href="#w3c-conventions"><span class="secno"></span> <span class="content">Document conventions</span></a>
+      <li><a href="#w3c-conformant-algorithms"><span class="secno"></span> <span class="content">Conformant Algorithms</span></a>
      </ol>
     <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
@@ -445,7 +444,7 @@ for many uses cases while still providing material improvments to loading perfor
    <p>The collection of IFT technologies utilizes a single shared opt-in mechanism. Each method does not use its own opt-in mechanism; instead, the webpage opts into the IFT technologies as a whole, and the browser and server negotiate to decide which specific method will be employed.</p>
    <p>The opt-in mechanism is the <code>incremental</code> keyword inside the <a class="css" data-link-type="maybe" href="https://www.w3.org/TR/css-fonts-5/#at-font-face-rule" id="ref-for-at-font-face-rule">@font-face</a> block. Websites specify this keyword inside their <code>@font-face</code> block, and the browser is then responsible for using IFT technologies, and for negotiating with the server to determine which specific IFT method to use.</p>
    <div class="example" id="example-a9a7e9cd">
-    <a class="self-link" href="#example-a9a7e9cd"></a> The use of the <code>incremental</code> keyword in this CSS rule indicates to the browser they should use IFT.
+    <a class="self-link" href="#example-a9a7e9cd"></a> The use of the <code>incremental</code> keyword in this CSS rule indicates to the browser they should use IFT. 
 <pre>@font-face {
     font-family: "MyCoolWebFont";
     src: url("MyCoolWebFont.otf") tech(incremental);
@@ -460,7 +459,7 @@ for many uses cases while still providing material improvments to loading perfor
     <li data-md>
      <p>The browser makes the first request to the server. If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant <a data-link-type="dfn" href="#query-parameter" id="ref-for-query-parameter">query parameter</a>. If the client prefers the range-request method, it does not send the query parameter.</p>
     <li data-md>
-     <p>If the server receives the patch-subset query parameter and wishes to honor it, the server must reply with a valid <a href="#PatchResponse">patch subset response</a> which includes the <a href="#handling-patch-response">patch-subset magic number</a>. Otherwise, the server must reply with the <a data-link-type="biblio" href="#biblio-rfc9110">[RFC9110]</a> <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a> header, if it supports HTTP Range Requests.</p>
+     <p>If the server receives the patch-subset query parameter and wishes to honor it, the server must reply with a valid <a href="#PatchResponse">patch subset response</a> which includes the <a href="#handling-patch-response">patch-subset magic number</a>. Otherwise, the server must reply with the <a href="https://www.rfc-editor.org/rfc/rfc9110#range.requests">HTTP Semantics § range.requests</a> <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a> header, if it supports HTTP Range Requests.</p>
     <li data-md>
      <p>If the client receives the patch-subset magic number, it commences using the patch-subset method. Otherwise, if the client receives the <code>Accept-Ranges: bytes</code> header, it commences using the range-request method. Otherwise, the whole font file is downloaded, and the current non-incremental loading behavior is used.</p>
    </ol>
@@ -471,23 +470,23 @@ for many uses cases while still providing material improvments to loading perfor
     <thead>
      <tr>
       <th>
-      <th>Client prefers range-request method
-      <th>Client prefers patch-subset method
+      <th>Client prefers range-request method 
+      <th>Client prefers patch-subset method 
     <tbody>
      <tr>
-      <th>Server supports both range-request method and patch-subset method
+      <th>Server supports both range-request method and patch-subset method 
       <td>
-       Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Because all patch-subset servers must support the range-request method, the server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method.
+       Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Because all patch-subset servers must support the range-request method, the server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method. 
        <p class="issue" id="issue-2bae6363"><a class="self-link" href="#issue-2bae6363"></a> <a href="https://github.com/w3c/IFT/issues/56">Server-recommended IFT Method selection</a></p>
-      <td>Client makes initial request with query parameter. Server replies with the patch-subset magic number, and client/server commence using patch-subset method.
+      <td>Client makes initial request with query parameter. Server replies with the patch-subset magic number, and client/server commence using patch-subset method. 
      <tr>
-      <th>Server supports only range-request method
-      <td>Same as above.
-      <td>Client makes initial request with query parameter. Server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method.
+      <th>Server supports only range-request method 
+      <td>Same as above. 
+      <td>Client makes initial request with query parameter. Server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method. 
      <tr>
-      <th>Server supports neither
-      <td>Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Server replies without <code>Accept-Ranges</code> header, and sends the full font file to the client from beginning to end.
-      <td>Client makes initial request to server with query parameter. Server does not reply with the patch-subset magic number, and sends the full font file to the client from beginning to end.
+      <th>Server supports neither 
+      <td>Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Server replies without <code>Accept-Ranges</code> header, and sends the full font file to the client from beginning to end. 
+      <td>Client makes initial request to server with query parameter. Server does not reply with the patch-subset magic number, and sends the full font file to the client from beginning to end. 
    </table>
    <h2 class="heading settled" data-level="4" id="patch-incxfer"><span class="secno">4. </span><span class="content">Patch Based Incremental Transfer</span><a class="self-link" href="#patch-incxfer"></a></h2>
    <h3 class="heading settled" data-level="4.1" id="font-subset"><span class="secno">4.1. </span><span class="content">Font Subset</span><a class="self-link" href="#font-subset"></a></h3>
@@ -619,7 +618,7 @@ next multiple of 8.
 The bit with the smallest index in the bit string is the least
 significant bit in the byte and the bit with the largest index is the most significant bit.</p>
    <div class="example" id="example-ad7a28d1">
-    <a class="self-link" href="#example-ad7a28d1"></a> The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the bit string:
+    <a class="self-link" href="#example-ad7a28d1"></a> The set {2, 33, 323} in a tree with a branching factor of 8 is encoded as the bit string: 
 <pre>BitString:
 |- header |- lvl 0 |---- level 1 ----|------- level 2 -----------|
 |         |   n0   |   n1       n2   |   n3       n4       n5    |
@@ -676,7 +675,7 @@ Which then becomes the ByteString:
     </ul>
    </div>
    <div class="example" id="example-bc5ac7b1">
-    <a class="self-link" href="#example-bc5ac7b1"></a> The set {} in a tree with a branching factor of 4 is encoded as the bit string:
+    <a class="self-link" href="#example-bc5ac7b1"></a> The set {} in a tree with a branching factor of 4 is encoded as the bit string: 
 <pre>BitString:
 |- header- |
 |          |
@@ -702,7 +701,7 @@ Which then becomes the ByteString:
     <p>Empty sets have no nodes, so no bytes beyond the header need to be appended.</p>
    </div>
    <div class="example" id="example-bcd5e3df">
-    <a class="self-link" href="#example-bcd5e3df"></a> The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as:
+    <a class="self-link" href="#example-bcd5e3df"></a> The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as: 
 <pre>BitString:
 |- header | l0 |- lvl 1 -| l2  |
 |         | n0 | n1 | n2 | n3  |
@@ -766,7 +765,7 @@ of N integers D<sub>i<sub>0..n-1</sub></sub> as follows:</p>
    <p>This has the effect of reducing the magnitude of the values, which reduces the number
 of bytes required in the UIntBase128 encoding, below.</p>
    <div class="example" id="example-a8b975f3">
-    <a class="self-link" href="#example-a8b975f3"></a>
+    <a class="self-link" href="#example-a8b975f3"></a> 
 <pre>// Note: unsorted
 int_list = [23, 43, 12, 3, 67, 68, 69, 0]
 delta_list = [23, 20, -31, -9, 64, 1, 1, -69]
@@ -791,7 +790,7 @@ decode(n) {
     return n / 2
 </pre>
    <div class="example" id="example-16a15e38">
-    <a class="self-link" href="#example-16a15e38"></a>
+    <a class="self-link" href="#example-16a15e38"></a> 
     <table>
      <tbody>
       <tr>
@@ -827,7 +826,7 @@ decode(n) {
     </table>
    </div>
    <div class="example" id="example-d75ff9a8">
-    <a class="self-link" href="#example-d75ff9a8"></a>
+    <a class="self-link" href="#example-d75ff9a8"></a> 
 <pre>delta_list = [23, 20, -31, -9, 64, 1, 1, -69]
 zig_zag_encoded_list = [46, 40, 61, 17, 128, 2, 2, 137]
 </pre>
@@ -874,7 +873,7 @@ exceeds 2<sup>32</sup>-1.</span> Pseudo-code:</p>
 }
 </pre>
    <div class="example" id="example-ca5da7f7">
-    <a class="self-link" href="#example-ca5da7f7"></a>
+    <a class="self-link" href="#example-ca5da7f7"></a> 
 <pre>Value       Output Bytes
 0           00000000
 1           00000001
@@ -890,7 +889,7 @@ exceeds 2<sup>32</sup>-1.</span> Pseudo-code:</p>
 </pre>
    </div>
    <div class="example" id="example-0f812e73">
-    <a class="self-link" href="#example-0f812e73"></a>
+    <a class="self-link" href="#example-0f812e73"></a> 
 <pre>zig_zag_encoded_list = [46, 40, 61, 17, 128, 2, 2, 137]
 bytes = [2E 28 3D 11 81 00 02 02 81 09]
          └┘ └┘ └┘ └┘ └───┘ └┘ └┘ └───┘
@@ -918,7 +917,7 @@ i = 0..n-1.</p>
    <p>L is a sorted list of integers, so <a href="#sortedintegerlist">§ 4.2.6 SortedIntegerList</a> is used to encode it as a
 ByteString.</p>
    <div class="example" id="example-228f592b">
-    <a class="self-link" href="#example-228f592b"></a>
+    <a class="self-link" href="#example-228f592b"></a> 
 <pre>range_list = [3, 10], [13, 268]
 int_list = [3, 10, 13, 268]
 delta_list = [3, 7, 3, 255]
@@ -1211,7 +1210,7 @@ HTTP fetching algorithm the user agent supports.</p>
      <p>Client State: client state that has been updated to contain a font subset which covers at least
 the requested subset definition.</p>
     <li data-md>
-     <p>Cache headers: HTTP Cache headers <a href="https://www.rfc-editor.org/rfc/rfc9111#name-cache-control">HTTP Caching § name-cache-control</a> describing how client state
+     <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions">HTTP Caching § name-field-definitions</a> describing how client state
 can be cached, or null.</p>
    </ul>
    <p>Extend font subset algorithm:</p>
@@ -1219,7 +1218,7 @@ can be cached, or null.</p>
     <li data-md>
      <p>Compare the input font subset definition to the input client state. If the input client state
  already satisifies the font subset definition. Then return client state, and null for the
- cache headers.</p>
+ cache fields.</p>
     <li data-md>
      <p>Otherwise make an HTTP request using the input fetching algorithm:</p>
      <ul>
@@ -1444,8 +1443,8 @@ minimum font subset.</p>
      </ul>
      <p>Once that returns go to step 4.</p>
     <li data-md>
-     <p>If the returned cache headers are non-null update the cache entry for the input
- font url with the returned client state and returned cache headers.</p>
+     <p>If the returned cache fields are non-null update the cache entry for the input
+ font url with the returned client state and returned cache fields.</p>
     <li data-md>
      <p>Return the font subset contained in the returned client state.</p>
    </ol>
@@ -1556,7 +1555,8 @@ same client to the same server task.</p>
    </ul>
    <h4 class="heading settled" data-level="4.5.1" id="range-request-support"><span class="secno">4.5.1. </span><span class="content">Range Request Support</span><a class="self-link" href="#range-request-support"></a></h4>
    <p>A patch subset support server must also support incremental transfer via <a href="#range-request-incxfer">§ 5 Range Request Incremental Transfer</a>.
-To support range request incremental tranfser the patch subset server must support HTTP range requests <a data-link-type="biblio" href="#biblio-rfc9110">[RFC9110]</a> against the font files it provides via patch subset.</p>
+To support range request incremental tranfser the patch subset server must support HTTP range requests
+(<a href="https://www.rfc-editor.org/rfc/rfc9110#range.requests">HTTP Semantics § range.requests</a>) against the font files it provides via patch subset.</p>
    <h3 class="heading settled" data-level="4.6" id="computing-checksums"><span class="secno">4.6. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h3>
    <p>64 bit checksums of byte strings are computed using the <a data-link-type="biblio" href="#biblio-fast-hash">[fast-hash]</a> algorithm. A python like pseudo
 code version of the algorithm is presented below:</p>
@@ -1589,7 +1589,7 @@ fast_hash(byte[] data):
 in little endian order.</p>
    <p class="note" role="note"><span>Note:</span> a C implementation of fast hash can be found here: <a data-link-type="biblio" href="#biblio-fast-hash">[fast-hash]</a></p>
    <div class="example" id="example-e69b2b2f">
-    <a class="self-link" href="#example-e69b2b2f"></a>
+    <a class="self-link" href="#example-e69b2b2f"></a> 
     <table>
      <tbody>
       <tr>
@@ -1633,7 +1633,7 @@ fast_hash_ordering(uint64[] ordering):
    <p>To ensure checksums are consistent across all platforms, all integers during the computation are
 in little endian order.</p>
    <div class="example" id="example-6c33d2ed">
-    <a class="self-link" href="#example-6c33d2ed"></a>
+    <a class="self-link" href="#example-6c33d2ed"></a> 
     <table>
      <tbody>
       <tr>
@@ -1656,7 +1656,7 @@ and a target file:</p>
      <tr>
       <td>VCDIFF
       <td>0
-      <td> Uses VCDIFF format <a data-link-type="biblio" href="#biblio-rfc3284">[RFC3284]</a> to produce the patch. <span class="conform server client" id="conform-vcdiff"> All client and server implementations must support this format. </span>
+      <td> Uses VCDIFF format <a data-link-type="biblio" href="#biblio-rfc3284">[RFC3284]</a> to produce the patch. <span class="conform server client" id="conform-vcdiff"> All client and server implementations must support this format. </span> 
      <tr>
       <td>Brotli Shared Dictionary
       <td>1
@@ -1680,7 +1680,7 @@ and a target file:</p>
    <div class="example" id="example-85584618"><a class="self-link" href="#example-85584618"></a> The result of optimizing an OpenType font for the range-request IFT method is still a valid OpenType font. The resulting file may be larger (by byte count) than it was before optimizing it, but fewer of those bytes should be necessary for a client to download in order to render a target text. </div>
    <p class="note" role="note"><span>Note:</span> There are no <code>MUST</code>-level requirements on the organization of a <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font">range-request optimized font</a>. Any arbitrary font file may be considered to be a <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font①">range-request optimized font</a>. However, additional optimizations should increase the performance of loading in a browser via the range-request IFT method. Font creators are encouraged to enact as many of the optimizations listed in this section as are reasonable for the fonts they create.</p>
    <h4 class="heading settled" data-level="5.2.3" id="font-organization-compression"><span class="secno">5.2.3. </span><span class="content">Compression</span><a class="self-link" href="#font-organization-compression"></a></h4>
-   <p>Servers supporting the range-request IFT method should support compression via the <a data-link-type="biblio" href="#biblio-rfc9110">[RFC9110]</a> <code>Content-Encoding</code> header or the <a data-link-type="biblio" href="#biblio-rfc9112">[RFC9112]</a> <code>Transfer-Encoding</code> header, rather than having the font file itself be statically compressed.</p>
+   <p>Servers supporting the range-request IFT method should support compression via the <code>Content-Encoding</code> header (<a href="https://www.rfc-editor.org/rfc/rfc9110#name-content-encoding">HTTP Semantics § name-content-encoding</a>) or the <code>Transfer-Encoding</code> header (<a href="https://www.rfc-editor.org/rfc/rfc9112#section-6.1">HTTP/1.1 § section-6.1</a>), rather than having the font file itself be statically compressed.</p>
    <p>A <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font②">range-request optimized font</a> file (the file itself) should not use any kind of compression other than <a data-link-type="biblio" href="#biblio-rfc7932">[RFC7932]</a> (commonly referred to as "Brotli") compression.</p>
    <p>If Brotli compression is used in a <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font③">range-request optimized font</a>, it should use only one <a href="https://datatracker.ietf.org/doc/html/rfc7932#section-9.2">meta-block</a>.</p>
    <p>If Brotli compression is used in a <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font④">range-request optimized font</a>, its one meta-block should have the <a href="https://datatracker.ietf.org/doc/html/rfc7932#section-9.2"><code>ISUNCOMPRESSED</code></a> bit set to 1.</p>
@@ -1729,16 +1729,17 @@ which carry different types of glyph outlines:</p>
    <p>There is a certain amount of data from the beginning of the font file which the browser should unconditionally download. The boundary at the end of this data is called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="range-request-threshold">range-request threshold</dfn>.</p>
    <p class="note" role="note"><span>Note:</span> The first request does not have to be a range request. If the browser expects the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold">range-request threshold</a> to lie within the first <code>n</code> bytes of the font, the first request may be a range request for the first <code>n</code> bytes of the font. However, a browser may instead make a non-range request, parse the data as it is being streamed from the server, and discover that it has reached the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold①">range-request threshold</a> while data is still being streamed.</p>
    <p>Once all the data before the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold②">range-request threshold</a> has been loaded by the browser, the browser may either close this connection to the server, or it may choose to leave the connection open and let the font data continue loading in the background.</p>
-   <p>A browser may choose to add a <a data-link-type="biblio" href="#biblio-rfc9110">[RFC9110]</a> <code>Range</code> header to the initial request during the IFT method selection if it has reason to believe the range it requests will be large enough and it prefers to not close this connection to the server.</p>
+   <p>A browser may choose to add a <code>Range</code> header (<a href="https://www.rfc-editor.org/rfc/rfc9110#name-range">HTTP Semantics § name-range</a>) to the initial request during the IFT method selection if it has reason to believe the range it requests will be large enough and it prefers to not close this connection to the server.</p>
    <p class="note" role="note"><span>Note:</span> Different browsers may choose different <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold③">range-request thresholds</a>. Some browsers may treat this threshold as occuring at the end of the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">sfnt tableDirectory</a>. Other browsers may treat this threshold as occurring just before any outline data, provided the outline data appears at the end of the font. Other browsers may place this threshold at the very beginning of the file, thereby treating the whole file as able to be downloaded with range-requests.</p>
    <h4 class="heading settled" data-level="5.3.2" id="browser-behaviors-subsequent-requests"><span class="secno">5.3.2. </span><span class="content">Subsequent Requests</span><a class="self-link" href="#browser-behaviors-subsequent-requests"></a></h4>
-   <p>After all the data before the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold④">range-request threshold</a> has been loaded by the browser, the browser will determine which additional byte ranges in the file are necessary to load. It will then issue <a data-link-type="biblio" href="#biblio-rfc9110">[RFC9110]</a> HTTP Range Requests for at least those ranges.</p>
+   <p>After all the data before the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold④">range-request threshold</a> has been loaded by the browser, the browser will determine which additional byte ranges in the file are necessary to load. It will then issue HTTP Range Requests (<a href="https://www.rfc-editor.org/rfc/rfc9110#range.requests">HTTP Semantics § range.requests</a>) for at least those ranges.</p>
    <p class="note" role="note"><span>Note:</span> Browsers are encouraged to coalesce range requests for nearby areas of the file, to minimize the amount of range-request overhead required. Browsers are encouraged to inform these coalescing decisions from network configuration parameters and bandwidth / latency observations.</p>
    <p class="note" role="note"><span>Note:</span> If the font file has followed all of the organization guidelines above, all information required for laying out content and performing shaping will lie before any of the outline data in the file, and every glyph’s outline will be independent from every other glyph. Therefore, the browser can treat the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold⑤">range-request threshold</a> as being just before outline data begins, and once it has loaded up to that threshold, it can lay out page content. After laying out the page, downloading all the necessary outlines can be done with a collection of independent and parallel range requests. This works particularly well for Chinese, Japanese, and Korean fonts, where 90% or more of the font data is outline data.</p>
    <p class="note" role="note"><span>Note:</span> Another valid alternative is to treat the entire font as residing on an asynchronous virtual filesystem, and have the browser track which ranges of the font it ended up reading during its normal operation. The browser could then request those regions in range requests.</p>
    <h3 class="heading settled" data-level="5.4" id="server-behaviors"><span class="secno">5.4. </span><span class="content">Server Behaviors</span><a class="self-link" href="#server-behaviors"></a></h3>
-   <p>Servers supporting the range-request IFT method must support <a data-link-type="biblio" href="#biblio-rfc9110">[RFC9110]</a> range requests.</p>
-   <p>Servers supporting the range-request IFT method should support compression via the <a data-link-type="biblio" href="#biblio-rfc9110">[RFC9110]</a> <code>Content-Encoding</code> header or the <a data-link-type="biblio" href="#biblio-rfc9112">[RFC9112]</a> <code>Transfer-Encoding</code> header, rather than having the font file itself be statically compressed.</p>
+   <p>Servers supporting the range-request IFT method must support range requests (<a href="https://www.rfc-editor.org/rfc/rfc9110#range.requests">HTTP Semantics § range.requests</a>).</p>
+   <p>Servers supporting the range-request IFT method should support compression via the <code>Content-Encoding</code> (<a href="https://www.rfc-editor.org/rfc/rfc9110#name-content-encoding">HTTP Semantics § name-content-encoding</a>) header or the <code>Transfer-Encoding</code> header (<a href="https://www.rfc-editor.org/rfc/rfc9112#section-6.1">HTTP/1.1 § section-6.1</a>), rather than having the font file
+itself be statically compressed.</p>
    <h2 class="no-num heading settled" id="priv"><span class="content">Privacy Considerations</span><a class="self-link" href="#priv"></a></h2>
    <h3 class="heading settled" id="content-inference-from-character-set"><span class="content">Content inference from character set</span><a class="self-link" href="#content-inference-from-character-set"></a></h3>
    <p>IFT exposes, to the server hosting a Web font, the set of characters that the browser can already render in a given Web font, and also the set of characters that it cannot render, but wants to (for example, to render a new Web page). For details, see <a href="#extend-subset">Extending the Font Subset</a>.</p>
@@ -2147,49 +2148,50 @@ which carry different types of glyph outlines:</p>
    </table>
   </main>
   <div data-fill-with="conformance">
-   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
-   <h3 class="no-ref no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h3>
-   <p>Conformance requirements are expressed with a combination of
-    descriptive assertions and RFC 2119 terminology. The key words “MUST”,
-    “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”,
-    “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative parts of this
-    document are to be interpreted as described in RFC 2119.
-    However, for readability, these words do not appear in all uppercase
-    letters in this specification. </p>
-   <p>All of the text of this specification is normative except sections
-    explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
+   <h2 class="no-ref no-num heading settled" id="w3c-conformance"><span class="content">Conformance</span><a class="self-link" href="#w3c-conformance"></a></h2>
+   <h3 class="no-ref no-num heading settled" id="w3c-conventions"><span class="content">Document conventions</span><a class="self-link" href="#w3c-conventions"></a></h3>
+   <p>Conformance requirements are expressed
+    with a combination of descriptive assertions
+    and RFC 2119 terminology.
+    The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+    in the normative parts of this document
+    are to be interpreted as described in RFC 2119.
+    However, for readability,
+    these words do not appear in all uppercase letters in this specification. </p>
+   <p>All of the text of this specification is normative
+    except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
    <p>Examples in this specification are introduced with the words “for example”
-    or are set apart from the normative text with <code>class="example"</code>,
+    or are set apart from the normative text
+    with <code>class="example"</code>,
     like this: </p>
-   <div class="example" id="example-ae2b6bc0">
-    <a class="self-link" href="#example-ae2b6bc0"></a>
-    <p>This is an example of an informative example.</p>
+   <div class="example" id="w3c-example">
+    <a class="self-link" href="#w3c-example"></a> 
+    <p>This is an example of an informative example. </p>
    </div>
-   <p>Informative notes begin with the word “Note” and are set apart from the
-    normative text with <code>class="note"</code>, like this: </p>
+   <p>Informative notes begin with the word “Note”
+    and are set apart from the normative text
+    with <code>class="note"</code>,
+    like this: </p>
    <p class="note" role="note">Note, this is an informative note.</p>
-   <h3 class="no-ref no-num heading settled" id="conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#conformant-algorithms"></a></h3>
-   <p>Requirements phrased in the imperative as part of algorithms (such as
-    "strip any leading space characters" or "return false and abort these
-    steps") are to be interpreted with the meaning of the key word ("must",
-    "should", "may", etc) used in introducing the algorithm.</p>
-   <p>Conformance requirements phrased as algorithms or specific steps can be
-    implemented in any manner, so long as the end result is equivalent. In
-    particular, the algorithms defined in this specification are intended to
-    be easy to understand and are not intended to be performant. Implementers
-    are encouraged to optimize.</p>
-   <h3 class="no-ref no-num heading settled" id="conformance-classes"><span class="content">Conformance Classes</span><a class="self-link" href="#conformance-classes"></a></h3>
-   <p>A <dfn data-dfn-type="dfn" data-export id="conformant-user-agent">conformant user agent<a class="self-link" href="#conformant-user-agent"></a></dfn> must implement all the requirements
-    listed in this specification that are applicable to user agents.</p>
-   <p>A <dfn data-dfn-type="dfn" data-export id="conformant-server">conformant server<a class="self-link" href="#conformant-server"></a></dfn> must implement all the requirements listed
-    in this specification that are applicable to servers.</p>
+   <h3 class="no-ref no-num heading settled" id="w3c-conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#w3c-conformant-algorithms"></a></h3>
+   <p>Requirements phrased in the imperative as part of algorithms
+    (such as "strip any leading space characters"
+    or "return false and abort these steps")
+    are to be interpreted with the meaning of the key word
+    ("must", "should", "may", etc)
+    used in introducing the algorithm. </p>
+   <p>Conformance requirements phrased as algorithms or specific steps
+    can be implemented in any manner,
+    so long as the end result is equivalent.
+    In particular, the algorithms defined in this specification
+    are intended to be easy to understand
+    and are not intended to be performant.
+    Implementers are encouraged to optimize. </p>
   </div>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#conformant-server">conformant server</a><span>, in § Unnumbered section</span>
-   <li><a href="#conformant-user-agent">conformant user agent</a><span>, in § Unnumbered section</span>
    <li><a href="#corpus">corpus</a><span>, in § 5.2.6</span>
    <li><a href="#outline-table">outline table</a><span>, in § 5.2.4</span>
    <li><a href="#query-parameter">query parameter</a><span>, in § 4.4.2</span>
@@ -2305,7 +2307,7 @@ which carry different types of glyph outlines:</p>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-css-fonts-4">[CSS-FONTS-4]
-   <dd>John Daggett; Myles Maxfield; Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-4/"><cite>CSS Fonts Module Level 4</cite></a>. 21 December 2021. WD. URL: <a href="https://www.w3.org/TR/css-fonts-4/">https://www.w3.org/TR/css-fonts-4/</a>
+   <dd>CSS Fonts Module Level 4 URL: <a href="https://www.w3.org/TR/css-fonts-4/">https://www.w3.org/TR/css-fonts-4/</a>
    <dt id="biblio-css-fonts-5">[CSS-FONTS-5]
    <dd>Myles Maxfield; Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-5/"><cite>CSS Fonts Module Level 5</cite></a>. 21 December 2021. WD. URL: <a href="https://www.w3.org/TR/css-fonts-5/">https://www.w3.org/TR/css-fonts-5/</a>
    <dt id="biblio-fast-hash">[FAST-HASH]
@@ -2320,10 +2322,14 @@ which carry different types of glyph outlines:</p>
    <dd>D. Korn; et al. <a href="https://www.rfc-editor.org/rfc/rfc3284"><cite>The VCDIFF Generic Differencing and Compression Data Format</cite></a>. June 2002. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3284">https://www.rfc-editor.org/rfc/rfc3284</a>
    <dt id="biblio-rfc7932">[RFC7932]
    <dd>J. Alakuijala; Z. Szabadka. <a href="https://www.rfc-editor.org/rfc/rfc7932"><cite>Brotli Compressed Data Format</cite></a>. July 2016. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc7932">https://www.rfc-editor.org/rfc/rfc7932</a>
+   <dt id="biblio-rfc8081">[RFC8081]
+   <dd>C. Lilley. <a href="https://www.rfc-editor.org/rfc/rfc8081"><cite>The "font" Top-Level Media Type</cite></a>. February 2017. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc8081">https://www.rfc-editor.org/rfc/rfc8081</a>
    <dt id="biblio-rfc8949">[RFC8949]
    <dd>C. Bormann; P. Hoffman. <a href="https://www.rfc-editor.org/rfc/rfc8949"><cite>Concise Binary Object Representation (CBOR)</cite></a>. December 2020. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc8949">https://www.rfc-editor.org/rfc/rfc8949</a>
    <dt id="biblio-rfc9110">[RFC9110]
    <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9110"><cite>HTTP Semantics</cite></a>. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a>
+   <dt id="biblio-rfc9111">[RFC9111]
+   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9111"><cite>HTTP Caching</cite></a>. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9111">https://www.rfc-editor.org/rfc/rfc9111</a>
    <dt id="biblio-rfc9112">[RFC9112]
    <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9112"><cite>HTTP/1.1</cite></a>. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9112">https://www.rfc-editor.org/rfc/rfc9112</a>
    <dt id="biblio-shared-brotli">[Shared-Brotli]
@@ -2347,8 +2353,6 @@ which carry different types of glyph outlines:</p>
    <dd>F. Yergeau. <a href="https://www.rfc-editor.org/rfc/rfc3629"><cite>UTF-8, a transformation format of ISO 10646</cite></a>. November 2003. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3629">https://www.rfc-editor.org/rfc/rfc3629</a>
    <dt id="biblio-rfc4648">[RFC4648]
    <dd>S. Josefsson. <a href="https://www.rfc-editor.org/rfc/rfc4648"><cite>The Base16, Base32, and Base64 Data Encodings</cite></a>. October 2006. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc4648">https://www.rfc-editor.org/rfc/rfc4648</a>
-   <dt id="biblio-rfc9111">[RFC9111]
-   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9111"><cite>HTTP Caching</cite></a>. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9111">https://www.rfc-editor.org/rfc/rfc9111</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">


### PR DESCRIPTION
For example for range request link to the specific range request section within rfc9110.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/102.html" title="Last updated on Jun 22, 2022, 6:38 PM UTC (17687d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/102/497c2d4...17687d7.html" title="Last updated on Jun 22, 2022, 6:38 PM UTC (17687d7)">Diff</a>