### PR TITLE
Revise method selection and negotiation.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -212,16 +212,24 @@ Opt-In Mechanism {#opt-in}
 
 <em>This section is general to both IFT methods.</em>
 
-The collection of IFT technologies utilizes a single shared opt-in mechanism. Each method does not use its own opt-in mechanism; instead, the webpage opts into the IFT technologies as a whole, and the browser and server negotiate to decide which specific method will be employed.
+Webpage's can choose to opt-in to either patch subset or range request incremental transfer for a font
+via the use of a CSS font tech keyword ([[css-fonts-4#font-tech-definitions]]) inside the
+''@font-face'' block.
 
-The opt-in mechanism is the <code>incremental</code> keyword inside the ''@font-face'' block. Websites specify this keyword inside their <code>@font-face</code> block, and the browser is then responsible for using IFT technologies, and for negotiating with the server to determine which specific IFT method to use.
+There are three tech keywords available:
+
+*  <code>incremental-patch</code>: Load the font incrementally using the patch subset method.
+*  <code>incremental-range</code>: Load the font incrementally using the range request method.
+*  <code>incremental-auto</code>:  Load the font incrementally. The particular method to use is
+    determined by <a href="#method-negotiation">Method Negotiation</a>.
 
 <div class=example>
-The use of the <code>incremental</code> keyword in this CSS rule indicates to the browser they should use IFT.
+The use of the <code>incremental-patch</code> keyword in this CSS rule indicates to the browser they
+should use the patch subset IFT method to load the font.
 <pre>
 @font-face {
     font-family: "MyCoolWebFont";
-    src: url("MyCoolWebFont.otf") tech(incremental);
+    src: url("MyCoolWebFont.otf") tech(incremental-patch);
 }
 </pre>
 </div>
@@ -233,11 +241,47 @@ IFT Method Selection {#method-selection}
 
 <em>This section is general to both IFT methods.</em>
 
-When a page has indicated that a particular font should utilize IFT technology, the browser must determine which method to use. Different browsers may support different IFT methods, and different servers may support different IFT methods, so a negotation occurs as such:
+The client selects the IFT method to utilize for a font load using the following procedure:
 
-1. The browser makes the first request to the server. If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant [=query parameter=]. If the client prefers the range-request method, it does not send the query parameter.
-2. If the server receives the patch-subset query parameter and wishes to honor it, the server must reply with a valid <a href="#PatchResponse">patch subset response</a> which includes the <a href="#handling-patch-response">patch-subset magic number</a>. Otherwise, the server must reply with the [[RFC9110#range.requests]] <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a> header, if it supports HTTP Range Requests.
-3. If the client receives the patch-subset magic number, it commences using the patch-subset method. Otherwise, if the client receives the <code>Accept-Ranges: bytes</code> header, it commences using the range-request method. Otherwise, the whole font file is downloaded, and the current non-incremental loading behavior is used.
+1. If the content has specified which method to use, such as via the
+    <a href="#opt-in">opt-in mechanism</a>, then that method should be used.
+
+2. Otherwise if the client does not know which particular IFT method that the server hosting the font
+    supports then, <a href="#method-negotiation">method negotiation</a> should be used to determine
+    the method.
+
+TODO what happens if the server doesn't actually support the content specified method?
+
+Note: the most recently specified method by the content takes precedence. For example if on a site the
+first page specifies to use the patch subset method for a font URL, but the second page specifies
+range request for the same font URL then the second page should load the font using range request.
+Such cases will require the client to reset any previously stored state for that URL and start fresh
+with the new method.
+
+
+IFT Method Negotiation {#method-negotiation}
+--------------------------------------------
+
+When the particular IFT method(s) that are supported by a server are not known, the client must
+determine which method to use. Different clients may support different IFT methods, and different
+servers may support different IFT methods, so a negotation occurs as such:
+
+1.  The browser makes the first request to the server using the GET HTTP method ([[rfc9110#name-get]]).
+     If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant
+     [=patch request header=]. If the client prefers the range-request method, it does not send the
+     header.
+
+2.  If the server receives the patch request header and wishes to honor it, the server must reply with
+     a valid <a href="#PatchResponse">patch subset response</a> which includes the
+     <a href="#handling-patch-response">patch-subset magic number</a>. Otherwise, the server must
+     reply with the [[RFC9110#range.requests]]
+     <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a>
+     header, if it supports HTTP Range Requests.
+     
+3.  If the client receives the patch-subset magic number, it commences using the patch-subset method.
+     Otherwise, if the client receives the <code>Accept-Ranges: bytes</code> header, it commences
+     using the range-request method. Otherwise, the whole font file is downloaded, and the current
+     non-incremental loading behavior is used.
 
 IFT Method Fallback {#fallback}
 -------------------------------

--- a/Overview.bs
+++ b/Overview.bs
@@ -244,13 +244,15 @@ IFT Method Selection {#method-selection}
 The client selects the IFT method to utilize for a font load using the following procedure:
 
 1. If the content has specified which method to use, such as via the
-    <a href="#opt-in">opt-in mechanism</a>, then that method should be used.
+    <a href="#opt-in">opt-in mechanism</a>, then that method should be used if the client supports
+    it.
 
-2. Otherwise if the client does not know which particular IFT method that the server hosting the font
+2. If the client does not support the specified method then it should fallback to to loading
+    the font non-incrementally.
+
+3. Otherwise if the client does not know which particular IFT method that the server hosting the font
     supports then, <a href="#method-negotiation">method negotiation</a> should be used to determine
     the method.
-
-TODO what happens if the server doesn't actually support the content specified method?
 
 Note: the most recently specified method by the content takes precedence. For example if on a site the
 first page specifies to use the patch subset method for a font URL, but the second page specifies
@@ -288,7 +290,50 @@ IFT Method Fallback {#fallback}
 
 <em>This section is not normative.</em>
 
-This summarizes behaviors that result from the above method selection.
+This summarizes behaviors that result from the above method selection and negotiation sections.
+
+If the content specifies the range request method:
+
+<table class="data">
+    <thead>
+        <tr>
+            <th>&nbsp;
+            <th>Client supports range-request method
+            <th>Client does not support range-request method
+    <tbody>
+	<tr>
+	    <th>Server supports range-request method
+	    <td>Range-request method is used.
+	    <td>Client falls back to non-incremental load of the full font file.
+	<tr>
+	    <th>Server does not support range-request method.
+	    <td>Response is missing accept-ranges header. Client falls back to
+	        non-incremental load of the full font file.
+	    <td>Client falls back to non-incremental load of the full font file.
+</table>
+
+If the content specifies the patch subset method:
+
+<table class="data">
+    <thead>
+        <tr>
+            <th>&nbsp;
+            <th>Client supports patch-subset method
+            <th>Client does not support patch-subset method
+    <tbody>
+	<tr>
+	    <th>Server supports patch-subset method
+	    <td>Patch-subset method is used.
+	    <td>Client falls back to non-incremental load of the full font file.
+	<tr>
+	    <th>Server does not support patch-subset method
+	    <td>Response is missing magic number. Client falls back to non-incremental load of the
+	    full font file.
+	    <td>Client falls back to non-incremental load of the
+	    full font file.
+</table>
+
+If the content does not specify a specific method:
 
 <table class="data">
     <thead>
@@ -299,8 +344,6 @@ This summarizes behaviors that result from the above method selection.
     <tbody>
         <tr><th>Server supports both range-request method and patch-subset method
             <td>Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Because all patch-subset servers must support the range-request method, the server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method.
-
-            Issue: <a href="https://github.com/w3c/IFT/issues/56">Server-recommended IFT Method selection</a>
 
             <td>Client makes initial request with query parameter. Server replies with the patch-subset magic number, and client/server commence using patch-subset method.
         <tr><th>Server supports only range-request method

--- a/Overview.bs
+++ b/Overview.bs
@@ -246,16 +246,14 @@ IFT Method Selection {#method-selection}
 
 The client selects the IFT method to utilize for a font load using the following procedure:
 
-1. If the content has specified which method to use, such as via the
-    <a href="#opt-in">opt-in mechanism</a>, then that method should be used if the client supports
-    it.
+*  If the content has specified which method to use, such as via the <code>incremental-patch</code> or
+    <code>incremental-range</code> font tech keyword (see: <a href="#opt-in">opt-in mechanism</a>),
+    then that method should be used if the client supports it. If the specified method is not supported
+    then the client should fallback to to loading the font non-incrementally.
 
-2. If the client does not support the specified method then it should fallback to to loading
-    the font non-incrementally.
-
-3. Otherwise if the client does not know which particular IFT method that the server hosting the font
-    supports then, <a href="#method-negotiation">method negotiation</a> should be used to determine
-    the method.
+*  Otherwise if the client does not know which particular IFT method(s) that the server hosting the
+    font supports then, <a href="#method-negotiation">method negotiation</a> should be used to
+    determine the method.
 
 Note: the most recently specified method by the content takes precedence. For example if on a site the
 first page specifies to use the patch subset method for a font URL, but the second page specifies

--- a/Overview.bs
+++ b/Overview.bs
@@ -343,15 +343,15 @@ If the content does not specify a specific method:
             <th>Client prefers patch-subset method
     <tbody>
         <tr><th>Server supports both range-request method and patch-subset method
-            <td>Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Because all patch-subset servers must support the range-request method, the server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method.
+            <td>Client makes initial request without the patch request header, and possibly with the <code>Range</code> header. Because all patch-subset servers must support the range-request method, the server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method.
 
-            <td>Client makes initial request with query parameter. Server replies with the patch-subset magic number, and client/server commence using patch-subset method.
+            <td>Client makes initial request with the patch request header. Server replies with the patch-subset magic number, and client/server commence using patch-subset method.
         <tr><th>Server supports only range-request method
             <td>Same as above.
-            <td>Client makes initial request with query parameter. Server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method.
+            <td>Client makes initial request with the patch request header. Server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method.
         <tr><th>Server supports neither
-            <td>Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Server replies without <code>Accept-Ranges</code> header, and sends the full font file to the client from beginning to end.
-            <td>Client makes initial request to server with query parameter. Server does not reply with the patch-subset magic number, and sends the full font file to the client from beginning to end.
+            <td>Client makes initial request without the patch request header, and possibly with the <code>Range</code> header. Server replies without <code>Accept-Ranges</code> header, and sends the full font file to the client from beginning to end.
+            <td>Client makes initial request to server with the patch request header. Server does not reply with the patch-subset magic number, and sends the full font file to the client from beginning to end.
 </table>
 
 Patch Based Incremental Transfer {#patch-incxfer}
@@ -1066,11 +1066,11 @@ Extend font subset algorithm:
      * If [=request/method=] is "POST" then, request [=request/body=] must be a single
          <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR.
 
-     * Otherwise if [=request/method=] is "GET" then, URL [=url/query=] must contain a
-          <dfn export>query
-          parameter</dfn> "request" whose value is a single
+     * Otherwise if [=request/method=] is "GET" then, a [=header=] with name
+         <code>Font-Patch-Request</code> (the <dfn export>patch request header</dfn>)
+         and whose value is a single
           <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then
-          base64url encoding [[rfc4648]].
+          base64url encoding [[rfc4648]] must be added to the request's header list.
 
      Any request and/or url parameters which are not specified here should be set based on
      the user agent's normal handling for font requests. For example if this font load is
@@ -1143,6 +1143,9 @@ Extend font subset algorithm:
 
 3. Goto [[#handling-patch-response]].
 
+Note: POST is preferred for the HTTP method since it will not cause a CORS preflight request
+and the request object is more compactly encoded. GET should only be used during
+<a href="#method-negotiation">method negotiation</a>.
 
 #### Handling PatchResponse #### {#handling-patch-response}
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -236,6 +236,9 @@ should use the patch subset IFT method to load the font.
 
 Note: Each individual <code>@font-face</code> block may or may not opt-in to IFT. This is due to the variety of ways fonts are used on web pages. Authors have control over which fonts they want to use this technology with, and which they do not.
 
+Note: the use of <code>incremental-auto</code> may incur a CORS preflight request for the initial
+request of method negotiation, as the initial request sets a custom header.
+
 IFT Method Selection {#method-selection}
 ========================================
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -255,11 +255,13 @@ The client selects the IFT method to utilize for a font load using the following
     font supports, such as when the <code>incremental-auto</code> font tech keyword is used, then
     <a href="#method-negotiation">method negotiation</a> should be used to determine the method.
 
-Note: the most recently specified method by the content takes precedence. For example if on a site the
+The most recently specified method by the content takes precedence. For example if on a site the
 first page specifies to use the patch subset method for a font URL, but the second page specifies
 range request for the same font URL then the second page should load the font using range request.
 Such cases will require the client to reset any previously stored state for that URL and start fresh
-with the new method.
+with the new method. In the case that <code>incremental-auto</code> is encountered where previously a
+specific method was specified then the client can choose to continue using the previously selected
+method.
 
 
 IFT Method Negotiation {#method-negotiation}

--- a/Overview.bs
+++ b/Overview.bs
@@ -252,8 +252,8 @@ The client selects the IFT method to utilize for a font load using the following
     then the client should fallback to to loading the font non-incrementally.
 
 *  Otherwise if the client does not know which particular IFT method(s) that the server hosting the
-    font supports then, <a href="#method-negotiation">method negotiation</a> should be used to
-    determine the method.
+    font supports, such as when the <code>incremental-auto</code> font tech keyword is used, then
+    <a href="#method-negotiation">method negotiation</a> should be used to determine the method.
 
 Note: the most recently specified method by the content takes precedence. For example if on a site the
 first page specifies to use the patch subset method for a font URL, but the second page specifies

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="1135beb903d73364c643bfc8e1cf66f7f933326d" name="document-revision">
+  <meta content="2c8574229785497f5f9131363967e380f660059e" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -539,6 +539,8 @@ should use the patch subset IFT method to load the font.
 </pre>
    </div>
    <p class="note" role="note"><span>Note:</span> Each individual <code>@font-face</code> block may or may not opt-in to IFT. This is due to the variety of ways fonts are used on web pages. Authors have control over which fonts they want to use this technology with, and which they do not.</p>
+   <p class="note" role="note"><span>Note:</span> the use of <code>incremental-auto</code> may incur a CORS preflight request for the initial
+request of method negotiation, as the initial request sets a custom header.</p>
    <h2 class="heading settled" data-level="3" id="method-selection"><span class="secno">3. </span><span class="content">IFT Method Selection</span><a class="self-link" href="#method-selection"></a></h2>
    <p><em>This section is general to both IFT methods.</em></p>
    <p>The client selects the IFT method to utilize for a font load using the following procedure:</p>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="3f0d6bb8b86e14dabfdc1af153a6e5ce18c83b0e" name="document-revision">
+  <meta content="272d183b36e36644a09271531ee0a8f95e533b68" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -553,11 +553,13 @@ then the client should fallback to to loading the font non-incrementally.</p>
      <p>Otherwise if the client does not know which particular IFT method(s) that the server hosting the
 font supports, such as when the <code>incremental-auto</code> font tech keyword is used, then <a href="#method-negotiation">method negotiation</a> should be used to determine the method.</p>
    </ul>
-   <p class="note" role="note"><span>Note:</span> the most recently specified method by the content takes precedence. For example if on a site the
+   <p>The most recently specified method by the content takes precedence. For example if on a site the
 first page specifies to use the patch subset method for a font URL, but the second page specifies
 range request for the same font URL then the second page should load the font using range request.
 Such cases will require the client to reset any previously stored state for that URL and start fresh
-with the new method.</p>
+with the new method. In the case that <code>incremental-auto</code> is encountered where previously a
+specific method was specified then the client can choose to continue using the previously selected
+method.</p>
    <h3 class="heading settled" data-level="3.1" id="method-negotiation"><span class="secno">3.1. </span><span class="content">IFT Method Negotiation</span><a class="self-link" href="#method-negotiation"></a></h3>
    <p>When the particular IFT method(s) that are supported by a server are not known, the client must
 determine which method to use. Different clients may support different IFT methods, and different

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="7f379afe5587795eaaeed5555b807c4c27f9ccde" name="document-revision">
+  <meta content="b6cc57d5eee09e3be1fb9dda1932eb011282cfcd" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -544,13 +544,16 @@ should use the patch subset IFT method to load the font.
    <p>The client selects the IFT method to utilize for a font load using the following procedure:</p>
    <ol>
     <li data-md>
-     <p>If the content has specified which method to use, such as via the <a href="#opt-in">opt-in mechanism</a>, then that method should be used.</p>
+     <p>If the content has specified which method to use, such as via the <a href="#opt-in">opt-in mechanism</a>, then that method should be used if the client supports
+it.</p>
+    <li data-md>
+     <p>If the client does not support the specified method then it should fallback to to loading
+the font non-incrementally.</p>
     <li data-md>
      <p>Otherwise if the client does not know which particular IFT method that the server hosting the font
 supports then, <a href="#method-negotiation">method negotiation</a> should be used to determine
 the method.</p>
    </ol>
-   <p>TODO what happens if the server doesn’t actually support the content specified method?</p>
    <p class="note" role="note"><span>Note:</span> the most recently specified method by the content takes precedence. For example if on a site the
 first page specifies to use the patch subset method for a font URL, but the second page specifies
 range request for the same font URL then the second page should load the font using range request.
@@ -577,7 +580,45 @@ servers may support different IFT methods, so a negotation occurs as such:</p>
    </ol>
    <h3 class="heading settled" data-level="3.2" id="fallback"><span class="secno">3.2. </span><span class="content">IFT Method Fallback</span><a class="self-link" href="#fallback"></a></h3>
    <p><em>This section is not normative.</em></p>
-   <p>This summarizes behaviors that result from the above method selection.</p>
+   <p>This summarizes behaviors that result from the above method selection and negotiation sections.</p>
+   <p>If the content specifies the range request method:</p>
+   <table class="data">
+    <thead>
+     <tr>
+      <th>
+      <th>Client supports range-request method 
+      <th>Client does not support range-request method 
+    <tbody>
+     <tr>
+      <th>Server supports range-request method 
+      <td>Range-request method is used. 
+      <td>Client falls back to non-incremental load of the full font file. 
+     <tr>
+      <th>Server does not support range-request method. 
+      <td>Response is missing accept-ranges header. Client falls back to
+	        non-incremental load of the full font file. 
+      <td>Client falls back to non-incremental load of the full font file. 
+   </table>
+   <p>If the content specifies the patch subset method:</p>
+   <table class="data">
+    <thead>
+     <tr>
+      <th>
+      <th>Client supports patch-subset method 
+      <th>Client does not support patch-subset method 
+    <tbody>
+     <tr>
+      <th>Server supports patch-subset method 
+      <td>Patch-subset method is used. 
+      <td>Client falls back to non-incremental load of the full font file. 
+     <tr>
+      <th>Server does not support patch-subset method 
+      <td>Response is missing magic number. Client falls back to non-incremental load of the
+	    full font file. 
+      <td>Client falls back to non-incremental load of the
+	    full font file. 
+   </table>
+   <p>If the content does not specify a specific method:</p>
    <table class="data">
     <thead>
      <tr>
@@ -587,9 +628,7 @@ servers may support different IFT methods, so a negotation occurs as such:</p>
     <tbody>
      <tr>
       <th>Server supports both range-request method and patch-subset method 
-      <td>
-       Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Because all patch-subset servers must support the range-request method, the server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method. 
-       <p class="issue" id="issue-2bae6363"><a class="self-link" href="#issue-2bae6363"></a> <a href="https://github.com/w3c/IFT/issues/56">Server-recommended IFT Method selection</a></p>
+      <td>Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Because all patch-subset servers must support the range-request method, the server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method. 
       <td>Client makes initial request with query parameter. Server replies with the patch-subset magic number, and client/server commence using patch-subset method. 
      <tr>
       <th>Server supports only range-request method 
@@ -2468,7 +2507,6 @@ itself be statically compressed.</p>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> <a href="https://github.com/w3c/IFT/issues/56">Server-recommended IFT Method selection</a> <a class="issue-return" href="#issue-2bae6363" title="Jump to section">↵</a></div>
    <div class="issue"> <a href="https://github.com/w3c/IFT/issues/59">Using WOFF2 files with range-request mechanism doesn’t seem to be a viable option</a> <a class="issue-return" href="#issue-73fb8795" title="Jump to section">↵</a></div>
    <div class="issue"> <a href="https://github.com/w3c/IFT/issues/60">Static file compression compatibility with range-request method</a> <a class="issue-return" href="#issue-6786fd81" title="Jump to section">↵</a></div>
    <div class="issue"> <a href="https://github.com/w3c/IFT/issues/28">Font Collections support</a> <a class="issue-return" href="#issue-010f4980" title="Jump to section">↵</a></div>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="1907a75b4c1395f4405b9cf8450a9b941a61fe13" name="document-revision">
+  <meta content="7f379afe5587795eaaeed5555b807c4c27f9ccde" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -298,7 +298,8 @@ dfn > a.self-link::before      { content: "#"; }
     <li>
      <a href="#method-selection"><span class="secno">3</span> <span class="content">IFT Method Selection</span></a>
      <ol class="toc">
-      <li><a href="#fallback"><span class="secno">3.1</span> <span class="content">IFT Method Fallback</span></a>
+      <li><a href="#method-negotiation"><span class="secno">3.1</span> <span class="content">IFT Method Negotiation</span></a>
+      <li><a href="#fallback"><span class="secno">3.2</span> <span class="content">IFT Method Fallback</span></a>
      </ol>
     <li>
      <a href="#patch-incxfer"><span class="secno">4</span> <span class="content">Patch Based Incremental Transfer</span></a>
@@ -516,29 +517,65 @@ CPU, RAM usage) per request vs range request.</p>
    </ul>
    <h2 class="heading settled" data-level="2" id="opt-in"><span class="secno">2. </span><span class="content">Opt-In Mechanism</span><a class="self-link" href="#opt-in"></a></h2>
    <p><em>This section is general to both IFT methods.</em></p>
-   <p>The collection of IFT technologies utilizes a single shared opt-in mechanism. Each method does not use its own opt-in mechanism; instead, the webpage opts into the IFT technologies as a whole, and the browser and server negotiate to decide which specific method will be employed.</p>
-   <p>The opt-in mechanism is the <code>incremental</code> keyword inside the <a class="css" data-link-type="maybe" href="https://www.w3.org/TR/css-fonts-5/#at-font-face-rule" id="ref-for-at-font-face-rule">@font-face</a> block. Websites specify this keyword inside their <code>@font-face</code> block, and the browser is then responsible for using IFT technologies, and for negotiating with the server to determine which specific IFT method to use.</p>
-   <div class="example" id="example-a9a7e9cd">
-    <a class="self-link" href="#example-a9a7e9cd"></a> The use of the <code>incremental</code> keyword in this CSS rule indicates to the browser they should use IFT. 
+   <p>Webpage’s can choose to opt-in to either patch subset or range request incremental transfer for a font
+via the use of a CSS font tech keyword (<a href="https://www.w3.org/TR/css-fonts-4/#font-tech-definitions"><cite>CSS Fonts 4</cite> § 11.1 Font tech</a>) inside the <a class="css" data-link-type="maybe" href="https://www.w3.org/TR/css-fonts-5/#at-font-face-rule" id="ref-for-at-font-face-rule">@font-face</a> block.</p>
+   <p>There are three tech keywords available:</p>
+   <ul>
+    <li data-md>
+     <p><code>incremental-patch</code>: Load the font incrementally using the patch subset method.</p>
+    <li data-md>
+     <p><code>incremental-range</code>: Load the font incrementally using the range request method.</p>
+    <li data-md>
+     <p><code>incremental-auto</code>:  Load the font incrementally. The particular method to use is
+determined by <a href="#method-negotiation">Method Negotiation</a>.</p>
+   </ul>
+   <div class="example" id="example-162f300b">
+    <a class="self-link" href="#example-162f300b"></a> The use of the <code>incremental-patch</code> keyword in this CSS rule indicates to the browser they
+should use the patch subset IFT method to load the font. 
 <pre>@font-face {
     font-family: "MyCoolWebFont";
-    src: url("MyCoolWebFont.otf") tech(incremental);
+    src: url("MyCoolWebFont.otf") tech(incremental-patch);
 }
 </pre>
    </div>
    <p class="note" role="note"><span>Note:</span> Each individual <code>@font-face</code> block may or may not opt-in to IFT. This is due to the variety of ways fonts are used on web pages. Authors have control over which fonts they want to use this technology with, and which they do not.</p>
    <h2 class="heading settled" data-level="3" id="method-selection"><span class="secno">3. </span><span class="content">IFT Method Selection</span><a class="self-link" href="#method-selection"></a></h2>
    <p><em>This section is general to both IFT methods.</em></p>
-   <p>When a page has indicated that a particular font should utilize IFT technology, the browser must determine which method to use. Different browsers may support different IFT methods, and different servers may support different IFT methods, so a negotation occurs as such:</p>
+   <p>The client selects the IFT method to utilize for a font load using the following procedure:</p>
    <ol>
     <li data-md>
-     <p>The browser makes the first request to the server. If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant <a data-link-type="dfn" href="#query-parameter" id="ref-for-query-parameter">query parameter</a>. If the client prefers the range-request method, it does not send the query parameter.</p>
+     <p>If the content has specified which method to use, such as via the <a href="#opt-in">opt-in mechanism</a>, then that method should be used.</p>
     <li data-md>
-     <p>If the server receives the patch-subset query parameter and wishes to honor it, the server must reply with a valid <a href="#PatchResponse">patch subset response</a> which includes the <a href="#handling-patch-response">patch-subset magic number</a>. Otherwise, the server must reply with the <a href="https://www.rfc-editor.org/rfc/rfc9110#range.requests">HTTP Semantics § range.requests</a> <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a> header, if it supports HTTP Range Requests.</p>
-    <li data-md>
-     <p>If the client receives the patch-subset magic number, it commences using the patch-subset method. Otherwise, if the client receives the <code>Accept-Ranges: bytes</code> header, it commences using the range-request method. Otherwise, the whole font file is downloaded, and the current non-incremental loading behavior is used.</p>
+     <p>Otherwise if the client does not know which particular IFT method that the server hosting the font
+supports then, <a href="#method-negotiation">method negotiation</a> should be used to determine
+the method.</p>
    </ol>
-   <h3 class="heading settled" data-level="3.1" id="fallback"><span class="secno">3.1. </span><span class="content">IFT Method Fallback</span><a class="self-link" href="#fallback"></a></h3>
+   <p>TODO what happens if the server doesn’t actually support the content specified method?</p>
+   <p class="note" role="note"><span>Note:</span> the most recently specified method by the content takes precedence. For example if on a site the
+first page specifies to use the patch subset method for a font URL, but the second page specifies
+range request for the same font URL then the second page should load the font using range request.
+Such cases will require the client to reset any previously stored state for that URL and start fresh
+with the new method.</p>
+   <h3 class="heading settled" data-level="3.1" id="method-negotiation"><span class="secno">3.1. </span><span class="content">IFT Method Negotiation</span><a class="self-link" href="#method-negotiation"></a></h3>
+   <p>When the particular IFT method(s) that are supported by a server are not known, the client must
+determine which method to use. Different clients may support different IFT methods, and different
+servers may support different IFT methods, so a negotation occurs as such:</p>
+   <ol>
+    <li data-md>
+     <p>The browser makes the first request to the server using the GET HTTP method (<a href="https://www.rfc-editor.org/rfc/rfc9110#name-get">HTTP Semantics § name-get</a>).
+ If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant <a data-link-type="dfn">patch request header</a>. If the client prefers the range-request method, it does not send the
+ header.</p>
+    <li data-md>
+     <p>If the server receives the patch request header and wishes to honor it, the server must reply with
+ a valid <a href="#PatchResponse">patch subset response</a> which includes the <a href="#handling-patch-response">patch-subset magic number</a>. Otherwise, the server must
+ reply with the <a href="https://www.rfc-editor.org/rfc/rfc9110#range.requests">HTTP Semantics § range.requests</a> <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a> header, if it supports HTTP Range Requests.</p>
+    <li data-md>
+     <p>If the client receives the patch-subset magic number, it commences using the patch-subset method.
+ Otherwise, if the client receives the <code>Accept-Ranges: bytes</code> header, it commences
+ using the range-request method. Otherwise, the whole font file is downloaded, and the current
+ non-incremental loading behavior is used.</p>
+   </ol>
+   <h3 class="heading settled" data-level="3.2" id="fallback"><span class="secno">3.2. </span><span class="content">IFT Method Fallback</span><a class="self-link" href="#fallback"></a></h3>
    <p><em>This section is not normative.</em></p>
    <p>This summarizes behaviors that result from the above method selection.</p>
    <table class="data">
@@ -1312,8 +1349,8 @@ can be cached, or null.</p>
       <li data-md>
        <p>If <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method①">method</a> is "POST" then, request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-body" id="ref-for-concept-request-body">body</a> must be a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR.</p>
       <li data-md>
-       <p>Otherwise if <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method②">method</a> is "GET" then, URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-query" id="ref-for-concept-url-query">query</a> must contain a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="query parameter" id="query-parameter">query
-  parameter</dfn> "request" whose value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then
+       <p>Otherwise if <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method②">method</a> is "GET" then, URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-query" id="ref-for-concept-url-query">query</a> must contain a <dfn data-dfn-type="dfn" data-export data-lt="query parameter" id="query-parameter">query
+  parameter<a class="self-link" href="#query-parameter"></a></dfn> "request" whose value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then
   base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>.</p>
      </ul>
      <p>Any request and/or url parameters which are not specified here should be set based on
@@ -2438,12 +2475,6 @@ itself be statically compressed.</p>
    <div class="issue"> <a href="https://github.com/w3c/IFT/issues/58">Supporting fonts with composite glyphs via range-request</a> <a class="issue-return" href="#issue-5533a524" title="Jump to section">↵</a></div>
    <div class="issue"> <a href="https://github.com/w3c/IFT/issues/61">Populate suggested character ordering for range-request method</a> <a class="issue-return" href="#issue-763d5c98" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="query-parameter">
-   <b><a href="#query-parameter">#query-parameter</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-query-parameter">3. IFT Method Selection</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="range-request-optimized-font">
    <b><a href="#range-request-optimized-font">#range-request-optimized-font</a></b><b>Referenced in:</b>
    <ul>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="2c8574229785497f5f9131363967e380f660059e" name="document-revision">
+  <meta content="1539682d227da9c45435af11c3aa3a60702225b2" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -544,18 +544,16 @@ request of method negotiation, as the initial request sets a custom header.</p>
    <h2 class="heading settled" data-level="3" id="method-selection"><span class="secno">3. </span><span class="content">IFT Method Selection</span><a class="self-link" href="#method-selection"></a></h2>
    <p><em>This section is general to both IFT methods.</em></p>
    <p>The client selects the IFT method to utilize for a font load using the following procedure:</p>
-   <ol>
+   <ul>
     <li data-md>
-     <p>If the content has specified which method to use, such as via the <a href="#opt-in">opt-in mechanism</a>, then that method should be used if the client supports
-it.</p>
+     <p>If the content has specified which method to use, such as via the <code>incremental-patch</code> or <code>incremental-range</code> font tech keyword (see: <a href="#opt-in">opt-in mechanism</a>),
+then that method should be used if the client supports it. If the specified method is not supported
+then the client should fallback to to loading the font non-incrementally.</p>
     <li data-md>
-     <p>If the client does not support the specified method then it should fallback to to loading
-the font non-incrementally.</p>
-    <li data-md>
-     <p>Otherwise if the client does not know which particular IFT method that the server hosting the font
-supports then, <a href="#method-negotiation">method negotiation</a> should be used to determine
-the method.</p>
-   </ol>
+     <p>Otherwise if the client does not know which particular IFT method(s) that the server hosting the
+font supports then, <a href="#method-negotiation">method negotiation</a> should be used to
+determine the method.</p>
+   </ul>
    <p class="note" role="note"><span>Note:</span> the most recently specified method by the content takes precedence. For example if on a site the
 first page specifies to use the patch subset method for a font URL, but the second page specifies
 range request for the same font URL then the second page should load the font using range request.

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="1539682d227da9c45435af11c3aa3a60702225b2" name="document-revision">
+  <meta content="3f0d6bb8b86e14dabfdc1af153a6e5ce18c83b0e" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -551,8 +551,7 @@ then that method should be used if the client supports it. If the specified meth
 then the client should fallback to to loading the font non-incrementally.</p>
     <li data-md>
      <p>Otherwise if the client does not know which particular IFT method(s) that the server hosting the
-font supports then, <a href="#method-negotiation">method negotiation</a> should be used to
-determine the method.</p>
+font supports, such as when the <code>incremental-auto</code> font tech keyword is used, then <a href="#method-negotiation">method negotiation</a> should be used to determine the method.</p>
    </ul>
    <p class="note" role="note"><span>Note:</span> the most recently specified method by the content takes precedence. For example if on a site the
 first page specifies to use the patch subset method for a font URL, but the second page specifies

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="b6cc57d5eee09e3be1fb9dda1932eb011282cfcd" name="document-revision">
+  <meta content="1135beb903d73364c643bfc8e1cf66f7f933326d" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -566,7 +566,7 @@ servers may support different IFT methods, so a negotation occurs as such:</p>
    <ol>
     <li data-md>
      <p>The browser makes the first request to the server using the GET HTTP method (<a href="https://www.rfc-editor.org/rfc/rfc9110#name-get">HTTP Semantics § name-get</a>).
- If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant <a data-link-type="dfn">patch request header</a>. If the client prefers the range-request method, it does not send the
+ If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant <a data-link-type="dfn" href="#patch-request-header" id="ref-for-patch-request-header">patch request header</a>. If the client prefers the range-request method, it does not send the
  header.</p>
     <li data-md>
      <p>If the server receives the patch request header and wishes to honor it, the server must reply with
@@ -628,16 +628,16 @@ servers may support different IFT methods, so a negotation occurs as such:</p>
     <tbody>
      <tr>
       <th>Server supports both range-request method and patch-subset method 
-      <td>Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Because all patch-subset servers must support the range-request method, the server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method. 
-      <td>Client makes initial request with query parameter. Server replies with the patch-subset magic number, and client/server commence using patch-subset method. 
+      <td>Client makes initial request without the patch request header, and possibly with the <code>Range</code> header. Because all patch-subset servers must support the range-request method, the server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method. 
+      <td>Client makes initial request with the patch request header. Server replies with the patch-subset magic number, and client/server commence using patch-subset method. 
      <tr>
       <th>Server supports only range-request method 
       <td>Same as above. 
-      <td>Client makes initial request with query parameter. Server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method. 
+      <td>Client makes initial request with the patch request header. Server replies with <code>Accept-Ranges</code> and initial font data. Client/server commence using range-request method. 
      <tr>
       <th>Server supports neither 
-      <td>Client makes initial request without query parameter, and possibly with the <code>Range</code> header. Server replies without <code>Accept-Ranges</code> header, and sends the full font file to the client from beginning to end. 
-      <td>Client makes initial request to server with query parameter. Server does not reply with the patch-subset magic number, and sends the full font file to the client from beginning to end. 
+      <td>Client makes initial request without the patch request header, and possibly with the <code>Range</code> header. Server replies without <code>Accept-Ranges</code> header, and sends the full font file to the client from beginning to end. 
+      <td>Client makes initial request to server with the patch request header. Server does not reply with the patch-subset magic number, and sends the full font file to the client from beginning to end. 
    </table>
    <h2 class="heading settled" data-level="4" id="patch-incxfer"><span class="secno">4. </span><span class="content">Patch Based Incremental Transfer</span><a class="self-link" href="#patch-incxfer"></a></h2>
    <h3 class="heading settled" data-level="4.1" id="font-subset"><span class="secno">4.1. </span><span class="content">Font Subset</span><a class="self-link" href="#font-subset"></a></h3>
@@ -1388,9 +1388,9 @@ can be cached, or null.</p>
       <li data-md>
        <p>If <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method①">method</a> is "POST" then, request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-body" id="ref-for-concept-request-body">body</a> must be a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR.</p>
       <li data-md>
-       <p>Otherwise if <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method②">method</a> is "GET" then, URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-query" id="ref-for-concept-url-query">query</a> must contain a <dfn data-dfn-type="dfn" data-export data-lt="query parameter" id="query-parameter">query
-  parameter<a class="self-link" href="#query-parameter"></a></dfn> "request" whose value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then
-  base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a>.</p>
+       <p>Otherwise if <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method②">method</a> is "GET" then, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header">header</a> with name <code>Font-Patch-Request</code> (the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="patch-request-header">patch request header</dfn>)
+ and whose value is a single <a href="#PatchRequest"><code>PatchRequest</code></a> object encoded via CBOR and then
+  base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648">[rfc4648]</a> must be added to the request’s header list.</p>
      </ul>
      <p>Any request and/or url parameters which are not specified here should be set based on
  the user agent’s normal handling for font requests. For example if this font load is
@@ -1454,6 +1454,8 @@ can be cached, or null.</p>
     <li data-md>
      <p>Goto <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a>.</p>
    </ol>
+   <p class="note" role="note"><span>Note:</span> POST is preferred for the HTTP method since it will not cause a CORS preflight request
+and the request object is more compactly encoded. GET should only be used during <a href="#method-negotiation">method negotiation</a>.</p>
    <h5 class="heading settled" data-level="4.4.2.1" id="handling-patch-response"><span class="secno">4.4.2.1. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h5>
    <p>If a server is able to succsessfully process a <a href="#PatchRequest"><code>PatchRequest</code></a> it will respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> code 200 and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body">body</a> of the response will
 be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single <a href="#PatchResponse"><code>PatchResponse</code></a> object encoded via CBOR. The client
@@ -2345,7 +2347,7 @@ itself be statically compressed.</p>
   <ul class="index">
    <li><a href="#corpus">corpus</a><span>, in § 5.2.6</span>
    <li><a href="#outline-table">outline table</a><span>, in § 5.2.4</span>
-   <li><a href="#query-parameter">query parameter</a><span>, in § 4.4.2</span>
+   <li><a href="#patch-request-header">patch request header</a><span>, in § 4.4.2</span>
    <li><a href="#range-request-optimized-font">range-request optimized font</a><span>, in § 5.2.2</span>
    <li><a href="#range-request-threshold">range-request threshold</a><span>, in § 5.3.1</span>
    <li><a href="#usage-document-frequency">usage document frequency</a><span>, in § 5.2.6</span>
@@ -2376,6 +2378,12 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-concept-request-destination">4.4.2. Extending the Font Subset</a>
     <li><a href="#ref-for-concept-request-destination①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-header">
+   <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-header">4.4.2. Extending the Font Subset</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-method">
@@ -2415,12 +2423,6 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-concept-url-path③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-url-path④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-query">
-   <a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-url-query">4.4.2. Extending the Font Subset</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
    <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
@@ -2441,6 +2443,7 @@ itself be statically compressed.</p>
      <li><span class="dfn-paneled" id="term-for-concept-response-body">body <small>(for response)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-request-cache-mode">cache mode</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-destination">destination</span>
+     <li><span class="dfn-paneled" id="term-for-concept-header">header</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-method">method</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-mode">mode</span>
      <li><span class="dfn-paneled" id="term-for-concept-response-status">status <small>(for response)</small></span>
@@ -2450,7 +2453,6 @@ itself be statically compressed.</p>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-concept-url-path">path</span>
-     <li><span class="dfn-paneled" id="term-for-concept-url-query">query</span>
      <li><span class="dfn-paneled" id="term-for-concept-url-scheme">scheme</span>
     </ul>
   </ul>
@@ -2513,6 +2515,12 @@ itself be statically compressed.</p>
    <div class="issue"> <a href="https://github.com/w3c/IFT/issues/58">Supporting fonts with composite glyphs via range-request</a> <a class="issue-return" href="#issue-5533a524" title="Jump to section">↵</a></div>
    <div class="issue"> <a href="https://github.com/w3c/IFT/issues/61">Populate suggested character ordering for range-request method</a> <a class="issue-return" href="#issue-763d5c98" title="Jump to section">↵</a></div>
   </div>
+  <aside class="dfn-panel" data-for="patch-request-header">
+   <b><a href="#patch-request-header">#patch-request-header</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-patch-request-header">3.1. IFT Method Negotiation</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="range-request-optimized-font">
    <b><a href="#range-request-optimized-font">#range-request-optimized-font</a></b><b>Referenced in:</b>
    <ul>


### PR DESCRIPTION
This introduces three css font tech keywords to aid method selection:
- incremental-patch: tells client to use patch subset
- incremental-range: tells client to use range request
- incremental-auto: tells client to use the existing method negotiation mechanism.

Additionally the negotiation mechanism has been revised to use a GET + Header in the initial request instead of GET + a URL query parameter. This addresses feedback about the use of a URL query parameter.

This is based on the findings of [Revisting Method Negotiation in Incremental Transfer](https://docs.google.com/document/d/1IcPg4o5k4OOmfLCfa1z2wQl6MD-kPBrahtcb4r-97ZU/edit?usp=sharing&resourcekey=0-9WtXKj_y4uihiB7K740xMQ)

Marking as draft, pending discussions with CSS wg about changing the incremental font tech keyword.

This will resolve the following issues:
#107 
#75 
#63 
#30 

and is relevant to some of the discussion in #57


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/113.html" title="Last updated on Aug 25, 2022, 9:23 PM UTC (b93ac7b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/113/7f379af...b93ac7b.html" title="Last updated on Aug 25, 2022, 9:23 PM UTC (b93ac7b)">Diff</a>