### PR TITLE
Update remaining algorithms to use markup

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1244,64 +1244,87 @@ The algorithm:
      example, on slower connections it may be more performant to request extra codepoints if
      that is likely to prevent a future request from needing to be sent.
 
-<!-- TODO: change to algorithm ref -->
-3. Invoke [[#handling-patch-response]] with the response from the server and return the result.
+3. Invoke [$Handling PatchResponse$] with the response from the server and return the result.
 
 Note: POST is preferred for the HTTP method since it will not cause a CORS preflight request
 and the request object is more compactly encoded. GET should only be used during
 <a href="#method-negotiation">method negotiation</a>.
 
-#### Handling PatchResponse #### {#handling-patch-response}
+<h5 algorithm id="handling-patch-response">Handling PatchResponse</h5>
 
 If a server is able to succsessfully process a [=PatchRequest=]
 it will respond with HTTP [=response/status=] code 200 and the [=response/body=] of the response will
-be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single
-[=PatchResponse=] object encoded via CBOR. The client
-should interpret and process the fields of the object as follows:
+be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single [=PatchResponse=] object encoded
+via CBOR. The client should use the following algorithm to interpret and process the fields of the
+object.
+
+<dfn abstract-op>Handling PatchResponse</dfn>
+
+Inputs:
+
+<!-- TODO: take the whole response, not just the object -->
+
+* <var>patch response</var>: a PatchResponse object from a successful [=PatchRequest=].
+
+* <var>client state</var> (optional): previously saved [=client state=].
+
+The algorithm outputs:
+
+* Client State: [=client state=] that has been updated to contain a [=font subset=] which covers at
+    least the requested subset definition.
+
+* Cache fields: HTTP cache fields [[rfc9111#name-field-definitions]] describing how client state
+    can be cached, or null.
+
+The algorithm:
+<!-- TODO: Redirect to error handling on non-200 response code -->
 
 1.  If field [=PatchResponse/replacement=] is set then: the byte array in this field is a binary patch
      in the format specified by [=PatchResponse/patch_format=]. Apply the binary patch to a base which
      is an empty byte array. Replace the [=Client State/client font subset|font subset=] in the input
-     client state with the result of the patch application.
+     <var>client state</var> with the result of the patch application.
 
 2. If field [=PatchResponse/patch=] is set then:  the byte array in this field is a binary patch
     in the format specifiedy [=PatchResponse/patch_format=]. Apply the binary patch to the
     [=Client State/client font subset|font subset=] from the input client state. Replace the
-    [=Client State/client font subset|font subset=] in the input client state with the result of the
-    patch application.
+    [=Client State/client font subset|font subset=] in the input <var>client state</var> with the
+    result of the patch application.
 
+<!-- TODO: use algorithm ref for error handling -->
 3. If either [=PatchResponse/replacement=] or [=PatchResponse/patch=] is set then:
     <a href="#computing-checksums">compute the checksum</a> of the [=font subset=] produced by the patch
-    application in steps 1 or 2. If the computed checksum is not equal to [=PatchResponse/patched_checksum=]
-    this is a recoverable error. Follow the procedure in [[#client-side-checksum-mismatch]]. Otherwise
-    update the [=Client State/original font checksum=] in the input client state with the value in
-    [=PatchResponse/original_font_checksum=].
+    application in steps 1 or 2. If the computed checksum is not equal to
+    [=PatchResponse/patched_checksum=] this is a recoverable error. Follow the procedure in
+    [[#client-side-checksum-mismatch]]. Otherwise update the [=Client State/original font checksum=] in
+    the input <var>client state</var> with the value in [=PatchResponse/original_font_checksum=].
 
 4. If fields [=PatchResponse/codepoint_ordering=] and [=PatchResponse/ordering_checksum=] are set then
-    update the [=Client State/codepoint reordering checksum=] in the input client state with the new
-    values specified by these two fields. If neither [=PatchResponse/replacement=] nor
+    update the [=Client State/codepoint reordering checksum=] in the input <var>client state</var> with
+    the new values specified by these two fields. If neither [=PatchResponse/replacement=] nor
     [=PatchResponse/patch=] are set, then the client should resend the request that triggered this
-    response but use the new codepoint ordering provided in this response.
+    response but use the new codepoint ordering provided in this response. Go back to step 1 to process
+    the response.
 
 5. If [=PatchResponse/original_features=] is set and the client has opted to save them then replace the
-    [=Client State/original font feature list=] in the input client state with the value from the
-    response.
+    [=Client State/original font feature list=] in the input <var>client state</var> with the value from    the response.
 
 6. If [=PatchResponse/original_axis_space=] is set then update the
-    [=Client State/original font axis space=] in the input client state with the value specified in
-    this field.
+    [=Client State/original font axis space=] in the input <var>client state</var> with the value
+    specified in this field.
 
 7. If [=PatchResponse/subset_axis_space=] is set then update the
-    [=Client State/subset axis space=] in the input client state with the value specified in this field.
+    [=Client State/subset axis space=] in the input <var>client state</var> with the value specified in
+    this field.
 
-After processing the response, return the updated input client state and any cache headers that were
-set on the response.
+After processing the response, return the updated input <var>client state</var> and any cache headers
+that were set on the response.
 
 #### Handling Invalid Response from the Server #### {#invalid-server-response}
 
 
 If the response a client receives from the server has a [=response/status=] code other than 200:
 
+<!-- TODO: use aglorithm ref -->
 *  If it is a redirect [=status=]: follow normal redirect handling, such as
      [[fetch#http-redirect-fetch]] and then go back to [[#handling-patch-response]].
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1124,6 +1124,8 @@ The inputs to this algorithm are:
 * <var>client state</var> (optional): previously saved [=client state=] for the given
     font url, or null.
 
+<!-- TODO specify this must be a super set of what's in client state -->
+<!-- TODO update *_have definitions to specify the subtraction of this and client state -->
 * <var>desired subset definition</var>: a [=font subset definition|description=] of the desired
     minimum [=font subset=].
 
@@ -1308,15 +1310,21 @@ The algorithm:
     [=Client State/client font subset|font subset=] in the input <var>client state</var> with the
     result of the patch application.
 
-<!-- TODO: use algorithm ref for error handling -->
 6. If either [=PatchResponse/replacement=] or [=PatchResponse/patch=] is set then:
     <a href="#computing-checksums">compute the checksum</a> of the [=font subset=] produced by the
-    patch application in steps 1 or 2. If the computed checksum is not equal to
-    [=PatchResponse/patched_checksum=] this is a recoverable error. Follow the procedure in
-    [[#client-side-checksum-mismatch]]. Otherwise update the [=Client State/original font checksum=] in
-    the input <var>client state</var> with the value in [=PatchResponse/original_font_checksum=].
+    patch application in steps 1 or 2.
 
-<!-- TODO invoke request sending algorithm -->
+    *  If the computed checksum is not equal to [=PatchResponse/patched_checksum=] this is a
+        recoverable error. Discard the saved client state and invoke [$Extend the font subset$] to
+        resend the request with the same arguments as the original request, except client state is set
+        to null. If the resent request also results in a checksum mismatch then this is an error. The
+        <!-- TODO algorithm ref -->
+        client must not resend the request again and should invoke [[#font-load-failed]] and return the
+        result. Otherwise return the result from the call to [$Extend the font subset$].
+
+    *  Otherwise update the [=Client State/original font checksum=] in
+        the input <var>client state</var> with the value in [=PatchResponse/original_font_checksum=].
+
 7. If fields [=PatchResponse/codepoint_ordering=] and [=PatchResponse/ordering_checksum=] are set then
     update the [=Client State/codepoint reordering checksum=] in the input <var>client state</var> with
     the new values specified by these two fields. If neither [=PatchResponse/replacement=] nor
@@ -1338,21 +1346,6 @@ The algorithm:
 
 After processing the response, return the updated input <var>client state</var> and any cache headers
 that were set on the response.
-
-#### Client Side Checksum Mismatch #### {#client-side-checksum-mismatch}
-
-If the checksum of the [=font subset=] computed by the client does not match the
-[=PatchResponse/patched_checksum=] in the server's response then the client should:
-
-1. Discard the input client state for this font.
-
-<!-- TODO: specify the arguments to the extension algo -->
-2. Invoke [$Extend the font subset$] to resend the request. Set the
-    [=PatchRequest/codepoints_needed=] field to the union of the codepoints in the discarded
-    [=font subset=] and the set of code points that the previous request was trying to add.
-
-    If the resent request also results in a checksum mismatch then this is an error. The client
-    must not resend the request again and should follow [[#font-load-failed]]
 
 #### Font Load Failed #### {#font-load-failed}
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -24,6 +24,7 @@ Abstract: This specification defines two methods to incrementally transfer fonts
 
 <pre class=link-defaults>
 spec:fetch; type:dfn; for:/; text:status
+spec:fetch; type:dfn; for:/; text:response
 </pre>
 
 <pre class=biblio>
@@ -1244,27 +1245,25 @@ The algorithm:
      example, on slower connections it may be more performant to request extra codepoints if
      that is likely to prevent a future request from needing to be sent.
 
-3. Invoke [$Handling PatchResponse$] with the response from the server and return the result.
+3. Invoke [$Handle server response$] with the response from the server and return the result.
 
 Note: POST is preferred for the HTTP method since it will not cause a CORS preflight request
 and the request object is more compactly encoded. GET should only be used during
 <a href="#method-negotiation">method negotiation</a>.
 
-<h5 algorithm id="handling-patch-response">Handling PatchResponse</h5>
+<h5 algorithm id="handling-patch-response">Handling Server Response</h5>
 
 If a server is able to succsessfully process a [=PatchRequest=]
 it will respond with HTTP [=response/status=] code 200 and the [=response/body=] of the response will
 be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single [=PatchResponse=] object encoded
-via CBOR. The client should use the following algorithm to interpret and process the fields of the
+via CBOR. The client uses the following algorithm to interpret and process the fields of the
 object.
 
-<dfn abstract-op>Handling PatchResponse</dfn>
+<dfn abstract-op>Handle server response</dfn>
 
 Inputs:
 
-<!-- TODO: take the whole response, not just the object -->
-
-* <var>patch response</var>: a PatchResponse object from a successful [=PatchRequest=].
+* <var>server response</var>: HTTP [=response=] to a patch request.
 
 * <var>client state</var> (optional): previously saved [=client state=].
 
@@ -1277,64 +1276,68 @@ The algorithm outputs:
     can be cached, or null.
 
 The algorithm:
-<!-- TODO: Redirect to error handling on non-200 response code -->
 
-1.  If field [=PatchResponse/replacement=] is set then: the byte array in this field is a binary patch
+1.  If the <var>server response</var> has [=response/status=] other than 200:
+
+     *  If it is a redirect [=status=]: follow normal redirect handling, such as
+         [[fetch#http-redirect-fetch]] and then go back to step 1.
+
+     <!-- TODO algorithm ref -->
+     *  All other statuses, the [=font subset=] extension has failed. Invoke [[#font-load-failed]]
+         and return the result.
+
+2.  Check the first four bytes of the <var>server response</var> [=response/body=]. If they are
+     not equal to [0x49, 0x46, 0x54, 0x20] then this response is malformed.
+     <!-- TODO algorithm ref -->
+     Invoke [[#font-load-failed]] and return the result.
+
+3.  Interpret the remaining bytes of the <var>server response</var> [=response/body=] as a CBOR
+     encoded [=PatchResponse=]. If the bytes are not decodable with CBOR, or the
+     <!-- TODO algorithm ref -->
+     [=PatchResponse=] is not well formed, then this is an error. Invoke [[#font-load-failed]] and
+     return the result.
+
+4.  If field [=PatchResponse/replacement=] is set then: the byte array in this field is a binary patch
      in the format specified by [=PatchResponse/patch_format=]. Apply the binary patch to a base which
      is an empty byte array. Replace the [=Client State/client font subset|font subset=] in the input
      <var>client state</var> with the result of the patch application.
 
-2. If field [=PatchResponse/patch=] is set then:  the byte array in this field is a binary patch
+5. If field [=PatchResponse/patch=] is set then:  the byte array in this field is a binary patch
     in the format specifiedy [=PatchResponse/patch_format=]. Apply the binary patch to the
     [=Client State/client font subset|font subset=] from the input client state. Replace the
     [=Client State/client font subset|font subset=] in the input <var>client state</var> with the
     result of the patch application.
 
 <!-- TODO: use algorithm ref for error handling -->
-3. If either [=PatchResponse/replacement=] or [=PatchResponse/patch=] is set then:
-    <a href="#computing-checksums">compute the checksum</a> of the [=font subset=] produced by the patch
-    application in steps 1 or 2. If the computed checksum is not equal to
+6. If either [=PatchResponse/replacement=] or [=PatchResponse/patch=] is set then:
+    <a href="#computing-checksums">compute the checksum</a> of the [=font subset=] produced by the
+    patch application in steps 1 or 2. If the computed checksum is not equal to
     [=PatchResponse/patched_checksum=] this is a recoverable error. Follow the procedure in
     [[#client-side-checksum-mismatch]]. Otherwise update the [=Client State/original font checksum=] in
     the input <var>client state</var> with the value in [=PatchResponse/original_font_checksum=].
 
-4. If fields [=PatchResponse/codepoint_ordering=] and [=PatchResponse/ordering_checksum=] are set then
+<!-- TODO invoke request sending algorithm -->
+7. If fields [=PatchResponse/codepoint_ordering=] and [=PatchResponse/ordering_checksum=] are set then
     update the [=Client State/codepoint reordering checksum=] in the input <var>client state</var> with
     the new values specified by these two fields. If neither [=PatchResponse/replacement=] nor
     [=PatchResponse/patch=] are set, then the client should resend the request that triggered this
     response but use the new codepoint ordering provided in this response. Go back to step 1 to process
     the response.
 
-5. If [=PatchResponse/original_features=] is set and the client has opted to save them then replace the
-    [=Client State/original font feature list=] in the input <var>client state</var> with the value from    the response.
+8. If [=PatchResponse/original_features=] is set and the client has opted to save them then replace the
+    [=Client State/original font feature list=] in the input <var>client state</var> with the value
+    from the response.
 
-6. If [=PatchResponse/original_axis_space=] is set then update the
+9. If [=PatchResponse/original_axis_space=] is set then update the
     [=Client State/original font axis space=] in the input <var>client state</var> with the value
     specified in this field.
 
-7. If [=PatchResponse/subset_axis_space=] is set then update the
-    [=Client State/subset axis space=] in the input <var>client state</var> with the value specified in
-    this field.
+10. If [=PatchResponse/subset_axis_space=] is set then update the
+     [=Client State/subset axis space=] in the input <var>client state</var> with the value specified
+     in this field.
 
 After processing the response, return the updated input <var>client state</var> and any cache headers
 that were set on the response.
-
-#### Handling Invalid Response from the Server #### {#invalid-server-response}
-
-
-If the response a client receives from the server has a [=response/status=] code other than 200:
-
-<!-- TODO: use aglorithm ref -->
-*  If it is a redirect [=status=]: follow normal redirect handling, such as
-     [[fetch#http-redirect-fetch]] and then go back to [[#handling-patch-response]].
-
-*  All other statuses, the [=font subset=] extension has failed. Follow [[#font-load-failed]].
-
-If the response the client receives has a [=response/status=] code of 200, but the [=response/body=]
-is malformed. That is, it is missing the magic number, not decodable with CBOR, or the
-[=PatchResponse=] is not well formed:
-
-*  This is an error. Follow [[#font-load-failed]].
 
 #### Client Side Checksum Mismatch #### {#client-side-checksum-mismatch}
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1124,10 +1124,9 @@ The inputs to this algorithm are:
 * <var>client state</var> (optional): previously saved [=client state=] for the given
     font url, or null.
 
-<!-- TODO specify this must be a super set of what's in client state -->
-<!-- TODO update *_have definitions to specify the subtraction of this and client state -->
 * <var>desired subset definition</var>: a [=font subset definition|description=] of the desired
-    minimum [=font subset=].
+    minimum [=font subset=]. The subset definition must be a superset of the [=font subset=] in
+    <var>client state</var>.
 
 * <var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as [[fetch]]. The remainder
     of this section is desribed in terms of [[fetch#fetching]], but it is allowed to substitute
@@ -1190,7 +1189,8 @@ The algorithm:
          should not be set.
 
      *  [=PatchRequest/codepoints_needed=]: set to the set of codepoints that the client wants to
-         add to its [=font subset=] as defined in the <var>desired subset definition</var>. If the
+         add to its [=font subset=]. That is the codepoint set from <var>desired subset
+         definition</var> minus the codepoints already in [=Client State/Client font subset=]. If the
          <var>client state</var> has a [=Client State/codepoint reordering map=] for this font then
          this field should not be set.
 
@@ -1201,10 +1201,11 @@ The algorithm:
          font then this field should not be set.
 
      *  [=PatchRequest/indices_needed=]: encodes the set of codepoints that the client wants to add to
-         its [=font subset=] as defined in the <var>desired subset definition</var>. The codepoint
-         values are transformed to indices by applying the [=Client State/codepoint reordering map=]
-         to each codepoint value. If the client does not have a codepoint ordering for this font then
-         this field should not be set.
+         its [=font subset=]. That is the codepoint set from <var>desired subset
+         definition</var> minus the codepoints already in [=Client State/Client font subset=]. The
+         codepoint values are transformed to indices by applying the [=Client State/codepoint
+         reordering map=] to each codepoint value. If the client does not have a codepoint ordering
+         for this font then this field should not be set.
 
      *  [=PatchRequest/features_have=]: set to the list of
          <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">
@@ -1214,12 +1215,13 @@ The algorithm:
          data for features present in the [=original font=] then this field can be unset.
 
      *  [=PatchRequest/features_needed=]: set to the list of feature tags that the client wants to add
-         to the current [=font subset=] as defined in the <var>desired subset definition</var>.
-         Alternatively, if the client wishes to add all features from the [=original font=] to it's
+         to the current [=font subset=]. That is the feature set from <var>desired subset
+         definition</var> minus the set of features already in [=Client State/Client font subset=].
+         If the client wishes to add all remaining layout features from the [=original font=] to it's
          subset then this field should be unset.
 
-     *  [=PatchRequest/axis_space_have=]: set to the current value of [=Client State/subset axis space=]
-         saved in the <var>client state</var> for this font.
+     *  [=PatchRequest/axis_space_have=]: set to the current value of
+         [=Client State/subset axis space=] saved in the <var>client state</var> for this font.
 
      *  [=PatchRequest/axis_space_needed=]: set to the intervals of each variable axis in the
          [=original font=] that the client wants to add to its [=font subset=] as defined in the

--- a/Overview.bs
+++ b/Overview.bs
@@ -1361,19 +1361,28 @@ If the font load or extension has failed the client should choose one of the fol
 Regardless of which of the above options are used, the saved client state for this font must be
 discarded.
 
-### Load a Font in a User Agent with a HTTP Cache ### {#load-a-font}
+<h4 algorithm id="load-a-font">Load a Font in a User Agent with a HTTP Cache</h4>
 
 The previous section [[#extend-subset]] provides no guidance on how a user agent should handle
 saving client state between invocations of the subset extension algorithm. This section provides an
 algorithm that user agents which implement [[fetch]] should use to save client state to the user
 agent's HTTP cache ([[RFC9111]]).
 
+<dfn abstract-op>Load a font with a HTTP Cache</h4>
+
 The inputs to this algorithm:
 
-*  Font URL: a URL where the font to be extended is located.
+* <var>font URL</var>: a URL where the font to be extended is located.
 
-*  Desired Subset Definition: a [=font subset definition|description=] of the desired
+* <var>fragment identifier</var> (optional): if the font at the font url is a collection of fonts,
+    the fragment identifier ([[rfc8081#section-4.2]]) identifies a single font within the collection.
+
+* <var>desired subset definition</var>: a [=font subset definition|description=] of the desired
     minimum [=font subset=].
+
+* <var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as [[fetch]]. The remainder
+    of this section is desribed in terms of [[fetch#fetching]], but it is allowed to substitute
+    whatever HTTP fetching algorithm the user agent supports.
 
 The algorithm outputs:
 
@@ -1395,30 +1404,32 @@ The algorithm:
 
      * The request [=request/cache mode=] is "only-if-cached".
 
-<!-- TODO: use algorithm ref -->
 2.  If the request is successful and the response is "fresh" ([[RFC9111#name-freshness]])
-     then invoke [[#extend-subset]] with:
+     then invoke [$Extend the font subset$] with:
 
-     *  Font url set to the input font url.
+     *  Font url set to the input <var>font URL</var>.
+
+     *  Fragment identifier set to the input <var>fragment identifier</var>
 
      *  Client state set to the response.
 
-     *  Desired subset definition set to the input subset definition.
+     *  Desired subset definition set to the input <var>desired subset definition</var>.
 
-     *  Fetch algorithm set to [[fetch]].
+     *  Fetch algorithm set to the input <var>fetch algorithm</var>.
 
      Once that returns go to step 4.
 
-<!-- TODO: use algorithm ref -->
-3.  Otherwise, invoke [[#extend-subset]] with:
+3.  Otherwise, invoke [$Extend the font subset$] with:
 
-     *  Font url set to the input font url.
+     *  Font url set to the input <var>font URL</var>.
+
+     *  Fragment identifier set to the input <var>fragment identifier</var>
 
      *  Client state set to null.
 
-     *  Desired subset definition set to the input subset definition.
+     *  Desired subset definition set to the input <var>desired subset definition</var>.
 
-     *  Fetch algorithm set to [[fetch]].
+     *  Fetch algorithm set to the input <var>fetch algorithm</var>.
 
      Once that returns go to step 4.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1255,7 +1255,7 @@ Note: POST is preferred for the HTTP method since it will not cause a CORS prefl
 and the request object is more compactly encoded. GET should only be used during
 <a href="#method-negotiation">method negotiation</a>.
 
-<h5 algorithm id="handling-patch-response">Handling Server Response</h5>
+<h4 algorithm id="handling-patch-response">Handling Server Response</h4>
 
 If a server is able to succsessfully process a [=PatchRequest=]
 it will respond with HTTP [=response/status=] code 200 and the [=response/body=] of the response will
@@ -1286,20 +1286,17 @@ The algorithm:
      *  If it is a redirect [=status=]: follow normal redirect handling, such as
          [[fetch#http-redirect-fetch]] and then go back to step 1.
 
-     <!-- TODO algorithm ref -->
-     *  All other statuses, the [=font subset=] extension has failed. Invoke [[#font-load-failed]]
-         and return the result.
+     *  All other statuses, the [=font subset=] extension has failed. Invoke
+         [$Handle failed font load$] and return the result.
 
 2.  Check the first four bytes of the <var>server response</var> [=response/body=]. If they are
      not equal to [0x49, 0x46, 0x54, 0x20] then this response is malformed.
-     <!-- TODO algorithm ref -->
-     Invoke [[#font-load-failed]] and return the result.
+     Invoke [$Handle failed font load$] and return the result.
 
 3.  Interpret the remaining bytes of the <var>server response</var> [=response/body=] as a CBOR
      encoded [=PatchResponse=]. If the bytes are not decodable with CBOR, or the
-     <!-- TODO algorithm ref -->
-     [=PatchResponse=] is not well formed, then this is an error. Invoke [[#font-load-failed]] and
-     return the result.
+     [=PatchResponse=] is not well formed, then this is an error. Invoke [$Handle failed font load$]
+     and return the result.
 
 4.  If field [=PatchResponse/replacement=] is set then: the byte array in this field is a binary patch
      in the format specified by [=PatchResponse/patch_format=]. Apply the binary patch to a base which
@@ -1320,9 +1317,8 @@ The algorithm:
         recoverable error. Discard the saved client state and invoke [$Extend the font subset$] to
         resend the request with the same arguments as the original request, except client state is set
         to null. If the resent request also results in a checksum mismatch then this is an error. The
-        <!-- TODO algorithm ref -->
-        client must not resend the request again and should invoke [[#font-load-failed]] and return the
-        result. Otherwise return the result from the call to [$Extend the font subset$].
+        client must not resend the request again and should invoke [$Handle failed font load$] and
+        return the result. Otherwise return the result from the call to [$Extend the font subset$].
 
     *  Otherwise update the [=Client State/original font checksum=] in
         the input <var>client state</var> with the value in [=PatchResponse/original_font_checksum=].
@@ -1347,9 +1343,9 @@ The algorithm:
      in this field.
 
 After processing the response, return the updated input <var>client state</var> and any cache headers
-that were set on the response.
+that were set on the <var>server response</var>.
 
-#### Font Load Failed #### {#font-load-failed}
+<dfn abstract-op>Handle failed font load</dfn>
 
 If the font load or extension has failed the client should choose one of the following options:
 
@@ -1357,7 +1353,7 @@ If the font load or extension has failed the client should choose one of the fol
       agent's existing font fallback mechanism for codepoints not covered by the subset.
 
 2.  The client may re-issue the request as a regular non incremental font fetch to the same
-      [=url/path=]. It must not include the patch subset request parameter. This will load
+      [=url/path=]. It must not include the patch subset request parameter or header. This will load
       the entire [=original font=].
 
 3.  Discard the saved [=font subset=], and use the user agent's existing font fallback mechanism.

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="80e3fef99cb0d880fed69ab292aaa51d7ff8c1c1" name="document-revision">
+  <meta content="843e56738d50ca0e9e44a4c399e1077715dd0e1e" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -360,8 +360,7 @@ dfn > a.self-link::before      { content: "#"; }
          <a href="#extend-subset"><span class="secno">4.4.2</span> <span class="content">Extending the Font Subset</span></a>
          <ol class="toc">
           <li><a href="#handling-patch-response"><span class="secno">4.4.2.1</span> <span class="content">Handling Server Response</span></a>
-          <li><a href="#client-side-checksum-mismatch"><span class="secno">4.4.2.2</span> <span class="content">Client Side Checksum Mismatch</span></a>
-          <li><a href="#font-load-failed"><span class="secno">4.4.2.3</span> <span class="content">Font Load Failed</span></a>
+          <li><a href="#font-load-failed"><span class="secno">4.4.2.2</span> <span class="content">Font Load Failed</span></a>
          </ol>
         <li><a href="#load-a-font"><span class="secno">4.4.3</span> <span class="content">Load a Font in a User Agent with a HTTP Cache</span></a>
        </ol>
@@ -1506,15 +1505,15 @@ can be cached, or null.</p>
       <li data-md>
        <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to step 1.</p>
       <li data-md>
-       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> extension has failed. Invoke <a href="#font-load-failed">§ 4.4.2.3 Font Load Failed</a> and return the result.</p>
+       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> extension has failed. Invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and return the result.</p>
      </ul>
     <li data-md>
      <p>Check the first four bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a>. If they are
  not equal to [0x49, 0x46, 0x54, 0x20] then this response is malformed.
- Invoke <a href="#font-load-failed">§ 4.4.2.3 Font Load Failed</a> and return the result.</p>
+ Invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and return the result.</p>
     <li data-md>
      <p>Interpret the remaining bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body②">body</a> as a CBOR
- encoded <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse②">PatchResponse</a>. If the bytes are not decodable with CBOR, or the <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse③">PatchResponse</a> is not well formed, then this is an error. Invoke <a href="#font-load-failed">§ 4.4.2.3 Font Load Failed</a> and
+ encoded <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse②">PatchResponse</a>. If the bytes are not decodable with CBOR, or the <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse③">PatchResponse</a> is not well formed, then this is an error. Invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and
  return the result.</p>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> is set then: the byte array in this field is a binary patch
@@ -1526,8 +1525,19 @@ in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_form
 result of the patch application.</p>
     <li data-md>
      <p>If either <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> or <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> is set then: <a href="#computing-checksums">compute the checksum</a> of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> produced by the
-patch application in steps 1 or 2. If the computed checksum is not equal to <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum①">patched_checksum</a> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 4.4.2.2 Client Side Checksum Mismatch</a>. Otherwise update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in
+patch application in steps 1 or 2.</p>
+     <ul>
+      <li data-md>
+       <p>If the computed checksum is not equal to <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum①">patched_checksum</a> this is a
+recoverable error. Discard the saved client state and invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset">Extend the font subset</a> to
+resend the request with the same arguments as the original request, except client state is set
+to null. If the resent request also results in a checksum mismatch then this is an error. The
+client must not resend the request again and should invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and return the
+result. Otherwise return the result from the call to <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset①">Extend the font subset</a>.</p>
+      <li data-md>
+       <p>Otherwise update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in
 the input <var>client state</var> with the value in <a data-link-type="dfn" href="#patchresponse-original_font_checksum" id="ref-for-patchresponse-original_font_checksum①">original_font_checksum</a>.</p>
+     </ul>
     <li data-md>
      <p>If fields <a data-link-type="dfn" href="#patchresponse-codepoint_ordering" id="ref-for-patchresponse-codepoint_ordering②">codepoint_ordering</a> and <a data-link-type="dfn" href="#patchresponse-ordering_checksum" id="ref-for-patchresponse-ordering_checksum②">ordering_checksum</a> are set then
 update the <a data-link-type="dfn" href="#client-state-codepoint-reordering-checksum" id="ref-for-client-state-codepoint-reordering-checksum①">codepoint reordering checksum</a> in the input <var>client state</var> with
@@ -1546,27 +1556,17 @@ specified in this field.</p>
    </ol>
    <p>After processing the response, return the updated input <var>client state</var> and any cache headers
 that were set on the response.</p>
-   <h5 class="heading settled" data-level="4.4.2.2" id="client-side-checksum-mismatch"><span class="secno">4.4.2.2. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h5>
-   <p>If the checksum of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> computed by the client does not match the <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum②">patched_checksum</a> in the server’s response then the client should:</p>
-   <ol>
-    <li data-md>
-     <p>Discard the input client state for this font.</p>
-    <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset">Extend the font subset</a> to resend the request. Set the <a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed①">codepoints_needed</a> field to the union of the codepoints in the discarded <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> and the set of code points that the previous request was trying to add.</p>
-     <p>If the resent request also results in a checksum mismatch then this is an error. The client
-must not resend the request again and should follow <a href="#font-load-failed">§ 4.4.2.3 Font Load Failed</a></p>
-   </ol>
-   <h5 class="heading settled" data-level="4.4.2.3" id="font-load-failed"><span class="secno">4.4.2.3. </span><span class="content">Font Load Failed</span><a class="self-link" href="#font-load-failed"></a></h5>
+   <h5 class="heading settled" data-level="4.4.2.2" id="font-load-failed"><span class="secno">4.4.2.2. </span><span class="content">Font Load Failed</span><a class="self-link" href="#font-load-failed"></a></h5>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
    <ol>
     <li data-md>
-     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a>, it may choose to use that and then use the user
+     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>, it may choose to use that and then use the user
   agent’s existing font fallback mechanism for codepoints not covered by the subset.</p>
     <li data-md>
      <p>The client may re-issue the request as a regular non incremental font fetch to the same <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>. It must not include the patch subset request parameter. This will load
   the entire <a data-link-type="dfn" href="#original-font" id="ref-for-original-font④">original font</a>.</p>
     <li data-md>
-     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
+     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
    </ol>
    <p>Regardless of which of the above options are used, the saved client state for this font must be
 discarded.</p>
@@ -1581,12 +1581,12 @@ agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc9111">[RFC9111
      <p>Font URL: a URL where the font to be extended is located.</p>
     <li data-md>
      <p>Desired Subset Definition: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">description</a> of the desired
-minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a>.</p>
+minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> which covers at minimum the input subset definition.</p>
+     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> which covers at minimum the input subset definition.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1637,7 +1637,7 @@ minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①�
      <p>If the returned cache fields are non-null update the cache entry for the input
  font url with the returned client state and returned cache fields.</p>
     <li data-md>
-     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> contained in the returned client state.</p>
+     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> contained in the returned client state.</p>
    </ol>
    <h3 class="heading settled" data-level="4.5" id="handling-patch-request"><span class="secno">4.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
    <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a> over HTTPS for a font the server has and that was
@@ -1652,7 +1652,7 @@ that collection that a patch is desired for. The identified font is referred to 
      <p>Codepoints the client has: formed by the union of the codepoint sets specified by <a data-link-type="dfn" href="#patchrequest-codepoints_have" id="ref-for-patchrequest-codepoints_have②">codepoints_have</a> and <a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have④">indices_have</a>. <span class="conform server" id="conform-remap-codepoints-have">The indices in <a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have⑤">indices_have</a> must be mapped to codepoints by the application of the
  codepoint reordering with a checksum matching <a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-for-patchrequest-ordering_checksum②">ordering_checksum</a>.</span></p>
     <li data-md>
-     <p>Codepoints the client needs: formed by the union of the codepoint sets specified by <a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed②">codepoints_needed</a> and <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed③">indices_needed</a>. <span class="conform server" id="conform-remap-codepoints-needed">The indices in <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed④">indices_needed</a> must be mapped to codepoints by the application of the
+     <p>Codepoints the client needs: formed by the union of the codepoint sets specified by <a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed①">codepoints_needed</a> and <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed③">indices_needed</a>. <span class="conform server" id="conform-remap-codepoints-needed">The indices in <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed④">indices_needed</a> must be mapped to codepoints by the application of the
  codepoint reordering with a checksum matching <a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-for-patchrequest-ordering_checksum③">ordering_checksum</a>.</span></p>
    </ol>
    <p>Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a>:</p>
@@ -1679,8 +1679,8 @@ that collection that a patch is desired for. The identified font is referred to 
 with a response that will cause the client to update it’s codepoint ordering to one the server
 will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> and not include any patch.
 That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields must not be set. </span></p>
-   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
-result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>: </span></p>
+   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
+result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a>: </span></p>
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-subset">That contains data for at least the union
@@ -1715,10 +1715,10 @@ the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①�
 either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑥">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑥">replacement</a> fields must be one of those
 listed in <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format②">accept_patch_format</a></span>.</p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-patched-checksum"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑦">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑦">replacement</a> fields are set the value of <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum③">patched_checksum</a> must be set to the checksum of the extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a>.
+     <p><span class="conform server" id="conform-response-patched-checksum"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑦">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑦">replacement</a> fields are set the value of <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum②">patched_checksum</a> must be set to the checksum of the extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>.
  The checksum value must be computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑧">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑧">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space②">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a>.</span></p>
+     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑧">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑧">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space②">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-ignore-unrecognized-formats"> If <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format③">accept_patch_format</a> contains any unrecognized patch formats the server must
 ignore the unrecognized ones.</span></p>
@@ -2540,7 +2540,7 @@ itself be statically compressed.</p>
    <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-url-path①">4.4.2.3. Font Load Failed</a>
+    <li><a href="#ref-for-concept-url-path①">4.4.2.2. Font Load Failed</a>
     <li><a href="#ref-for-concept-url-path②">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
     <li><a href="#ref-for-concept-url-path③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-url-path④">(2)</a>
    </ul>
@@ -2648,10 +2648,9 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-font-subset②">4.4.1. Client State</a>
     <li><a href="#ref-for-font-subset③">4.4.2. Extending the Font Subset</a> <a href="#ref-for-font-subset④">(2)</a> <a href="#ref-for-font-subset⑤">(3)</a> <a href="#ref-for-font-subset⑥">(4)</a> <a href="#ref-for-font-subset⑦">(5)</a> <a href="#ref-for-font-subset⑧">(6)</a> <a href="#ref-for-font-subset⑨">(7)</a>
     <li><a href="#ref-for-font-subset①⓪">4.4.2.1. Handling Server Response</a> <a href="#ref-for-font-subset①①">(2)</a> <a href="#ref-for-font-subset①②">(3)</a>
-    <li><a href="#ref-for-font-subset①③">4.4.2.2. Client Side Checksum Mismatch</a> <a href="#ref-for-font-subset①④">(2)</a>
-    <li><a href="#ref-for-font-subset①⑤">4.4.2.3. Font Load Failed</a> <a href="#ref-for-font-subset①⑥">(2)</a>
-    <li><a href="#ref-for-font-subset①⑦">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑧">(2)</a> <a href="#ref-for-font-subset①⑨">(3)</a>
-    <li><a href="#ref-for-font-subset②⓪">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset②①">(2)</a> <a href="#ref-for-font-subset②②">(3)</a> <a href="#ref-for-font-subset②③">(4)</a>
+    <li><a href="#ref-for-font-subset①③">4.4.2.2. Font Load Failed</a> <a href="#ref-for-font-subset①④">(2)</a>
+    <li><a href="#ref-for-font-subset①⑤">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑥">(2)</a> <a href="#ref-for-font-subset①⑦">(3)</a>
+    <li><a href="#ref-for-font-subset①⑧">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset①⑨">(2)</a> <a href="#ref-for-font-subset②⓪">(3)</a> <a href="#ref-for-font-subset②①">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="font-subset-definition">
@@ -2824,8 +2823,7 @@ itself be statically compressed.</p>
    <b><a href="#patchrequest-codepoints_needed">#patchrequest-codepoints_needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-codepoints_needed">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-patchrequest-codepoints_needed①">4.4.2.2. Client Side Checksum Mismatch</a>
-    <li><a href="#ref-for-patchrequest-codepoints_needed②">4.5. Server: Responding to a PatchRequest</a>
+    <li><a href="#ref-for-patchrequest-codepoints_needed①">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-indices_have">
@@ -2953,8 +2951,7 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchresponse-patched_checksum">4.3.4. PatchResponse</a>
     <li><a href="#ref-for-patchresponse-patched_checksum①">4.4.2.1. Handling Server Response</a>
-    <li><a href="#ref-for-patchresponse-patched_checksum②">4.4.2.2. Client Side Checksum Mismatch</a>
-    <li><a href="#ref-for-patchresponse-patched_checksum③">4.5. Server: Responding to a PatchRequest</a>
+    <li><a href="#ref-for-patchresponse-patched_checksum②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-codepoint_ordering">
@@ -3055,7 +3052,7 @@ itself be statically compressed.</p>
   <aside class="dfn-panel" data-for="abstract-opdef-extend-the-font-subset">
    <b><a href="#abstract-opdef-extend-the-font-subset">#abstract-opdef-extend-the-font-subset</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-extend-the-font-subset">4.4.2.2. Client Side Checksum Mismatch</a>
+    <li><a href="#ref-for-abstract-opdef-extend-the-font-subset">4.4.2.1. Handling Server Response</a> <a href="#ref-for-abstract-opdef-extend-the-font-subset①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patch-request-header">
@@ -3074,7 +3071,7 @@ itself be statically compressed.</p>
    <b><a href="#original-font">#original-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-original-font">4.4.2. Extending the Font Subset</a> <a href="#ref-for-original-font①">(2)</a> <a href="#ref-for-original-font②">(3)</a> <a href="#ref-for-original-font③">(4)</a>
-    <li><a href="#ref-for-original-font④">4.4.2.3. Font Load Failed</a>
+    <li><a href="#ref-for-original-font④">4.4.2.2. Font Load Failed</a>
     <li><a href="#ref-for-original-font⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-original-font⑥">(2)</a> <a href="#ref-for-original-font⑦">(3)</a> <a href="#ref-for-original-font⑧">(4)</a> <a href="#ref-for-original-font⑨">(5)</a> <a href="#ref-for-original-font①⓪">(6)</a> <a href="#ref-for-original-font①①">(7)</a> <a href="#ref-for-original-font①②">(8)</a> <a href="#ref-for-original-font①③">(9)</a> <a href="#ref-for-original-font①④">(10)</a>
    </ul>
   </aside>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="4866719ba4a4b1d5e204b5ce68dde6d2c14f5e79" name="document-revision">
+  <meta content="035ed3d0a30d2b124b8cc7ace9b4bfc135f93631" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1569,18 +1569,26 @@ that were set on the <var>server response</var>.</p>
    </ol>
    <p>Regardless of which of the above options are used, the saved client state for this font must be
 discarded.</p>
-   <h4 class="heading settled" data-level="4.4.4" id="load-a-font"><span class="secno">4.4.4. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
+   <h4 class="heading settled algorithm" data-algorithm="Load a Font in a User Agent with a HTTP Cache" data-level="4.4.4" id="load-a-font"><span class="secno">4.4.4. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
    <p>The previous section <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> provides no guidance on how a user agent should handle
 saving client state between invocations of the subset extension algorithm. This section provides an
 algorithm that user agents which implement <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a> should use to save client state to the user
 agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc9111">[RFC9111]</a>).</p>
+   <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-load-a-font-with-a-http-cache">Load a font with a HTTP Cache<a class="self-link" href="#abstract-opdef-load-a-font-with-a-http-cache"></a></dfn></p>
    <p>The inputs to this algorithm:</p>
    <ul>
     <li data-md>
-     <p>Font URL: a URL where the font to be extended is located.</p>
+     <p><var>font URL</var>: a URL where the font to be extended is located.</p>
     <li data-md>
-     <p>Desired Subset Definition: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">description</a> of the desired
+     <p><var>fragment identifier</var> (optional): if the font at the font url is a collection of fonts,
+the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section-4.2">The "font" Top-Level Media Type § section-4.2</a>) identifies a single font within the collection.</p>
+    <li data-md>
+     <p><var>desired subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">description</a> of the desired
 minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a>.</p>
+    <li data-md>
+     <p><var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>. The remainder
+of this section is desribed in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>, but it is allowed to substitute
+whatever HTTP fetching algorithm the user agent supports.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1607,29 +1615,33 @@ minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①�
      </ul>
     <li data-md>
      <p>If the request is successful and the response is "fresh" (<a href="https://www.rfc-editor.org/rfc/rfc9111#name-freshness">HTTP Caching § name-freshness</a>)
- then invoke <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> with:</p>
+ then invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset②">Extend the font subset</a> with:</p>
      <ul>
       <li data-md>
-       <p>Font url set to the input font url.</p>
+       <p>Font url set to the input <var>font URL</var>.</p>
+      <li data-md>
+       <p>Fragment identifier set to the input <var>fragment identifier</var></p>
       <li data-md>
        <p>Client state set to the response.</p>
       <li data-md>
-       <p>Desired subset definition set to the input subset definition.</p>
+       <p>Desired subset definition set to the input <var>desired subset definition</var>.</p>
       <li data-md>
-       <p>Fetch algorithm set to <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>.</p>
+       <p>Fetch algorithm set to the input <var>fetch algorithm</var>.</p>
      </ul>
      <p>Once that returns go to step 4.</p>
     <li data-md>
-     <p>Otherwise, invoke <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> with:</p>
+     <p>Otherwise, invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset③">Extend the font subset</a> with:</p>
      <ul>
       <li data-md>
-       <p>Font url set to the input font url.</p>
+       <p>Font url set to the input <var>font URL</var>.</p>
+      <li data-md>
+       <p>Fragment identifier set to the input <var>fragment identifier</var></p>
       <li data-md>
        <p>Client state set to null.</p>
       <li data-md>
-       <p>Desired subset definition set to the input subset definition.</p>
+       <p>Desired subset definition set to the input <var>desired subset definition</var>.</p>
       <li data-md>
-       <p>Fetch algorithm set to <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>.</p>
+       <p>Fetch algorithm set to the input <var>fetch algorithm</var>.</p>
      </ul>
      <p>Once that returns go to step 4.</p>
     <li data-md>
@@ -2412,6 +2424,7 @@ itself be statically compressed.</p>
    <li><a href="#patchrequest-indices_needed">indices_needed</a><span>, in § 4.3.3</span>
    <li><a href="#integer">Integer</a><span>, in § 4.2.2</span>
    <li><a href="#integerlist">IntegerList</a><span>, in § 4.2.5</span>
+   <li><a href="#abstract-opdef-load-a-font-with-a-http-cache">Load a font with a HTTP Cache</a><span>, in § 4.4.4</span>
    <li>
     ordering_checksum
     <ul>
@@ -3052,6 +3065,7 @@ itself be statically compressed.</p>
    <b><a href="#abstract-opdef-extend-the-font-subset">#abstract-opdef-extend-the-font-subset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-extend-the-font-subset">4.4.3. Handling Server Response</a> <a href="#ref-for-abstract-opdef-extend-the-font-subset①">(2)</a>
+    <li><a href="#ref-for-abstract-opdef-extend-the-font-subset②">4.4.4. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-abstract-opdef-extend-the-font-subset③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patch-request-header">

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="992c405dc3c59e7ad6cd0ec6b468298e4fb1f98c" name="document-revision">
+  <meta content="80e3fef99cb0d880fed69ab292aaa51d7ff8c1c1" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -359,10 +359,9 @@ dfn > a.self-link::before      { content: "#"; }
         <li>
          <a href="#extend-subset"><span class="secno">4.4.2</span> <span class="content">Extending the Font Subset</span></a>
          <ol class="toc">
-          <li><a href="#handling-patch-response"><span class="secno">4.4.2.1</span> <span class="content">Handling PatchResponse</span></a>
-          <li><a href="#invalid-server-response"><span class="secno">4.4.2.2</span> <span class="content">Handling Invalid Response from the Server</span></a>
-          <li><a href="#client-side-checksum-mismatch"><span class="secno">4.4.2.3</span> <span class="content">Client Side Checksum Mismatch</span></a>
-          <li><a href="#font-load-failed"><span class="secno">4.4.2.4</span> <span class="content">Font Load Failed</span></a>
+          <li><a href="#handling-patch-response"><span class="secno">4.4.2.1</span> <span class="content">Handling Server Response</span></a>
+          <li><a href="#client-side-checksum-mismatch"><span class="secno">4.4.2.2</span> <span class="content">Client Side Checksum Mismatch</span></a>
+          <li><a href="#font-load-failed"><span class="secno">4.4.2.3</span> <span class="content">Font Load Failed</span></a>
          </ol>
         <li><a href="#load-a-font"><span class="secno">4.4.3</span> <span class="content">Load a Font in a User Agent with a HTTP Cache</span></a>
        </ol>
@@ -1473,20 +1472,20 @@ can be cached, or null.</p>
  example, on slower connections it may be more performant to request extra codepoints if
  that is likely to prevent a future request from needing to be sent.</p>
     <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handling-patchresponse" id="ref-for-abstract-opdef-handling-patchresponse">Handling PatchResponse</a> with the response from the server and return the result.</p>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-server-response" id="ref-for-abstract-opdef-handle-server-response">Handle server response</a> with the response from the server and return the result.</p>
    </ol>
    <p class="note" role="note"><span>Note:</span> POST is preferred for the HTTP method since it will not cause a CORS preflight request
 and the request object is more compactly encoded. GET should only be used during <a href="#method-negotiation">method negotiation</a>.</p>
-   <h5 class="heading settled algorithm" data-algorithm="Handling PatchResponse" data-level="4.4.2.1" id="handling-patch-response"><span class="secno">4.4.2.1. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h5>
+   <h5 class="heading settled algorithm" data-algorithm="Handling Server Response" data-level="4.4.2.1" id="handling-patch-response"><span class="secno">4.4.2.1. </span><span class="content">Handling Server Response</span><a class="self-link" href="#handling-patch-response"></a></h5>
    <p>If a server is able to succsessfully process a <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑤">PatchRequest</a> it will respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> code 200 and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body">body</a> of the response will
 be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse①">PatchResponse</a> object encoded
-via CBOR. The client should use the following algorithm to interpret and process the fields of the
+via CBOR. The client uses the following algorithm to interpret and process the fields of the
 object.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handling-patchresponse">Handling PatchResponse</dfn></p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-server-response">Handle server response</dfn></p>
    <p>Inputs:</p>
    <ul>
     <li data-md>
-     <p><var>patch response</var>: a PatchResponse object from a successful <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a>.</p>
+     <p><var>server response</var>: HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a> to a patch request.</p>
     <li data-md>
      <p><var>client state</var> (optional): previously saved <a data-link-type="dfn" href="#client-state" id="ref-for-client-state②">client state</a>.</p>
    </ul>
@@ -1502,6 +1501,22 @@ can be cached, or null.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
+     <p>If the <var>server response</var> has <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> other than 200:</p>
+     <ul>
+      <li data-md>
+       <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to step 1.</p>
+      <li data-md>
+       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> extension has failed. Invoke <a href="#font-load-failed">§ 4.4.2.3 Font Load Failed</a> and return the result.</p>
+     </ul>
+    <li data-md>
+     <p>Check the first four bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a>. If they are
+ not equal to [0x49, 0x46, 0x54, 0x20] then this response is malformed.
+ Invoke <a href="#font-load-failed">§ 4.4.2.3 Font Load Failed</a> and return the result.</p>
+    <li data-md>
+     <p>Interpret the remaining bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body②">body</a> as a CBOR
+ encoded <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse②">PatchResponse</a>. If the bytes are not decodable with CBOR, or the <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse③">PatchResponse</a> is not well formed, then this is an error. Invoke <a href="#font-load-failed">§ 4.4.2.3 Font Load Failed</a> and
+ return the result.</p>
+    <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> is set then: the byte array in this field is a binary patch
  in the format specified by <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to a base which
  is an empty byte array. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑧">font subset</a> in the input <var>client state</var> with the result of the patch application.</p>
@@ -1510,8 +1525,8 @@ can be cached, or null.</p>
 in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format③">patch_format</a>. Apply the binary patch to the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑨">font subset</a> from the input client state. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①⓪">font subset</a> in the input <var>client state</var> with the
 result of the patch application.</p>
     <li data-md>
-     <p>If either <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> or <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> is set then: <a href="#computing-checksums">compute the checksum</a> of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> produced by the patch
-application in steps 1 or 2. If the computed checksum is not equal to <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum①">patched_checksum</a> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 4.4.2.3 Client Side Checksum Mismatch</a>. Otherwise update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in
+     <p>If either <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> or <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> is set then: <a href="#computing-checksums">compute the checksum</a> of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> produced by the
+patch application in steps 1 or 2. If the computed checksum is not equal to <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum①">patched_checksum</a> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 4.4.2.2 Client Side Checksum Mismatch</a>. Otherwise update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in
 the input <var>client state</var> with the value in <a data-link-type="dfn" href="#patchresponse-original_font_checksum" id="ref-for-patchresponse-original_font_checksum①">original_font_checksum</a>.</p>
     <li data-md>
      <p>If fields <a data-link-type="dfn" href="#patchresponse-codepoint_ordering" id="ref-for-patchresponse-codepoint_ordering②">codepoint_ordering</a> and <a data-link-type="dfn" href="#patchresponse-ordering_checksum" id="ref-for-patchresponse-ordering_checksum②">ordering_checksum</a> are set then
@@ -1520,30 +1535,18 @@ the new values specified by these two fields. If neither <a data-link-type="dfn"
 response but use the new codepoint ordering provided in this response. Go back to step 1 to process
 the response.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#patchresponse-original_features" id="ref-for-patchresponse-original_features①">original_features</a> is set and the client has opted to save them then replace the <a data-link-type="dfn" href="#client-state-original-font-feature-list" id="ref-for-client-state-original-font-feature-list">original font feature list</a> in the input <var>client state</var> with the value from    the response.</p>
+     <p>If <a data-link-type="dfn" href="#patchresponse-original_features" id="ref-for-patchresponse-original_features①">original_features</a> is set and the client has opted to save them then replace the <a data-link-type="dfn" href="#client-state-original-font-feature-list" id="ref-for-client-state-original-font-feature-list">original font feature list</a> in the input <var>client state</var> with the value
+from the response.</p>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#patchresponse-original_axis_space" id="ref-for-patchresponse-original_axis_space①">original_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-original-font-axis-space" id="ref-for-client-state-original-font-axis-space">original font axis space</a> in the input <var>client state</var> with the value
 specified in this field.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space①">subset_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-subset-axis-space" id="ref-for-client-state-subset-axis-space①">subset axis space</a> in the input <var>client state</var> with the value specified in
-this field.</p>
+     <p>If <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space①">subset_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-subset-axis-space" id="ref-for-client-state-subset-axis-space①">subset axis space</a> in the input <var>client state</var> with the value specified
+ in this field.</p>
    </ol>
    <p>After processing the response, return the updated input <var>client state</var> and any cache headers
 that were set on the response.</p>
-   <h5 class="heading settled" data-level="4.4.2.2" id="invalid-server-response"><span class="secno">4.4.2.2. </span><span class="content">Handling Invalid Response from the Server</span><a class="self-link" href="#invalid-server-response"></a></h5>
-   <p>If the response a client receives from the server has a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> code other than 200:</p>
-   <ul>
-    <li data-md>
-     <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a>.</p>
-    <li data-md>
-     <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> extension has failed. Follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a>.</p>
-   </ul>
-   <p>If the response the client receives has a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> code of 200, but the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a> is malformed. That is, it is missing the magic number, not decodable with CBOR, or the <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse②">PatchResponse</a> is not well formed:</p>
-   <ul>
-    <li data-md>
-     <p>This is an error. Follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a>.</p>
-   </ul>
-   <h5 class="heading settled" data-level="4.4.2.3" id="client-side-checksum-mismatch"><span class="secno">4.4.2.3. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h5>
+   <h5 class="heading settled" data-level="4.4.2.2" id="client-side-checksum-mismatch"><span class="secno">4.4.2.2. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h5>
    <p>If the checksum of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> computed by the client does not match the <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum②">patched_checksum</a> in the server’s response then the client should:</p>
    <ol>
     <li data-md>
@@ -1551,9 +1554,9 @@ that were set on the response.</p>
     <li data-md>
      <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset">Extend the font subset</a> to resend the request. Set the <a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed①">codepoints_needed</a> field to the union of the codepoints in the discarded <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> and the set of code points that the previous request was trying to add.</p>
      <p>If the resent request also results in a checksum mismatch then this is an error. The client
-must not resend the request again and should follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a></p>
+must not resend the request again and should follow <a href="#font-load-failed">§ 4.4.2.3 Font Load Failed</a></p>
    </ol>
-   <h5 class="heading settled" data-level="4.4.2.4" id="font-load-failed"><span class="secno">4.4.2.4. </span><span class="content">Font Load Failed</span><a class="self-link" href="#font-load-failed"></a></h5>
+   <h5 class="heading settled" data-level="4.4.2.3" id="font-load-failed"><span class="secno">4.4.2.3. </span><span class="content">Font Load Failed</span><a class="self-link" href="#font-load-failed"></a></h5>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
    <ol>
     <li data-md>
@@ -1637,9 +1640,9 @@ minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①�
      <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> contained in the returned client state.</p>
    </ol>
    <h3 class="heading settled" data-level="4.5" id="handling-patch-request"><span class="secno">4.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
-   <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑦">PatchRequest</a> over HTTPS for a font the server has and that was
-populated according to the requirements in <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> then it must respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status③">status</a> code 200.</span> <span class="conform server" id="conform-magic-number">The first 4 bytes of the response <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body②">body</a> must be set to 0x49, 0x46, 0x54, 0x20 ("IFT " encoded as ASCII) followed by a
-single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse③">PatchResponse</a> object encoded via CBOR.</span></p>
+   <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a> over HTTPS for a font the server has and that was
+populated according to the requirements in <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> then it must respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> code 200.</span> <span class="conform server" id="conform-magic-number">The first 4 bytes of the response <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body③">body</a> must be set to 0x49, 0x46, 0x54, 0x20 ("IFT " encoded as ASCII) followed by a
+single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse④">PatchResponse</a> object encoded via CBOR.</span></p>
    <p>The <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path③">path</a> in the request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a> identifies the specific font that a patch is desired
 for. If the request has the <a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id①">fragment_id</a> field set and the file identified by <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path④">path</a> is a collection of fonts, then <a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id②">fragment_id</a> identifies the font within
 that collection that a patch is desired for. The identified font is referred to as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="original-font">original font</dfn> in the rest of this section.</p>
@@ -1674,9 +1677,9 @@ that collection that a patch is desired for. The identified font is referred to 
    </ol>
    <p><span class="conform server" id="conform-bad-reordering"> If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
-will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a> and not include any patch.
+will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> and not include any patch.
 That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields must not be set. </span></p>
-   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
+   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
 result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>: </span></p>
    <ul>
     <li data-md>
@@ -1734,10 +1737,10 @@ same client to the same server task.</p>
    <p>Possible error responses:</p>
    <ul>
     <li data-md>
-     <p><span class="conform server" id="conform-reject-malformed-request"> If the request is malformed the server must instead respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status④">status</a> code 400
+     <p><span class="conform server" id="conform-reject-malformed-request"> If the request is malformed the server must instead respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status③">status</a> code 400
  to indicate an error.</span></p>
     <li data-md>
-     <p>If the requested font is not recognized by the server it should respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status⑤">status</a> code 404 to indicate a not found error.</p>
+     <p>If the requested font is not recognized by the server it should respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status④">status</a> code 404 to indicate a not found error.</p>
    </ul>
    <h4 class="heading settled" data-level="4.5.1" id="range-request-support"><span class="secno">4.5.1. </span><span class="content">Range Request Support</span><a class="self-link" href="#range-request-support"></a></h4>
    <p>A patch subset support server must also support incremental transfer via <a href="#range-request-incxfer">§ 5 Range Request Incremental Transfer</a>.
@@ -2404,7 +2407,7 @@ itself be statically compressed.</p>
    <li><a href="#font-subset">font subset</a><span>, in § 4.1</span>
    <li><a href="#font-subset-definition">font subset definition</a><span>, in § 4.1</span>
    <li><a href="#patchrequest-fragment_id">fragment_id</a><span>, in § 4.3.3</span>
-   <li><a href="#abstract-opdef-handling-patchresponse">Handling PatchResponse</a><span>, in § 4.4.2.1</span>
+   <li><a href="#abstract-opdef-handle-server-response">Handle server response</a><span>, in § 4.4.2.1</span>
    <li><a href="#patchrequest-indices_have">indices_have</a><span>, in § 4.3.3</span>
    <li><a href="#patchrequest-indices_needed">indices_needed</a><span>, in § 4.3.3</span>
    <li><a href="#integer">Integer</a><span>, in § 4.2.2</span>
@@ -2470,9 +2473,8 @@ itself be statically compressed.</p>
   <aside class="dfn-panel" data-for="term-for-concept-response-body">
    <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-body">4.4.2.1. Handling PatchResponse</a>
-    <li><a href="#ref-for-concept-response-body①">4.4.2.2. Handling Invalid Response from the Server</a>
-    <li><a href="#ref-for-concept-response-body②">4.5. Server: Responding to a PatchRequest</a>
+    <li><a href="#ref-for-concept-response-body">4.4.2.1. Handling Server Response</a> <a href="#ref-for-concept-response-body①">(2)</a> <a href="#ref-for-concept-response-body②">(3)</a>
+    <li><a href="#ref-for-concept-response-body③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-cache-mode">
@@ -2509,18 +2511,23 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-concept-request-mode①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-response">
+   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-response">4.4.2.1. Handling Server Response</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-status">
    <a href="https://fetch.spec.whatwg.org/#concept-status">https://fetch.spec.whatwg.org/#concept-status</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-status">4.4.2.2. Handling Invalid Response from the Server</a>
+    <li><a href="#ref-for-concept-status">4.4.2.1. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-status">
    <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-status">4.4.2.1. Handling PatchResponse</a>
-    <li><a href="#ref-for-concept-response-status①">4.4.2.2. Handling Invalid Response from the Server</a> <a href="#ref-for-concept-response-status②">(2)</a>
-    <li><a href="#ref-for-concept-response-status③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-response-status④">(2)</a> <a href="#ref-for-concept-response-status⑤">(3)</a>
+    <li><a href="#ref-for-concept-response-status">4.4.2.1. Handling Server Response</a> <a href="#ref-for-concept-response-status①">(2)</a>
+    <li><a href="#ref-for-concept-response-status②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-response-status③">(2)</a> <a href="#ref-for-concept-response-status④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-url">
@@ -2533,7 +2540,7 @@ itself be statically compressed.</p>
    <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-url-path①">4.4.2.4. Font Load Failed</a>
+    <li><a href="#ref-for-concept-url-path①">4.4.2.3. Font Load Failed</a>
     <li><a href="#ref-for-concept-url-path②">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
     <li><a href="#ref-for-concept-url-path③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-url-path④">(2)</a>
    </ul>
@@ -2562,6 +2569,7 @@ itself be statically compressed.</p>
      <li><span class="dfn-paneled" id="term-for-concept-header">header</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-method">method</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-mode">mode</span>
+     <li><span class="dfn-paneled" id="term-for-concept-response">response</span>
      <li><span class="dfn-paneled" id="term-for-concept-status">status</span>
      <li><span class="dfn-paneled" id="term-for-concept-response-status">status <small>(for response)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-request-url">url</span>
@@ -2639,10 +2647,9 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-font-subset①">4.1. Font Subset</a>
     <li><a href="#ref-for-font-subset②">4.4.1. Client State</a>
     <li><a href="#ref-for-font-subset③">4.4.2. Extending the Font Subset</a> <a href="#ref-for-font-subset④">(2)</a> <a href="#ref-for-font-subset⑤">(3)</a> <a href="#ref-for-font-subset⑥">(4)</a> <a href="#ref-for-font-subset⑦">(5)</a> <a href="#ref-for-font-subset⑧">(6)</a> <a href="#ref-for-font-subset⑨">(7)</a>
-    <li><a href="#ref-for-font-subset①⓪">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-font-subset①①">(2)</a>
-    <li><a href="#ref-for-font-subset①②">4.4.2.2. Handling Invalid Response from the Server</a>
-    <li><a href="#ref-for-font-subset①③">4.4.2.3. Client Side Checksum Mismatch</a> <a href="#ref-for-font-subset①④">(2)</a>
-    <li><a href="#ref-for-font-subset①⑤">4.4.2.4. Font Load Failed</a> <a href="#ref-for-font-subset①⑥">(2)</a>
+    <li><a href="#ref-for-font-subset①⓪">4.4.2.1. Handling Server Response</a> <a href="#ref-for-font-subset①①">(2)</a> <a href="#ref-for-font-subset①②">(3)</a>
+    <li><a href="#ref-for-font-subset①③">4.4.2.2. Client Side Checksum Mismatch</a> <a href="#ref-for-font-subset①④">(2)</a>
+    <li><a href="#ref-for-font-subset①⑤">4.4.2.3. Font Load Failed</a> <a href="#ref-for-font-subset①⑥">(2)</a>
     <li><a href="#ref-for-font-subset①⑦">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑧">(2)</a> <a href="#ref-for-font-subset①⑨">(3)</a>
     <li><a href="#ref-for-font-subset②⓪">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset②①">(2)</a> <a href="#ref-for-font-subset②②">(3)</a> <a href="#ref-for-font-subset②③">(4)</a>
    </ul>
@@ -2786,8 +2793,8 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-patchrequest">4.2.3. ProtocolVersion</a>
     <li><a href="#ref-for-patchrequest①">4.3.3. PatchRequest</a>
     <li><a href="#ref-for-patchrequest②">4.4.2. Extending the Font Subset</a> <a href="#ref-for-patchrequest③">(2)</a> <a href="#ref-for-patchrequest④">(3)</a>
-    <li><a href="#ref-for-patchrequest⑤">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-patchrequest⑥">(2)</a>
-    <li><a href="#ref-for-patchrequest⑦">4.5. Server: Responding to a PatchRequest</a>
+    <li><a href="#ref-for-patchrequest⑤">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchrequest⑥">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-protocol_version">
@@ -2817,7 +2824,7 @@ itself be statically compressed.</p>
    <b><a href="#patchrequest-codepoints_needed">#patchrequest-codepoints_needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-codepoints_needed">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-patchrequest-codepoints_needed①">4.4.2.3. Client Side Checksum Mismatch</a>
+    <li><a href="#ref-for-patchrequest-codepoints_needed①">4.4.2.2. Client Side Checksum Mismatch</a>
     <li><a href="#ref-for-patchrequest-codepoints_needed②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2900,9 +2907,8 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse">#patchresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse">4.2.3. ProtocolVersion</a>
-    <li><a href="#ref-for-patchresponse①">4.4.2.1. Handling PatchResponse</a>
-    <li><a href="#ref-for-patchresponse②">4.4.2.2. Handling Invalid Response from the Server</a>
-    <li><a href="#ref-for-patchresponse③">4.5. Server: Responding to a PatchRequest</a>
+    <li><a href="#ref-for-patchresponse①">4.4.2.1. Handling Server Response</a> <a href="#ref-for-patchresponse②">(2)</a> <a href="#ref-for-patchresponse③">(3)</a>
+    <li><a href="#ref-for-patchresponse④">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-protocol_version">
@@ -2915,14 +2921,14 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-patch_format">#patchresponse-patch_format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patch_format">4.3.4. PatchResponse</a> <a href="#ref-for-patchresponse-patch_format①">(2)</a>
-    <li><a href="#ref-for-patchresponse-patch_format②">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-patchresponse-patch_format③">(2)</a>
+    <li><a href="#ref-for-patchresponse-patch_format②">4.4.2.1. Handling Server Response</a> <a href="#ref-for-patchresponse-patch_format③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-patch">
    <b><a href="#patchresponse-patch">#patchresponse-patch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patch">4.3.4. PatchResponse</a> <a href="#ref-for-patchresponse-patch①">(2)</a>
-    <li><a href="#ref-for-patchresponse-patch②">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-patchresponse-patch③">(2)</a> <a href="#ref-for-patchresponse-patch④">(3)</a>
+    <li><a href="#ref-for-patchresponse-patch②">4.4.2.1. Handling Server Response</a> <a href="#ref-for-patchresponse-patch③">(2)</a> <a href="#ref-for-patchresponse-patch④">(3)</a>
     <li><a href="#ref-for-patchresponse-patch⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-patch⑥">(2)</a> <a href="#ref-for-patchresponse-patch⑦">(3)</a> <a href="#ref-for-patchresponse-patch⑧">(4)</a>
    </ul>
   </aside>
@@ -2930,7 +2936,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-replacement">#patchresponse-replacement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-replacement">4.3.4. PatchResponse</a> <a href="#ref-for-patchresponse-replacement①">(2)</a>
-    <li><a href="#ref-for-patchresponse-replacement②">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-patchresponse-replacement③">(2)</a> <a href="#ref-for-patchresponse-replacement④">(3)</a>
+    <li><a href="#ref-for-patchresponse-replacement②">4.4.2.1. Handling Server Response</a> <a href="#ref-for-patchresponse-replacement③">(2)</a> <a href="#ref-for-patchresponse-replacement④">(3)</a>
     <li><a href="#ref-for-patchresponse-replacement⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement⑥">(2)</a> <a href="#ref-for-patchresponse-replacement⑦">(3)</a> <a href="#ref-for-patchresponse-replacement⑧">(4)</a>
    </ul>
   </aside>
@@ -2938,7 +2944,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-original_font_checksum">#patchresponse-original_font_checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-original_font_checksum">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-original_font_checksum①">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-patchresponse-original_font_checksum①">4.4.2.1. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-original_font_checksum②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2946,8 +2952,8 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-patched_checksum">#patchresponse-patched_checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patched_checksum">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-patched_checksum①">4.4.2.1. Handling PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-patched_checksum②">4.4.2.3. Client Side Checksum Mismatch</a>
+    <li><a href="#ref-for-patchresponse-patched_checksum①">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-patched_checksum②">4.4.2.2. Client Side Checksum Mismatch</a>
     <li><a href="#ref-for-patchresponse-patched_checksum③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2956,7 +2962,7 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchresponse-codepoint_ordering">4.3.4. PatchResponse</a>
     <li><a href="#ref-for-patchresponse-codepoint_ordering①">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-codepoint_ordering②">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-patchresponse-codepoint_ordering②">4.4.2.1. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-codepoint_ordering③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2965,7 +2971,7 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchresponse-ordering_checksum">4.3.4. PatchResponse</a>
     <li><a href="#ref-for-patchresponse-ordering_checksum①">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-ordering_checksum②">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-patchresponse-ordering_checksum②">4.4.2.1. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-ordering_checksum③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2973,7 +2979,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-subset_axis_space">#patchresponse-subset_axis_space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-subset_axis_space">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-subset_axis_space①">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-patchresponse-subset_axis_space①">4.4.2.1. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-subset_axis_space②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2981,7 +2987,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-original_axis_space">#patchresponse-original_axis_space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-original_axis_space">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-original_axis_space①">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-patchresponse-original_axis_space①">4.4.2.1. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-original_axis_space②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2989,7 +2995,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-original_features">#patchresponse-original_features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-original_features">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-original_features①">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-patchresponse-original_features①">4.4.2.1. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-original_features②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2997,21 +3003,21 @@ itself be statically compressed.</p>
    <b><a href="#client-state">#client-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state①">(2)</a>
-    <li><a href="#ref-for-client-state②">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-client-state③">(2)</a>
+    <li><a href="#ref-for-client-state②">4.4.2.1. Handling Server Response</a> <a href="#ref-for-client-state③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-client-font-subset">
    <b><a href="#client-state-client-font-subset">#client-state-client-font-subset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state-client-font-subset">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state-client-font-subset①">(2)</a> <a href="#ref-for-client-state-client-font-subset②">(3)</a> <a href="#ref-for-client-state-client-font-subset③">(4)</a> <a href="#ref-for-client-state-client-font-subset④">(5)</a> <a href="#ref-for-client-state-client-font-subset⑤">(6)</a> <a href="#ref-for-client-state-client-font-subset⑥">(7)</a> <a href="#ref-for-client-state-client-font-subset⑦">(8)</a>
-    <li><a href="#ref-for-client-state-client-font-subset⑧">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-client-state-client-font-subset⑨">(2)</a> <a href="#ref-for-client-state-client-font-subset①⓪">(3)</a>
+    <li><a href="#ref-for-client-state-client-font-subset⑧">4.4.2.1. Handling Server Response</a> <a href="#ref-for-client-state-client-font-subset⑨">(2)</a> <a href="#ref-for-client-state-client-font-subset①⓪">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-original-font-checksum">
    <b><a href="#client-state-original-font-checksum">#client-state-original-font-checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state-original-font-checksum">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-client-state-original-font-checksum①">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-client-state-original-font-checksum①">4.4.2.1. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-codepoint-reordering-map">
@@ -3024,32 +3030,32 @@ itself be statically compressed.</p>
    <b><a href="#client-state-codepoint-reordering-checksum">#client-state-codepoint-reordering-checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state-codepoint-reordering-checksum">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-client-state-codepoint-reordering-checksum①">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-client-state-codepoint-reordering-checksum①">4.4.2.1. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-original-font-axis-space">
    <b><a href="#client-state-original-font-axis-space">#client-state-original-font-axis-space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-state-original-font-axis-space">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-client-state-original-font-axis-space">4.4.2.1. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-subset-axis-space">
    <b><a href="#client-state-subset-axis-space">#client-state-subset-axis-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state-subset-axis-space">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-client-state-subset-axis-space①">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-client-state-subset-axis-space①">4.4.2.1. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-original-font-feature-list">
    <b><a href="#client-state-original-font-feature-list">#client-state-original-font-feature-list</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-state-original-font-feature-list">4.4.2.1. Handling PatchResponse</a>
+    <li><a href="#ref-for-client-state-original-font-feature-list">4.4.2.1. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-extend-the-font-subset">
    <b><a href="#abstract-opdef-extend-the-font-subset">#abstract-opdef-extend-the-font-subset</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-extend-the-font-subset">4.4.2.3. Client Side Checksum Mismatch</a>
+    <li><a href="#ref-for-abstract-opdef-extend-the-font-subset">4.4.2.2. Client Side Checksum Mismatch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patch-request-header">
@@ -3058,17 +3064,17 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-patch-request-header">3.1. IFT Method Negotiation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-handling-patchresponse">
-   <b><a href="#abstract-opdef-handling-patchresponse">#abstract-opdef-handling-patchresponse</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="abstract-opdef-handle-server-response">
+   <b><a href="#abstract-opdef-handle-server-response">#abstract-opdef-handle-server-response</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-handling-patchresponse">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-abstract-opdef-handle-server-response">4.4.2. Extending the Font Subset</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="original-font">
    <b><a href="#original-font">#original-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-original-font">4.4.2. Extending the Font Subset</a> <a href="#ref-for-original-font①">(2)</a> <a href="#ref-for-original-font②">(3)</a> <a href="#ref-for-original-font③">(4)</a>
-    <li><a href="#ref-for-original-font④">4.4.2.4. Font Load Failed</a>
+    <li><a href="#ref-for-original-font④">4.4.2.3. Font Load Failed</a>
     <li><a href="#ref-for-original-font⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-original-font⑥">(2)</a> <a href="#ref-for-original-font⑦">(3)</a> <a href="#ref-for-original-font⑧">(4)</a> <a href="#ref-for-original-font⑨">(5)</a> <a href="#ref-for-original-font①⓪">(6)</a> <a href="#ref-for-original-font①①">(7)</a> <a href="#ref-for-original-font①②">(8)</a> <a href="#ref-for-original-font①③">(9)</a> <a href="#ref-for-original-font①④">(10)</a>
    </ul>
   </aside>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="f2de2129f0d2549f16b5e8561d0d67f7572677c3" name="document-revision">
+  <meta content="992c405dc3c59e7ad6cd0ec6b468298e4fb1f98c" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1473,51 +1473,70 @@ can be cached, or null.</p>
  example, on slower connections it may be more performant to request extra codepoints if
  that is likely to prevent a future request from needing to be sent.</p>
     <li data-md>
-     <p>Invoke <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a> with the response from the server and return the result.</p>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handling-patchresponse" id="ref-for-abstract-opdef-handling-patchresponse">Handling PatchResponse</a> with the response from the server and return the result.</p>
    </ol>
    <p class="note" role="note"><span>Note:</span> POST is preferred for the HTTP method since it will not cause a CORS preflight request
 and the request object is more compactly encoded. GET should only be used during <a href="#method-negotiation">method negotiation</a>.</p>
-   <h5 class="heading settled" data-level="4.4.2.1" id="handling-patch-response"><span class="secno">4.4.2.1. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h5>
+   <h5 class="heading settled algorithm" data-algorithm="Handling PatchResponse" data-level="4.4.2.1" id="handling-patch-response"><span class="secno">4.4.2.1. </span><span class="content">Handling PatchResponse</span><a class="self-link" href="#handling-patch-response"></a></h5>
    <p>If a server is able to succsessfully process a <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑤">PatchRequest</a> it will respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> code 200 and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body">body</a> of the response will
-be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse①">PatchResponse</a> object encoded via CBOR. The client
-should interpret and process the fields of the object as follows:</p>
+be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse①">PatchResponse</a> object encoded
+via CBOR. The client should use the following algorithm to interpret and process the fields of the
+object.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handling-patchresponse">Handling PatchResponse</dfn></p>
+   <p>Inputs:</p>
+   <ul>
+    <li data-md>
+     <p><var>patch response</var>: a PatchResponse object from a successful <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a>.</p>
+    <li data-md>
+     <p><var>client state</var> (optional): previously saved <a data-link-type="dfn" href="#client-state" id="ref-for-client-state②">client state</a>.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p>Client State: <a data-link-type="dfn" href="#client-state" id="ref-for-client-state③">client state</a> that has been updated to contain a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> which covers at
+least the requested subset definition.</p>
+    <li data-md>
+     <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions">HTTP Caching § name-field-definitions</a> describing how client state
+can be cached, or null.</p>
+   </ul>
+   <p>The algorithm:</p>
    <ol>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> is set then: the byte array in this field is a binary patch
  in the format specified by <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to a base which
- is an empty byte array. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑧">font subset</a> in the input
- client state with the result of the patch application.</p>
+ is an empty byte array. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑧">font subset</a> in the input <var>client state</var> with the result of the patch application.</p>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch②">patch</a> is set then:  the byte array in this field is a binary patch
-in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format③">patch_format</a>. Apply the binary patch to the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑨">font subset</a> from the input client state. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①⓪">font subset</a> in the input client state with the result of the
-patch application.</p>
+in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format③">patch_format</a>. Apply the binary patch to the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑨">font subset</a> from the input client state. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①⓪">font subset</a> in the input <var>client state</var> with the
+result of the patch application.</p>
     <li data-md>
-     <p>If either <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> or <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> is set then: <a href="#computing-checksums">compute the checksum</a> of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> produced by the patch
-application in steps 1 or 2. If the computed checksum is not equal to <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum①">patched_checksum</a> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 4.4.2.3 Client Side Checksum Mismatch</a>. Otherwise
-update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in the input client state with the value in <a data-link-type="dfn" href="#patchresponse-original_font_checksum" id="ref-for-patchresponse-original_font_checksum①">original_font_checksum</a>.</p>
+     <p>If either <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> or <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> is set then: <a href="#computing-checksums">compute the checksum</a> of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> produced by the patch
+application in steps 1 or 2. If the computed checksum is not equal to <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum①">patched_checksum</a> this is a recoverable error. Follow the procedure in <a href="#client-side-checksum-mismatch">§ 4.4.2.3 Client Side Checksum Mismatch</a>. Otherwise update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in
+the input <var>client state</var> with the value in <a data-link-type="dfn" href="#patchresponse-original_font_checksum" id="ref-for-patchresponse-original_font_checksum①">original_font_checksum</a>.</p>
     <li data-md>
      <p>If fields <a data-link-type="dfn" href="#patchresponse-codepoint_ordering" id="ref-for-patchresponse-codepoint_ordering②">codepoint_ordering</a> and <a data-link-type="dfn" href="#patchresponse-ordering_checksum" id="ref-for-patchresponse-ordering_checksum②">ordering_checksum</a> are set then
-update the <a data-link-type="dfn" href="#client-state-codepoint-reordering-checksum" id="ref-for-client-state-codepoint-reordering-checksum①">codepoint reordering checksum</a> in the input client state with the new
-values specified by these two fields. If neither <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement④">replacement</a> nor <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch④">patch</a> are set, then the client should resend the request that triggered this
-response but use the new codepoint ordering provided in this response.</p>
+update the <a data-link-type="dfn" href="#client-state-codepoint-reordering-checksum" id="ref-for-client-state-codepoint-reordering-checksum①">codepoint reordering checksum</a> in the input <var>client state</var> with
+the new values specified by these two fields. If neither <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement④">replacement</a> nor <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch④">patch</a> are set, then the client should resend the request that triggered this
+response but use the new codepoint ordering provided in this response. Go back to step 1 to process
+the response.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#patchresponse-original_features" id="ref-for-patchresponse-original_features①">original_features</a> is set and the client has opted to save them then replace the <a data-link-type="dfn" href="#client-state-original-font-feature-list" id="ref-for-client-state-original-font-feature-list">original font feature list</a> in the input client state with the value from the
-response.</p>
+     <p>If <a data-link-type="dfn" href="#patchresponse-original_features" id="ref-for-patchresponse-original_features①">original_features</a> is set and the client has opted to save them then replace the <a data-link-type="dfn" href="#client-state-original-font-feature-list" id="ref-for-client-state-original-font-feature-list">original font feature list</a> in the input <var>client state</var> with the value from    the response.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#patchresponse-original_axis_space" id="ref-for-patchresponse-original_axis_space①">original_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-original-font-axis-space" id="ref-for-client-state-original-font-axis-space">original font axis space</a> in the input client state with the value specified in
+     <p>If <a data-link-type="dfn" href="#patchresponse-original_axis_space" id="ref-for-patchresponse-original_axis_space①">original_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-original-font-axis-space" id="ref-for-client-state-original-font-axis-space">original font axis space</a> in the input <var>client state</var> with the value
+specified in this field.</p>
+    <li data-md>
+     <p>If <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space①">subset_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-subset-axis-space" id="ref-for-client-state-subset-axis-space①">subset axis space</a> in the input <var>client state</var> with the value specified in
 this field.</p>
-    <li data-md>
-     <p>If <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space①">subset_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-subset-axis-space" id="ref-for-client-state-subset-axis-space①">subset axis space</a> in the input client state with the value specified in this field.</p>
    </ol>
-   <p>After processing the response, return the updated input client state and any cache headers that were
-set on the response.</p>
+   <p>After processing the response, return the updated input <var>client state</var> and any cache headers
+that were set on the response.</p>
    <h5 class="heading settled" data-level="4.4.2.2" id="invalid-server-response"><span class="secno">4.4.2.2. </span><span class="content">Handling Invalid Response from the Server</span><a class="self-link" href="#invalid-server-response"></a></h5>
    <p>If the response a client receives from the server has a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status①">status</a> code other than 200:</p>
    <ul>
     <li data-md>
      <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a>.</p>
     <li data-md>
-     <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> extension has failed. Follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a>.</p>
+     <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> extension has failed. Follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a>.</p>
    </ul>
    <p>If the response the client receives has a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> code of 200, but the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a> is malformed. That is, it is missing the magic number, not decodable with CBOR, or the <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse②">PatchResponse</a> is not well formed:</p>
    <ul>
@@ -1525,12 +1544,12 @@ set on the response.</p>
      <p>This is an error. Follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a>.</p>
    </ul>
    <h5 class="heading settled" data-level="4.4.2.3" id="client-side-checksum-mismatch"><span class="secno">4.4.2.3. </span><span class="content">Client Side Checksum Mismatch</span><a class="self-link" href="#client-side-checksum-mismatch"></a></h5>
-   <p>If the checksum of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> computed by the client does not match the <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum②">patched_checksum</a> in the server’s response then the client should:</p>
+   <p>If the checksum of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> computed by the client does not match the <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum②">patched_checksum</a> in the server’s response then the client should:</p>
    <ol>
     <li data-md>
      <p>Discard the input client state for this font.</p>
     <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset">Extend the font subset</a> to resend the request. Set the <a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed①">codepoints_needed</a> field to the union of the codepoints in the discarded <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> and the set of code points that the previous request was trying to add.</p>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset">Extend the font subset</a> to resend the request. Set the <a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed①">codepoints_needed</a> field to the union of the codepoints in the discarded <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> and the set of code points that the previous request was trying to add.</p>
      <p>If the resent request also results in a checksum mismatch then this is an error. The client
 must not resend the request again and should follow <a href="#font-load-failed">§ 4.4.2.4 Font Load Failed</a></p>
    </ol>
@@ -1538,13 +1557,13 @@ must not resend the request again and should follow <a href="#font-load-failed">
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
    <ol>
     <li data-md>
-     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>, it may choose to use that and then use the user
+     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a>, it may choose to use that and then use the user
   agent’s existing font fallback mechanism for codepoints not covered by the subset.</p>
     <li data-md>
      <p>The client may re-issue the request as a regular non incremental font fetch to the same <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>. It must not include the patch subset request parameter. This will load
   the entire <a data-link-type="dfn" href="#original-font" id="ref-for-original-font④">original font</a>.</p>
     <li data-md>
-     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
+     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
    </ol>
    <p>Regardless of which of the above options are used, the saved client state for this font must be
 discarded.</p>
@@ -1559,12 +1578,12 @@ agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc9111">[RFC9111
      <p>Font URL: a URL where the font to be extended is located.</p>
     <li data-md>
      <p>Desired Subset Definition: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">description</a> of the desired
-minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a>.</p>
+minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> which covers at minimum the input subset definition.</p>
+     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> which covers at minimum the input subset definition.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1615,10 +1634,10 @@ minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①�
      <p>If the returned cache fields are non-null update the cache entry for the input
  font url with the returned client state and returned cache fields.</p>
     <li data-md>
-     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> contained in the returned client state.</p>
+     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> contained in the returned client state.</p>
    </ol>
    <h3 class="heading settled" data-level="4.5" id="handling-patch-request"><span class="secno">4.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
-   <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a> over HTTPS for a font the server has and that was
+   <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑦">PatchRequest</a> over HTTPS for a font the server has and that was
 populated according to the requirements in <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> then it must respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status③">status</a> code 200.</span> <span class="conform server" id="conform-magic-number">The first 4 bytes of the response <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body②">body</a> must be set to 0x49, 0x46, 0x54, 0x20 ("IFT " encoded as ASCII) followed by a
 single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse③">PatchResponse</a> object encoded via CBOR.</span></p>
    <p>The <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path③">path</a> in the request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a> identifies the specific font that a patch is desired
@@ -1657,8 +1676,8 @@ that collection that a patch is desired for. The identified font is referred to 
 with a response that will cause the client to update it’s codepoint ordering to one the server
 will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a> and not include any patch.
 That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields must not be set. </span></p>
-   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
-result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>: </span></p>
+   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling PatchResponse</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
+result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>: </span></p>
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-subset">That contains data for at least the union
@@ -1693,10 +1712,10 @@ the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①�
 either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑥">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑥">replacement</a> fields must be one of those
 listed in <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format②">accept_patch_format</a></span>.</p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-patched-checksum"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑦">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑦">replacement</a> fields are set the value of <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum③">patched_checksum</a> must be set to the checksum of the extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>.
+     <p><span class="conform server" id="conform-response-patched-checksum"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑦">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑦">replacement</a> fields are set the value of <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum③">patched_checksum</a> must be set to the checksum of the extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a>.
  The checksum value must be computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑧">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑧">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space②">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a>.</span></p>
+     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑧">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑧">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space②">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-ignore-unrecognized-formats"> If <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format③">accept_patch_format</a> contains any unrecognized patch formats the server must
 ignore the unrecognized ones.</span></p>
@@ -2385,6 +2404,7 @@ itself be statically compressed.</p>
    <li><a href="#font-subset">font subset</a><span>, in § 4.1</span>
    <li><a href="#font-subset-definition">font subset definition</a><span>, in § 4.1</span>
    <li><a href="#patchrequest-fragment_id">fragment_id</a><span>, in § 4.3.3</span>
+   <li><a href="#abstract-opdef-handling-patchresponse">Handling PatchResponse</a><span>, in § 4.4.2.1</span>
    <li><a href="#patchrequest-indices_have">indices_have</a><span>, in § 4.3.3</span>
    <li><a href="#patchrequest-indices_needed">indices_needed</a><span>, in § 4.3.3</span>
    <li><a href="#integer">Integer</a><span>, in § 4.2.2</span>
@@ -2619,12 +2639,12 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-font-subset①">4.1. Font Subset</a>
     <li><a href="#ref-for-font-subset②">4.4.1. Client State</a>
     <li><a href="#ref-for-font-subset③">4.4.2. Extending the Font Subset</a> <a href="#ref-for-font-subset④">(2)</a> <a href="#ref-for-font-subset⑤">(3)</a> <a href="#ref-for-font-subset⑥">(4)</a> <a href="#ref-for-font-subset⑦">(5)</a> <a href="#ref-for-font-subset⑧">(6)</a> <a href="#ref-for-font-subset⑨">(7)</a>
-    <li><a href="#ref-for-font-subset①⓪">4.4.2.1. Handling PatchResponse</a>
-    <li><a href="#ref-for-font-subset①①">4.4.2.2. Handling Invalid Response from the Server</a>
-    <li><a href="#ref-for-font-subset①②">4.4.2.3. Client Side Checksum Mismatch</a> <a href="#ref-for-font-subset①③">(2)</a>
-    <li><a href="#ref-for-font-subset①④">4.4.2.4. Font Load Failed</a> <a href="#ref-for-font-subset①⑤">(2)</a>
-    <li><a href="#ref-for-font-subset①⑥">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑦">(2)</a> <a href="#ref-for-font-subset①⑧">(3)</a>
-    <li><a href="#ref-for-font-subset①⑨">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset②⓪">(2)</a> <a href="#ref-for-font-subset②①">(3)</a> <a href="#ref-for-font-subset②②">(4)</a>
+    <li><a href="#ref-for-font-subset①⓪">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-font-subset①①">(2)</a>
+    <li><a href="#ref-for-font-subset①②">4.4.2.2. Handling Invalid Response from the Server</a>
+    <li><a href="#ref-for-font-subset①③">4.4.2.3. Client Side Checksum Mismatch</a> <a href="#ref-for-font-subset①④">(2)</a>
+    <li><a href="#ref-for-font-subset①⑤">4.4.2.4. Font Load Failed</a> <a href="#ref-for-font-subset①⑥">(2)</a>
+    <li><a href="#ref-for-font-subset①⑦">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑧">(2)</a> <a href="#ref-for-font-subset①⑨">(3)</a>
+    <li><a href="#ref-for-font-subset②⓪">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset②①">(2)</a> <a href="#ref-for-font-subset②②">(3)</a> <a href="#ref-for-font-subset②③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="font-subset-definition">
@@ -2766,8 +2786,8 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-patchrequest">4.2.3. ProtocolVersion</a>
     <li><a href="#ref-for-patchrequest①">4.3.3. PatchRequest</a>
     <li><a href="#ref-for-patchrequest②">4.4.2. Extending the Font Subset</a> <a href="#ref-for-patchrequest③">(2)</a> <a href="#ref-for-patchrequest④">(3)</a>
-    <li><a href="#ref-for-patchrequest⑤">4.4.2.1. Handling PatchResponse</a>
-    <li><a href="#ref-for-patchrequest⑥">4.5. Server: Responding to a PatchRequest</a>
+    <li><a href="#ref-for-patchrequest⑤">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-patchrequest⑥">(2)</a>
+    <li><a href="#ref-for-patchrequest⑦">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-protocol_version">
@@ -2977,6 +2997,7 @@ itself be statically compressed.</p>
    <b><a href="#client-state">#client-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state①">(2)</a>
+    <li><a href="#ref-for-client-state②">4.4.2.1. Handling PatchResponse</a> <a href="#ref-for-client-state③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-client-font-subset">
@@ -3035,6 +3056,12 @@ itself be statically compressed.</p>
    <b><a href="#patch-request-header">#patch-request-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patch-request-header">3.1. IFT Method Negotiation</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="abstract-opdef-handling-patchresponse">
+   <b><a href="#abstract-opdef-handling-patchresponse">#abstract-opdef-handling-patchresponse</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-abstract-opdef-handling-patchresponse">4.4.2. Extending the Font Subset</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="original-font">

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="843e56738d50ca0e9e44a4c399e1077715dd0e1e" name="document-revision">
+  <meta content="f89ab56d3945e042cf571c956a6f9a3105305d90" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1366,7 +1366,7 @@ the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section
 font url, or null.</p>
     <li data-md>
      <p><var>desired subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">description</a> of the desired
-minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
+minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>. The subset definition must be a superset of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> in <var>client state</var>.</p>
     <li data-md>
      <p><var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>. The remainder
 of this section is desribed in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>, but it is allowed to substitute
@@ -1375,7 +1375,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>Client State: <a data-link-type="dfn" href="#client-state" id="ref-for-client-state①">client state</a> that has been updated to contain a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> which covers at
+     <p>Client State: <a data-link-type="dfn" href="#client-state" id="ref-for-client-state①">client state</a> that has been updated to contain a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> which covers at
 least the requested subset definition.</p>
     <li data-md>
      <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions">HTTP Caching § name-field-definitions</a> describing how client state
@@ -1425,32 +1425,36 @@ can be cached, or null.</p>
  should not be set.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed">codepoints_needed</a>: set to the set of codepoints that the client wants to
- add to its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> as defined in the <var>desired subset definition</var>. If the <var>client state</var> has a <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map">codepoint reordering map</a> for this font then
+ add to its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a>. That is the codepoint set from <var>desired subset
+ definition</var> minus the codepoints already in <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset③">Client font subset</a>. If the <var>client state</var> has a <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map">codepoint reordering map</a> for this font then
  this field should not be set.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have②">indices_have</a>: encodes the set of additional codepoints that the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset③">client font subset</a> contains data for. The codepoint values are transformed
+       <p><a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have②">indices_have</a>: encodes the set of additional codepoints that the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset④">client font subset</a> contains data for. The codepoint values are transformed
  to indices by applying <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map①">codepoint reordering map</a> to each codepoint value. If
  the <var>client state</var> does not have a <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map②">codepoint reordering map</a> for this
  font then this field should not be set.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed①">indices_needed</a>: encodes the set of codepoints that the client wants to add to
- its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a> as defined in the <var>desired subset definition</var>. The codepoint
- values are transformed to indices by applying the <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map③">codepoint reordering map</a> to each codepoint value. If the client does not have a codepoint ordering for this font then
- this field should not be set.</p>
+ its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a>. That is the codepoint set from <var>desired subset
+ definition</var> minus the codepoints already in <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑤">Client font subset</a>. The
+ codepoint values are transformed to indices by applying the <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map③">codepoint
+ reordering map</a> to each codepoint value. If the client does not have a codepoint ordering
+ for this font then this field should not be set.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"> opentype layout feature tags</a> that the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset④">client font subset</a> has data
- for. If the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑤">client font subset</a> is an empty byte array this
- field is left unset. Additionally, if the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑥">client font subset</a> has all
+       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"> opentype layout feature tags</a> that the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑥">client font subset</a> has data
+ for. If the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑦">client font subset</a> is an empty byte array this
+ field is left unset. Additionally, if the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑧">client font subset</a> has all
  data for features present in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font">original font</a> then this field can be unset.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-features_needed" id="ref-for-patchrequest-features_needed">features_needed</a>: set to the list of feature tags that the client wants to add
- to the current <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a> as defined in the <var>desired subset definition</var>.
- Alternatively, if the client wishes to add all features from the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①">original font</a> to it’s
+ to the current <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a>. That is the feature set from <var>desired subset
+ definition</var> minus the set of features already in <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑨">Client font subset</a>.
+ If the client wishes to add all remaining layout features from the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①">original font</a> to it’s
  subset then this field should be unset.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-axis_space_have" id="ref-for-patchrequest-axis_space_have">axis_space_have</a>: set to the current value of <a data-link-type="dfn" href="#client-state-subset-axis-space" id="ref-for-client-state-subset-axis-space">subset axis space</a> saved in the <var>client state</var> for this font.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-axis_space_needed" id="ref-for-patchrequest-axis_space_needed">axis_space_needed</a>: set to the intervals of each variable axis in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font②">original font</a> that the client wants to add to its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a> as defined in the <var>desired subset definition</var>. If the client wants an
+       <p><a data-link-type="dfn" href="#patchrequest-axis_space_needed" id="ref-for-patchrequest-axis_space_needed">axis_space_needed</a>: set to the intervals of each variable axis in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font②">original font</a> that the client wants to add to its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> as defined in the <var>desired subset definition</var>. If the client wants an
  entire axis from the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font③">original font</a> then that axis should not be listed.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-for-patchrequest-ordering_checksum①">ordering_checksum</a>: If either of <a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have③">indices_have</a> or <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed②">indices_needed</a> is set then this must be set to the current value of <a data-link-type="dfn" href="#client-state-codepoint-reordering-checksum" id="ref-for-client-state-codepoint-reordering-checksum">codepoint reordering checksum</a> saved in the state for this font.</p>
@@ -1460,7 +1464,7 @@ can be cached, or null.</p>
  there is no saved value leave this field unset.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum①">base_checksum</a>:
- Set to the checksum of the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑦">client font subset</a> byte array saved in
+ Set to the checksum of the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①⓪">client font subset</a> byte array saved in
  the <var>client state</var> for this font. See: <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id">fragment_id</a>:
@@ -1491,7 +1495,7 @@ object.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>Client State: <a data-link-type="dfn" href="#client-state" id="ref-for-client-state③">client state</a> that has been updated to contain a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> which covers at
+     <p>Client State: <a data-link-type="dfn" href="#client-state" id="ref-for-client-state③">client state</a> that has been updated to contain a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> which covers at
 least the requested subset definition.</p>
     <li data-md>
      <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions">HTTP Caching § name-field-definitions</a> describing how client state
@@ -1505,7 +1509,7 @@ can be cached, or null.</p>
       <li data-md>
        <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to step 1.</p>
       <li data-md>
-       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> extension has failed. Invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and return the result.</p>
+       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> extension has failed. Invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and return the result.</p>
      </ul>
     <li data-md>
      <p>Check the first four bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a>. If they are
@@ -1518,13 +1522,13 @@ can be cached, or null.</p>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> is set then: the byte array in this field is a binary patch
  in the format specified by <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to a base which
- is an empty byte array. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑧">font subset</a> in the input <var>client state</var> with the result of the patch application.</p>
+ is an empty byte array. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①①">font subset</a> in the input <var>client state</var> with the result of the patch application.</p>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch②">patch</a> is set then:  the byte array in this field is a binary patch
-in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format③">patch_format</a>. Apply the binary patch to the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑨">font subset</a> from the input client state. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①⓪">font subset</a> in the input <var>client state</var> with the
+in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format③">patch_format</a>. Apply the binary patch to the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①②">font subset</a> from the input client state. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①③">font subset</a> in the input <var>client state</var> with the
 result of the patch application.</p>
     <li data-md>
-     <p>If either <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> or <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> is set then: <a href="#computing-checksums">compute the checksum</a> of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> produced by the
+     <p>If either <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> or <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> is set then: <a href="#computing-checksums">compute the checksum</a> of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> produced by the
 patch application in steps 1 or 2.</p>
      <ul>
       <li data-md>
@@ -1560,13 +1564,13 @@ that were set on the response.</p>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
    <ol>
     <li data-md>
-     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>, it may choose to use that and then use the user
+     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>, it may choose to use that and then use the user
   agent’s existing font fallback mechanism for codepoints not covered by the subset.</p>
     <li data-md>
      <p>The client may re-issue the request as a regular non incremental font fetch to the same <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>. It must not include the patch subset request parameter. This will load
   the entire <a data-link-type="dfn" href="#original-font" id="ref-for-original-font④">original font</a>.</p>
     <li data-md>
-     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
+     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
    </ol>
    <p>Regardless of which of the above options are used, the saved client state for this font must be
 discarded.</p>
@@ -1581,12 +1585,12 @@ agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc9111">[RFC9111
      <p>Font URL: a URL where the font to be extended is located.</p>
     <li data-md>
      <p>Desired Subset Definition: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">description</a> of the desired
-minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a>.</p>
+minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> which covers at minimum the input subset definition.</p>
+     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> which covers at minimum the input subset definition.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1637,7 +1641,7 @@ minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①�
      <p>If the returned cache fields are non-null update the cache entry for the input
  font url with the returned client state and returned cache fields.</p>
     <li data-md>
-     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> contained in the returned client state.</p>
+     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> contained in the returned client state.</p>
    </ol>
    <h3 class="heading settled" data-level="4.5" id="handling-patch-request"><span class="secno">4.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
    <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a> over HTTPS for a font the server has and that was
@@ -1679,8 +1683,8 @@ that collection that a patch is desired for. The identified font is referred to 
 with a response that will cause the client to update it’s codepoint ordering to one the server
 will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> and not include any patch.
 That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields must not be set. </span></p>
-   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
-result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a>: </span></p>
+   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
+result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>: </span></p>
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-subset">That contains data for at least the union
@@ -1715,10 +1719,10 @@ the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①�
 either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑥">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑥">replacement</a> fields must be one of those
 listed in <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format②">accept_patch_format</a></span>.</p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-patched-checksum"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑦">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑦">replacement</a> fields are set the value of <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum②">patched_checksum</a> must be set to the checksum of the extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>.
+     <p><span class="conform server" id="conform-response-patched-checksum"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑦">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑦">replacement</a> fields are set the value of <a data-link-type="dfn" href="#patchresponse-patched_checksum" id="ref-for-patchresponse-patched_checksum②">patched_checksum</a> must be set to the checksum of the extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>.
  The checksum value must be computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑧">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑧">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space②">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>.</span></p>
+     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑧">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑧">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space②">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-ignore-unrecognized-formats"> If <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format③">accept_patch_format</a> contains any unrecognized patch formats the server must
 ignore the unrecognized ones.</span></p>
@@ -2646,11 +2650,11 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-font-subset">1.1. Patch Subset</a>
     <li><a href="#ref-for-font-subset①">4.1. Font Subset</a>
     <li><a href="#ref-for-font-subset②">4.4.1. Client State</a>
-    <li><a href="#ref-for-font-subset③">4.4.2. Extending the Font Subset</a> <a href="#ref-for-font-subset④">(2)</a> <a href="#ref-for-font-subset⑤">(3)</a> <a href="#ref-for-font-subset⑥">(4)</a> <a href="#ref-for-font-subset⑦">(5)</a> <a href="#ref-for-font-subset⑧">(6)</a> <a href="#ref-for-font-subset⑨">(7)</a>
-    <li><a href="#ref-for-font-subset①⓪">4.4.2.1. Handling Server Response</a> <a href="#ref-for-font-subset①①">(2)</a> <a href="#ref-for-font-subset①②">(3)</a>
-    <li><a href="#ref-for-font-subset①③">4.4.2.2. Font Load Failed</a> <a href="#ref-for-font-subset①④">(2)</a>
-    <li><a href="#ref-for-font-subset①⑤">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑥">(2)</a> <a href="#ref-for-font-subset①⑦">(3)</a>
-    <li><a href="#ref-for-font-subset①⑧">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset①⑨">(2)</a> <a href="#ref-for-font-subset②⓪">(3)</a> <a href="#ref-for-font-subset②①">(4)</a>
+    <li><a href="#ref-for-font-subset③">4.4.2. Extending the Font Subset</a> <a href="#ref-for-font-subset④">(2)</a> <a href="#ref-for-font-subset⑤">(3)</a> <a href="#ref-for-font-subset⑥">(4)</a> <a href="#ref-for-font-subset⑦">(5)</a> <a href="#ref-for-font-subset⑧">(6)</a> <a href="#ref-for-font-subset⑨">(7)</a> <a href="#ref-for-font-subset①⓪">(8)</a>
+    <li><a href="#ref-for-font-subset①①">4.4.2.1. Handling Server Response</a> <a href="#ref-for-font-subset①②">(2)</a> <a href="#ref-for-font-subset①③">(3)</a>
+    <li><a href="#ref-for-font-subset①④">4.4.2.2. Font Load Failed</a> <a href="#ref-for-font-subset①⑤">(2)</a>
+    <li><a href="#ref-for-font-subset①⑥">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑦">(2)</a> <a href="#ref-for-font-subset①⑧">(3)</a>
+    <li><a href="#ref-for-font-subset①⑨">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset②⓪">(2)</a> <a href="#ref-for-font-subset②①">(3)</a> <a href="#ref-for-font-subset②②">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="font-subset-definition">
@@ -3006,8 +3010,8 @@ itself be statically compressed.</p>
   <aside class="dfn-panel" data-for="client-state-client-font-subset">
    <b><a href="#client-state-client-font-subset">#client-state-client-font-subset</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-state-client-font-subset">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state-client-font-subset①">(2)</a> <a href="#ref-for-client-state-client-font-subset②">(3)</a> <a href="#ref-for-client-state-client-font-subset③">(4)</a> <a href="#ref-for-client-state-client-font-subset④">(5)</a> <a href="#ref-for-client-state-client-font-subset⑤">(6)</a> <a href="#ref-for-client-state-client-font-subset⑥">(7)</a> <a href="#ref-for-client-state-client-font-subset⑦">(8)</a>
-    <li><a href="#ref-for-client-state-client-font-subset⑧">4.4.2.1. Handling Server Response</a> <a href="#ref-for-client-state-client-font-subset⑨">(2)</a> <a href="#ref-for-client-state-client-font-subset①⓪">(3)</a>
+    <li><a href="#ref-for-client-state-client-font-subset">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state-client-font-subset①">(2)</a> <a href="#ref-for-client-state-client-font-subset②">(3)</a> <a href="#ref-for-client-state-client-font-subset③">(4)</a> <a href="#ref-for-client-state-client-font-subset④">(5)</a> <a href="#ref-for-client-state-client-font-subset⑤">(6)</a> <a href="#ref-for-client-state-client-font-subset⑥">(7)</a> <a href="#ref-for-client-state-client-font-subset⑦">(8)</a> <a href="#ref-for-client-state-client-font-subset⑧">(9)</a> <a href="#ref-for-client-state-client-font-subset⑨">(10)</a> <a href="#ref-for-client-state-client-font-subset①⓪">(11)</a>
+    <li><a href="#ref-for-client-state-client-font-subset①①">4.4.2.1. Handling Server Response</a> <a href="#ref-for-client-state-client-font-subset①②">(2)</a> <a href="#ref-for-client-state-client-font-subset①③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-original-font-checksum">

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="f89ab56d3945e042cf571c956a6f9a3105305d90" name="document-revision">
+  <meta content="4866719ba4a4b1d5e204b5ce68dde6d2c14f5e79" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -356,13 +356,9 @@ dfn > a.self-link::before      { content: "#"; }
        <a href="#client"><span class="secno">4.4</span> <span class="content">Client</span></a>
        <ol class="toc">
         <li><a href="#client-state-section"><span class="secno">4.4.1</span> <span class="content"><span>Client State</span></span></a>
-        <li>
-         <a href="#extend-subset"><span class="secno">4.4.2</span> <span class="content">Extending the Font Subset</span></a>
-         <ol class="toc">
-          <li><a href="#handling-patch-response"><span class="secno">4.4.2.1</span> <span class="content">Handling Server Response</span></a>
-          <li><a href="#font-load-failed"><span class="secno">4.4.2.2</span> <span class="content">Font Load Failed</span></a>
-         </ol>
-        <li><a href="#load-a-font"><span class="secno">4.4.3</span> <span class="content">Load a Font in a User Agent with a HTTP Cache</span></a>
+        <li><a href="#extend-subset"><span class="secno">4.4.2</span> <span class="content">Extending the Font Subset</span></a>
+        <li><a href="#handling-patch-response"><span class="secno">4.4.3</span> <span class="content">Handling Server Response</span></a>
+        <li><a href="#load-a-font"><span class="secno">4.4.4</span> <span class="content">Load a Font in a User Agent with a HTTP Cache</span></a>
        </ol>
       <li>
        <a href="#handling-patch-request"><span class="secno">4.5</span> <span class="content">Server: Responding to a PatchRequest</span></a>
@@ -1479,7 +1475,7 @@ can be cached, or null.</p>
    </ol>
    <p class="note" role="note"><span>Note:</span> POST is preferred for the HTTP method since it will not cause a CORS preflight request
 and the request object is more compactly encoded. GET should only be used during <a href="#method-negotiation">method negotiation</a>.</p>
-   <h5 class="heading settled algorithm" data-algorithm="Handling Server Response" data-level="4.4.2.1" id="handling-patch-response"><span class="secno">4.4.2.1. </span><span class="content">Handling Server Response</span><a class="self-link" href="#handling-patch-response"></a></h5>
+   <h4 class="heading settled algorithm" data-algorithm="Handling Server Response" data-level="4.4.3" id="handling-patch-response"><span class="secno">4.4.3. </span><span class="content">Handling Server Response</span><a class="self-link" href="#handling-patch-response"></a></h4>
    <p>If a server is able to succsessfully process a <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑤">PatchRequest</a> it will respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> code 200 and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body">body</a> of the response will
 be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse①">PatchResponse</a> object encoded
 via CBOR. The client uses the following algorithm to interpret and process the fields of the
@@ -1509,16 +1505,15 @@ can be cached, or null.</p>
       <li data-md>
        <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to step 1.</p>
       <li data-md>
-       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> extension has failed. Invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and return the result.</p>
+       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> extension has failed. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load">Handle failed font load</a> and return the result.</p>
      </ul>
     <li data-md>
      <p>Check the first four bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a>. If they are
  not equal to [0x49, 0x46, 0x54, 0x20] then this response is malformed.
- Invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and return the result.</p>
+ Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load①">Handle failed font load</a> and return the result.</p>
     <li data-md>
      <p>Interpret the remaining bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body②">body</a> as a CBOR
- encoded <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse②">PatchResponse</a>. If the bytes are not decodable with CBOR, or the <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse③">PatchResponse</a> is not well formed, then this is an error. Invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and
- return the result.</p>
+ encoded <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse②">PatchResponse</a>. If the bytes are not decodable with CBOR, or the <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse③">PatchResponse</a> is not well formed, then this is an error. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load②">Handle failed font load</a> and return the result.</p>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> is set then: the byte array in this field is a binary patch
  in the format specified by <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to a base which
@@ -1536,8 +1531,8 @@ patch application in steps 1 or 2.</p>
 recoverable error. Discard the saved client state and invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset">Extend the font subset</a> to
 resend the request with the same arguments as the original request, except client state is set
 to null. If the resent request also results in a checksum mismatch then this is an error. The
-client must not resend the request again and should invoke <a href="#font-load-failed">§ 4.4.2.2 Font Load Failed</a> and return the
-result. Otherwise return the result from the call to <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset①">Extend the font subset</a>.</p>
+client must not resend the request again and should invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load③">Handle failed font load</a> and
+return the result. Otherwise return the result from the call to <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset①">Extend the font subset</a>.</p>
       <li data-md>
        <p>Otherwise update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in
 the input <var>client state</var> with the value in <a data-link-type="dfn" href="#patchresponse-original_font_checksum" id="ref-for-patchresponse-original_font_checksum①">original_font_checksum</a>.</p>
@@ -1559,22 +1554,22 @@ specified in this field.</p>
  in this field.</p>
    </ol>
    <p>After processing the response, return the updated input <var>client state</var> and any cache headers
-that were set on the response.</p>
-   <h5 class="heading settled" data-level="4.4.2.2" id="font-load-failed"><span class="secno">4.4.2.2. </span><span class="content">Font Load Failed</span><a class="self-link" href="#font-load-failed"></a></h5>
+that were set on the <var>server response</var>.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-failed-font-load">Handle failed font load</dfn></p>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
    <ol>
     <li data-md>
      <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>, it may choose to use that and then use the user
   agent’s existing font fallback mechanism for codepoints not covered by the subset.</p>
     <li data-md>
-     <p>The client may re-issue the request as a regular non incremental font fetch to the same <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>. It must not include the patch subset request parameter. This will load
+     <p>The client may re-issue the request as a regular non incremental font fetch to the same <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>. It must not include the patch subset request parameter or header. This will load
   the entire <a data-link-type="dfn" href="#original-font" id="ref-for-original-font④">original font</a>.</p>
     <li data-md>
      <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
    </ol>
    <p>Regardless of which of the above options are used, the saved client state for this font must be
 discarded.</p>
-   <h4 class="heading settled" data-level="4.4.3" id="load-a-font"><span class="secno">4.4.3. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
+   <h4 class="heading settled" data-level="4.4.4" id="load-a-font"><span class="secno">4.4.4. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
    <p>The previous section <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> provides no guidance on how a user agent should handle
 saving client state between invocations of the subset extension algorithm. This section provides an
 algorithm that user agents which implement <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a> should use to save client state to the user
@@ -1681,9 +1676,9 @@ that collection that a patch is desired for. The identified font is referred to 
    </ol>
    <p><span class="conform server" id="conform-bad-reordering"> If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
-will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> and not include any patch.
+will recognize via the process described in <a href="#handling-patch-response">§ 4.4.3 Handling Server Response</a> and not include any patch.
 That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields must not be set. </span></p>
-   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2.1 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
+   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.3 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
 result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>: </span></p>
    <ul>
     <li data-md>
@@ -2411,7 +2406,8 @@ itself be statically compressed.</p>
    <li><a href="#font-subset">font subset</a><span>, in § 4.1</span>
    <li><a href="#font-subset-definition">font subset definition</a><span>, in § 4.1</span>
    <li><a href="#patchrequest-fragment_id">fragment_id</a><span>, in § 4.3.3</span>
-   <li><a href="#abstract-opdef-handle-server-response">Handle server response</a><span>, in § 4.4.2.1</span>
+   <li><a href="#abstract-opdef-handle-failed-font-load">Handle failed font load</a><span>, in § 4.4.3</span>
+   <li><a href="#abstract-opdef-handle-server-response">Handle server response</a><span>, in § 4.4.3</span>
    <li><a href="#patchrequest-indices_have">indices_have</a><span>, in § 4.3.3</span>
    <li><a href="#patchrequest-indices_needed">indices_needed</a><span>, in § 4.3.3</span>
    <li><a href="#integer">Integer</a><span>, in § 4.2.2</span>
@@ -2477,7 +2473,7 @@ itself be statically compressed.</p>
   <aside class="dfn-panel" data-for="term-for-concept-response-body">
    <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-body">4.4.2.1. Handling Server Response</a> <a href="#ref-for-concept-response-body①">(2)</a> <a href="#ref-for-concept-response-body②">(3)</a>
+    <li><a href="#ref-for-concept-response-body">4.4.3. Handling Server Response</a> <a href="#ref-for-concept-response-body①">(2)</a> <a href="#ref-for-concept-response-body②">(3)</a>
     <li><a href="#ref-for-concept-response-body③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2485,14 +2481,14 @@ itself be statically compressed.</p>
    <a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-cache-mode">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-request-cache-mode①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-request-cache-mode①">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-destination">
    <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-request-destination①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-request-destination①">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-header">
@@ -2505,32 +2501,32 @@ itself be statically compressed.</p>
    <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">4.4.2. Extending the Font Subset</a> <a href="#ref-for-concept-request-method①">(2)</a> <a href="#ref-for-concept-request-method②">(3)</a>
-    <li><a href="#ref-for-concept-request-method③">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-request-method③">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-mode">
    <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-request-mode①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-request-mode①">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response">
    <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-concept-response">4.4.3. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-status">
    <a href="https://fetch.spec.whatwg.org/#concept-status">https://fetch.spec.whatwg.org/#concept-status</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-status">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-concept-status">4.4.3. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-status">
    <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-status">4.4.2.1. Handling Server Response</a> <a href="#ref-for-concept-response-status①">(2)</a>
+    <li><a href="#ref-for-concept-response-status">4.4.3. Handling Server Response</a> <a href="#ref-for-concept-response-status①">(2)</a>
     <li><a href="#ref-for-concept-response-status②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-response-status③">(2)</a> <a href="#ref-for-concept-response-status④">(3)</a>
    </ul>
   </aside>
@@ -2544,8 +2540,8 @@ itself be statically compressed.</p>
    <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-url-path①">4.4.2.2. Font Load Failed</a>
-    <li><a href="#ref-for-concept-url-path②">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-url-path①">4.4.3. Handling Server Response</a>
+    <li><a href="#ref-for-concept-url-path②">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
     <li><a href="#ref-for-concept-url-path③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-url-path④">(2)</a>
    </ul>
   </aside>
@@ -2553,7 +2549,7 @@ itself be statically compressed.</p>
    <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-url-scheme①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-url-scheme①">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2651,9 +2647,8 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-font-subset①">4.1. Font Subset</a>
     <li><a href="#ref-for-font-subset②">4.4.1. Client State</a>
     <li><a href="#ref-for-font-subset③">4.4.2. Extending the Font Subset</a> <a href="#ref-for-font-subset④">(2)</a> <a href="#ref-for-font-subset⑤">(3)</a> <a href="#ref-for-font-subset⑥">(4)</a> <a href="#ref-for-font-subset⑦">(5)</a> <a href="#ref-for-font-subset⑧">(6)</a> <a href="#ref-for-font-subset⑨">(7)</a> <a href="#ref-for-font-subset①⓪">(8)</a>
-    <li><a href="#ref-for-font-subset①①">4.4.2.1. Handling Server Response</a> <a href="#ref-for-font-subset①②">(2)</a> <a href="#ref-for-font-subset①③">(3)</a>
-    <li><a href="#ref-for-font-subset①④">4.4.2.2. Font Load Failed</a> <a href="#ref-for-font-subset①⑤">(2)</a>
-    <li><a href="#ref-for-font-subset①⑥">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑦">(2)</a> <a href="#ref-for-font-subset①⑧">(3)</a>
+    <li><a href="#ref-for-font-subset①①">4.4.3. Handling Server Response</a> <a href="#ref-for-font-subset①②">(2)</a> <a href="#ref-for-font-subset①③">(3)</a> <a href="#ref-for-font-subset①④">(4)</a> <a href="#ref-for-font-subset①⑤">(5)</a>
+    <li><a href="#ref-for-font-subset①⑥">4.4.4. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑦">(2)</a> <a href="#ref-for-font-subset①⑧">(3)</a>
     <li><a href="#ref-for-font-subset①⑨">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset②⓪">(2)</a> <a href="#ref-for-font-subset②①">(3)</a> <a href="#ref-for-font-subset②②">(4)</a>
    </ul>
   </aside>
@@ -2661,7 +2656,7 @@ itself be statically compressed.</p>
    <b><a href="#font-subset-definition">#font-subset-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-subset-definition">4.4.2. Extending the Font Subset</a> <a href="#ref-for-font-subset-definition①">(2)</a>
-    <li><a href="#ref-for-font-subset-definition②">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-font-subset-definition②">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="integer">
@@ -2796,7 +2791,7 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-patchrequest">4.2.3. ProtocolVersion</a>
     <li><a href="#ref-for-patchrequest①">4.3.3. PatchRequest</a>
     <li><a href="#ref-for-patchrequest②">4.4.2. Extending the Font Subset</a> <a href="#ref-for-patchrequest③">(2)</a> <a href="#ref-for-patchrequest④">(3)</a>
-    <li><a href="#ref-for-patchrequest⑤">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchrequest⑤">4.4.3. Handling Server Response</a>
     <li><a href="#ref-for-patchrequest⑥">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2909,7 +2904,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse">#patchresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse">4.2.3. ProtocolVersion</a>
-    <li><a href="#ref-for-patchresponse①">4.4.2.1. Handling Server Response</a> <a href="#ref-for-patchresponse②">(2)</a> <a href="#ref-for-patchresponse③">(3)</a>
+    <li><a href="#ref-for-patchresponse①">4.4.3. Handling Server Response</a> <a href="#ref-for-patchresponse②">(2)</a> <a href="#ref-for-patchresponse③">(3)</a>
     <li><a href="#ref-for-patchresponse④">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2923,14 +2918,14 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-patch_format">#patchresponse-patch_format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patch_format">4.3.4. PatchResponse</a> <a href="#ref-for-patchresponse-patch_format①">(2)</a>
-    <li><a href="#ref-for-patchresponse-patch_format②">4.4.2.1. Handling Server Response</a> <a href="#ref-for-patchresponse-patch_format③">(2)</a>
+    <li><a href="#ref-for-patchresponse-patch_format②">4.4.3. Handling Server Response</a> <a href="#ref-for-patchresponse-patch_format③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-patch">
    <b><a href="#patchresponse-patch">#patchresponse-patch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patch">4.3.4. PatchResponse</a> <a href="#ref-for-patchresponse-patch①">(2)</a>
-    <li><a href="#ref-for-patchresponse-patch②">4.4.2.1. Handling Server Response</a> <a href="#ref-for-patchresponse-patch③">(2)</a> <a href="#ref-for-patchresponse-patch④">(3)</a>
+    <li><a href="#ref-for-patchresponse-patch②">4.4.3. Handling Server Response</a> <a href="#ref-for-patchresponse-patch③">(2)</a> <a href="#ref-for-patchresponse-patch④">(3)</a>
     <li><a href="#ref-for-patchresponse-patch⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-patch⑥">(2)</a> <a href="#ref-for-patchresponse-patch⑦">(3)</a> <a href="#ref-for-patchresponse-patch⑧">(4)</a>
    </ul>
   </aside>
@@ -2938,7 +2933,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-replacement">#patchresponse-replacement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-replacement">4.3.4. PatchResponse</a> <a href="#ref-for-patchresponse-replacement①">(2)</a>
-    <li><a href="#ref-for-patchresponse-replacement②">4.4.2.1. Handling Server Response</a> <a href="#ref-for-patchresponse-replacement③">(2)</a> <a href="#ref-for-patchresponse-replacement④">(3)</a>
+    <li><a href="#ref-for-patchresponse-replacement②">4.4.3. Handling Server Response</a> <a href="#ref-for-patchresponse-replacement③">(2)</a> <a href="#ref-for-patchresponse-replacement④">(3)</a>
     <li><a href="#ref-for-patchresponse-replacement⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement⑥">(2)</a> <a href="#ref-for-patchresponse-replacement⑦">(3)</a> <a href="#ref-for-patchresponse-replacement⑧">(4)</a>
    </ul>
   </aside>
@@ -2946,7 +2941,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-original_font_checksum">#patchresponse-original_font_checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-original_font_checksum">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-original_font_checksum①">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-original_font_checksum①">4.4.3. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-original_font_checksum②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2954,7 +2949,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-patched_checksum">#patchresponse-patched_checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patched_checksum">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-patched_checksum①">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-patched_checksum①">4.4.3. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-patched_checksum②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2963,7 +2958,7 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchresponse-codepoint_ordering">4.3.4. PatchResponse</a>
     <li><a href="#ref-for-patchresponse-codepoint_ordering①">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-codepoint_ordering②">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-codepoint_ordering②">4.4.3. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-codepoint_ordering③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2972,7 +2967,7 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchresponse-ordering_checksum">4.3.4. PatchResponse</a>
     <li><a href="#ref-for-patchresponse-ordering_checksum①">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-ordering_checksum②">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-ordering_checksum②">4.4.3. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-ordering_checksum③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2980,7 +2975,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-subset_axis_space">#patchresponse-subset_axis_space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-subset_axis_space">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-subset_axis_space①">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-subset_axis_space①">4.4.3. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-subset_axis_space②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2988,7 +2983,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-original_axis_space">#patchresponse-original_axis_space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-original_axis_space">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-original_axis_space①">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-original_axis_space①">4.4.3. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-original_axis_space②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2996,7 +2991,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-original_features">#patchresponse-original_features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-original_features">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-original_features①">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-original_features①">4.4.3. Handling Server Response</a>
     <li><a href="#ref-for-patchresponse-original_features②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -3004,21 +2999,21 @@ itself be statically compressed.</p>
    <b><a href="#client-state">#client-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state①">(2)</a>
-    <li><a href="#ref-for-client-state②">4.4.2.1. Handling Server Response</a> <a href="#ref-for-client-state③">(2)</a>
+    <li><a href="#ref-for-client-state②">4.4.3. Handling Server Response</a> <a href="#ref-for-client-state③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-client-font-subset">
    <b><a href="#client-state-client-font-subset">#client-state-client-font-subset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state-client-font-subset">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state-client-font-subset①">(2)</a> <a href="#ref-for-client-state-client-font-subset②">(3)</a> <a href="#ref-for-client-state-client-font-subset③">(4)</a> <a href="#ref-for-client-state-client-font-subset④">(5)</a> <a href="#ref-for-client-state-client-font-subset⑤">(6)</a> <a href="#ref-for-client-state-client-font-subset⑥">(7)</a> <a href="#ref-for-client-state-client-font-subset⑦">(8)</a> <a href="#ref-for-client-state-client-font-subset⑧">(9)</a> <a href="#ref-for-client-state-client-font-subset⑨">(10)</a> <a href="#ref-for-client-state-client-font-subset①⓪">(11)</a>
-    <li><a href="#ref-for-client-state-client-font-subset①①">4.4.2.1. Handling Server Response</a> <a href="#ref-for-client-state-client-font-subset①②">(2)</a> <a href="#ref-for-client-state-client-font-subset①③">(3)</a>
+    <li><a href="#ref-for-client-state-client-font-subset①①">4.4.3. Handling Server Response</a> <a href="#ref-for-client-state-client-font-subset①②">(2)</a> <a href="#ref-for-client-state-client-font-subset①③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-original-font-checksum">
    <b><a href="#client-state-original-font-checksum">#client-state-original-font-checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state-original-font-checksum">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-client-state-original-font-checksum①">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-client-state-original-font-checksum①">4.4.3. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-codepoint-reordering-map">
@@ -3031,32 +3026,32 @@ itself be statically compressed.</p>
    <b><a href="#client-state-codepoint-reordering-checksum">#client-state-codepoint-reordering-checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state-codepoint-reordering-checksum">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-client-state-codepoint-reordering-checksum①">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-client-state-codepoint-reordering-checksum①">4.4.3. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-original-font-axis-space">
    <b><a href="#client-state-original-font-axis-space">#client-state-original-font-axis-space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-state-original-font-axis-space">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-client-state-original-font-axis-space">4.4.3. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-subset-axis-space">
    <b><a href="#client-state-subset-axis-space">#client-state-subset-axis-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-state-subset-axis-space">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-client-state-subset-axis-space①">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-client-state-subset-axis-space①">4.4.3. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state-original-font-feature-list">
    <b><a href="#client-state-original-font-feature-list">#client-state-original-font-feature-list</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-state-original-font-feature-list">4.4.2.1. Handling Server Response</a>
+    <li><a href="#ref-for-client-state-original-font-feature-list">4.4.3. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-extend-the-font-subset">
    <b><a href="#abstract-opdef-extend-the-font-subset">#abstract-opdef-extend-the-font-subset</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-extend-the-font-subset">4.4.2.1. Handling Server Response</a> <a href="#ref-for-abstract-opdef-extend-the-font-subset①">(2)</a>
+    <li><a href="#ref-for-abstract-opdef-extend-the-font-subset">4.4.3. Handling Server Response</a> <a href="#ref-for-abstract-opdef-extend-the-font-subset①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patch-request-header">
@@ -3071,11 +3066,17 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-abstract-opdef-handle-server-response">4.4.2. Extending the Font Subset</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="abstract-opdef-handle-failed-font-load">
+   <b><a href="#abstract-opdef-handle-failed-font-load">#abstract-opdef-handle-failed-font-load</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-abstract-opdef-handle-failed-font-load">4.4.3. Handling Server Response</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load①">(2)</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load②">(3)</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load③">(4)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="original-font">
    <b><a href="#original-font">#original-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-original-font">4.4.2. Extending the Font Subset</a> <a href="#ref-for-original-font①">(2)</a> <a href="#ref-for-original-font②">(3)</a> <a href="#ref-for-original-font③">(4)</a>
-    <li><a href="#ref-for-original-font④">4.4.2.2. Font Load Failed</a>
+    <li><a href="#ref-for-original-font④">4.4.3. Handling Server Response</a>
     <li><a href="#ref-for-original-font⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-original-font⑥">(2)</a> <a href="#ref-for-original-font⑦">(3)</a> <a href="#ref-for-original-font⑧">(4)</a> <a href="#ref-for-original-font⑨">(5)</a> <a href="#ref-for-original-font①⓪">(6)</a> <a href="#ref-for-original-font①①">(7)</a> <a href="#ref-for-original-font①②">(8)</a> <a href="#ref-for-original-font①③">(9)</a> <a href="#ref-for-original-font①④">(10)</a>
    </ul>
   </aside>


### PR DESCRIPTION
Updates the "Handling Server Response" and "Load a Font  in a User Agent with a HTTP Cache" sections to use algorithm markup. Also merges the client side checksum mismatch and and the error handling sections to be inline in the handling server response section.

Fixes #106


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/131.html" title="Last updated on Nov 14, 2022, 11:49 PM UTC (9f68756)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/131/992c405...9f68756.html" title="Last updated on Nov 14, 2022, 11:49 PM UTC (9f68756)">Diff</a>