### PR TITLE
Add a 'should' requirement to have client support both methods.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -244,7 +244,8 @@ IFT Method Selection {#method-selection}
 
 <em>This section is general to both IFT methods.</em>
 
-The client selects the IFT method to utilize for a font load using the following procedure:
+The client should have support for both patch subset and range request IFT. The client selects the
+IFT method to utilize for a font load using the following procedure:
 
 *  If the content has specified which method to use, such as via the <code>incremental-patch</code> or
     <code>incremental-range</code> font tech keyword (see: <a href="#opt-in">opt-in mechanism</a>),

--- a/Overview.bs
+++ b/Overview.bs
@@ -38,7 +38,7 @@ spec:fetch; type:dfn; for:/; text:status
   },
 
   "Shared-Brotli": {
-    "href": "https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-08",
+    "href": "https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09",
     "authors": [
       "J. Alakuijala",
       "T. Duong",

--- a/Overview.bs
+++ b/Overview.bs
@@ -13,8 +13,8 @@ Editor: Myles C. Maxfield, Apple Inc., mmaxfield@apple.com, w3cid 77180
 Editor: Garret Rieger, Google Inc., grieger@google.com, w3cid 73905
 Abstract: This specification defines two methods to incrementally transfer fonts from server to client.
           Incremental transfer allows clients to load only the portions of the font they actually need
-	  which speeds up font loads and reduces data transfer needed to load the fonts. A font can
-	  be loaded over multiple requests where each request incrementally adds additional data.
+          which speeds up font loads and reduces data transfer needed to load the fonts. A font can
+          be loaded over multiple requests where each request incrementally adds additional data.
 </pre>
 
 <!--
@@ -304,15 +304,15 @@ If the content specifies the range request method:
             <th>Client supports range-request method
             <th>Client does not support range-request method
     <tbody>
-	<tr>
-	    <th>Server supports range-request method
-	    <td>Range-request method is used.
-	    <td>Client falls back to non-incremental load of the full font file.
-	<tr>
-	    <th>Server does not support range-request method.
-	    <td>Response is missing accept-ranges header. Client falls back to
-	        non-incremental load of the full font file.
-	    <td>Client falls back to non-incremental load of the full font file.
+        <tr>
+            <th>Server supports range-request method
+            <td>Range-request method is used.
+            <td>Client falls back to non-incremental load of the full font file.
+        <tr>
+            <th>Server does not support range-request method.
+            <td>Response is missing accept-ranges header. Client falls back to
+                non-incremental load of the full font file.
+            <td>Client falls back to non-incremental load of the full font file.
 </table>
 
 If the content specifies the patch subset method:
@@ -324,16 +324,16 @@ If the content specifies the patch subset method:
             <th>Client supports patch-subset method
             <th>Client does not support patch-subset method
     <tbody>
-	<tr>
-	    <th>Server supports patch-subset method
-	    <td>Patch-subset method is used.
-	    <td>Client falls back to non-incremental load of the full font file.
-	<tr>
-	    <th>Server does not support patch-subset method
-	    <td>Response is missing magic number. Client falls back to non-incremental load of the
-	    full font file.
-	    <td>Client falls back to non-incremental load of the
-	    full font file.
+        <tr>
+            <th>Server supports patch-subset method
+            <td>Patch-subset method is used.
+            <td>Client falls back to non-incremental load of the full font file.
+        <tr>
+            <th>Server does not support patch-subset method
+            <td>Response is missing magic number. Client falls back to non-incremental load of the
+            full font file.
+            <td>Client falls back to non-incremental load of the
+            full font file.
 </table>
 
 If the content does not specify a specific method:

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="bc5b5fd23d7241a81888faeaaab41af2ac7dc9b9" name="document-revision">
+  <meta content="36428e06c0e0f2b4fc0f08d5ca1e91b504e60fc4" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -551,7 +551,8 @@ should use the patch subset IFT method to load the font.
 request of method negotiation, as the initial request sets a custom header.</p>
    <h2 class="heading settled" data-level="3" id="method-selection"><span class="secno">3. </span><span class="content">IFT Method Selection</span><a class="self-link" href="#method-selection"></a></h2>
    <p><em>This section is general to both IFT methods.</em></p>
-   <p>The client selects the IFT method to utilize for a font load using the following procedure:</p>
+   <p>The client should have support for both patch subset and range request IFT. The client selects the
+IFT method to utilize for a font load using the following procedure:</p>
    <ul>
     <li data-md>
      <p>If the content has specified which method to use, such as via the <code>incremental-patch</code> or <code>incremental-range</code> font tech keyword (see: <a href="#opt-in">opt-in mechanism</a>),

--- a/Overview.html
+++ b/Overview.html
@@ -4,9 +4,9 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Incremental Font Transfer</title>
   <meta content="WD" name="w3c-status">
-  <meta content="Bikeshed version 37b7e7e68, updated Fri May 27 15:08:11 2022 -0700" name="generator">
+  <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="5516b030e2fc4405507c88439a09a28b59669ec0" name="document-revision">
+  <meta content="bc5b5fd23d7241a81888faeaaab41af2ac7dc9b9" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -190,6 +190,14 @@ a.self-link:hover {
 .heading > a.self-link {
     font-size: 83%;
 }
+.example > a.self-link,
+.note > a.self-link,
+.issue > a.self-link {
+    /* These blocks are overflow:auto, so positioning outside
+       doesn't work. */
+    left: auto;
+    right: 0;
+}
 li > a.self-link {
     left: calc(-1 * (3.5rem - 26px) - 2em);
 }
@@ -253,8 +261,8 @@ dfn > a.self-link::before      { content: "#"; }
    <p>This specification defines two methods to incrementally transfer fonts from server to client.
 
           Incremental transfer allows clients to load only the portions of the font they actually need
-	  which speeds up font loads and reduces data transfer needed to load the fonts. A font can
-	  be loaded over multiple requests where each request incrementally adds additional data.</p>
+          which speeds up font loads and reduces data transfer needed to load the fonts. A font can
+          be loaded over multiple requests where each request incrementally adds additional data.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
@@ -597,7 +605,7 @@ servers may support different IFT methods, so a negotation occurs as such:</p>
      <tr>
       <th>Server does not support range-request method. 
       <td>Response is missing accept-ranges header. Client falls back to
-	        non-incremental load of the full font file. 
+                non-incremental load of the full font file. 
       <td>Client falls back to non-incremental load of the full font file. 
    </table>
    <p>If the content specifies the patch subset method:</p>
@@ -615,9 +623,9 @@ servers may support different IFT methods, so a negotation occurs as such:</p>
      <tr>
       <th>Server does not support patch-subset method 
       <td>Response is missing magic number. Client falls back to non-incremental load of the
-	    full font file. 
+            full font file. 
       <td>Client falls back to non-incremental load of the
-	    full font file. 
+            full font file. 
    </table>
    <p>If the content does not specify a specific method:</p>
    <table class="data">
@@ -2359,6 +2367,12 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-at-font-face-rule">2. Opt-In Mechanism</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-request-body">
+   <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-request-body">4.4.2. Extending the Font Subset</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-body">
    <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
@@ -2401,6 +2415,12 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-concept-request-mode①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-status">
+   <a href="https://fetch.spec.whatwg.org/#concept-status">https://fetch.spec.whatwg.org/#concept-status</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-status">4.4.2.2. Handling Invalid Response from the Server</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-status">
    <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
@@ -2434,19 +2454,21 @@ itself be statically compressed.</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio">[css-fonts-5]</a> defines the following terms:
+    <a data-link-type="biblio">[CSS-FONTS-5]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-at-font-face-rule">@font-face</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[fetch]</a> defines the following terms:
+    <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
+     <li><span class="dfn-paneled" id="term-for-concept-request-body">body <small>(for request)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-response-body">body <small>(for response)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-request-cache-mode">cache mode</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-destination">destination</span>
      <li><span class="dfn-paneled" id="term-for-concept-header">header</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-method">method</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-mode">mode</span>
+     <li><span class="dfn-paneled" id="term-for-concept-status">status</span>
      <li><span class="dfn-paneled" id="term-for-concept-response-status">status <small>(for response)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-request-url">url</span>
     </ul>
@@ -2461,7 +2483,7 @@ itself be statically compressed.</p>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-css-fonts-4">[CSS-FONTS-4]
-   <dd>CSS Fonts Module Level 4 URL: <a href="https://www.w3.org/TR/css-fonts-4/">https://www.w3.org/TR/css-fonts-4/</a>
+   <dd>John Daggett; Myles Maxfield; Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-4/"><cite>CSS Fonts Module Level 4</cite></a>. 21 December 2021. WD. URL: <a href="https://www.w3.org/TR/css-fonts-4/">https://www.w3.org/TR/css-fonts-4/</a>
    <dt id="biblio-css-fonts-5">[CSS-FONTS-5]
    <dd>Myles Maxfield; Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-5/"><cite>CSS Fonts Module Level 5</cite></a>. 21 December 2021. WD. URL: <a href="https://www.w3.org/TR/css-fonts-5/">https://www.w3.org/TR/css-fonts-5/</a>
    <dt id="biblio-fast-hash">[FAST-HASH]

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="36428e06c0e0f2b4fc0f08d5ca1e91b504e60fc4" name="document-revision">
+  <meta content="bce3e68f4eff42e9304651add1bbc1b3e96ad2bb" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -2512,7 +2512,7 @@ itself be statically compressed.</p>
    <dt id="biblio-rfc9112">[RFC9112]
    <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9112"><cite>HTTP/1.1</cite></a>. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9112">https://www.rfc-editor.org/rfc/rfc9112</a>
    <dt id="biblio-shared-brotli">[Shared-Brotli]
-   <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-08"><cite>Shared Brotli Compressed Data Format</cite></a>. 27 Jul 2021. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-08">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-08</a>
+   <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09"><cite>Shared Brotli Compressed Data Format</cite></a>. 27 Jul 2021. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09</a>
    <dt id="biblio-truetype">[TRUETYPE]
    <dd><a href="https://developer.apple.com/fonts/TrueType-Reference-Manual/"><cite>TrueType™ Reference Manual</cite></a>. URL: <a href="https://developer.apple.com/fonts/TrueType-Reference-Manual/">https://developer.apple.com/fonts/TrueType-Reference-Manual/</a>
    <dt id="biblio-url">[URL]


### PR DESCRIPTION
Fixes #57 also bumps shared brotli spec version so it's no longer pointing at an expired one for #101.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/126.html" title="Last updated on Nov 9, 2022, 6:55 PM UTC (04f6f72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/126/bc5b5fd...04f6f72.html" title="Last updated on Nov 9, 2022, 6:55 PM UTC (04f6f72)">Diff</a>