### PR TITLE
Shrink Integer primitive range to match that of an int64_t.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -240,7 +240,7 @@ should be encoded by CBOR are given in the definition of those data types.
     <th>Data Type</th><th>Description</th><th>CBOR Major Type</th>
   </tr>
   <tr>
-    <td>Integer</td><td>An integer value range [-2<sup>64</sup> - 1, 2<sup>64</sup> - 1] inclusive.</td>
+    <td>Integer</td><td>An integer value range [-2<sup>63</sup>, 2<sup>63</sup> - 1] inclusive.</td>
     <td>0 or 1</td>
   </tr>
   <tr>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="497c2d45af635e32687790511475b7abb4962a8b" name="document-revision">
+  <meta content="b5322b76ebd70624798011c0654e9e4eb8873f30" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -524,7 +524,7 @@ should be encoded by CBOR are given in the definition of those data types.</p>
       <th>CBOR Major Type
      <tr>
       <td>Integer
-      <td>An integer value range [-2<sup>64</sup> - 1, 2<sup>64</sup> - 1] inclusive.
+      <td>An integer value range [-2<sup>63</sup>, 2<sup>63</sup> - 1] inclusive.
       <td>0 or 1
      <tr>
       <td>Float


### PR DESCRIPTION
Fixes #105.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/111.html" title="Last updated on Jul 8, 2022, 8:47 PM UTC (54ec9bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/111/b5322b7...54ec9bd.html" title="Last updated on Jul 8, 2022, 8:47 PM UTC (54ec9bd)">Diff</a>