### PR TITLE
Make client state part of the font file.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1329,7 +1329,6 @@ The algorithm:
      return the result.
 
 <dfn abstract-op>Handle failed font load</dfn>
-<!-- TODO update for client state, and proceeding sections -->
 
 If the font load or extension has failed the client should choose one of the following options:
 
@@ -1342,15 +1341,12 @@ If the font load or extension has failed the client should choose one of the fol
 
 3.  Discard the saved [=font subset=], and use the user agent's existing font fallback mechanism.
 
-Regardless of which of the above options are used, the saved client state for this font must be
-discarded.
-
 <h4 algorithm id="load-a-font">Load a Font in a User Agent with a HTTP Cache</h4>
 
 The previous section [[#extend-subset]] provides no guidance on how a user agent should handle
-saving client state between invocations of the subset extension algorithm. This section provides an
-algorithm that user agents which implement [[fetch]] should use to save client state to the user
-agent's HTTP cache ([[RFC9111]]).
+saving the font subset and client state between invocations of the subset extension algorithm. This
+section provides an algorithm that user agents which implement [[fetch]] should use to save the font
+subset to the user agent's HTTP cache ([[RFC9111]]).
 
 <dfn abstract-op>Load a font with a HTTP Cache</h4>
 
@@ -1395,7 +1391,7 @@ The algorithm:
 
      *  Fragment identifier set to the input <var>fragment identifier</var>
 
-     *  Client state set to the response.
+     *  Font subset set to the response.
 
      *  Desired subset definition set to the input <var>desired subset definition</var>.
 
@@ -1409,7 +1405,7 @@ The algorithm:
 
      *  Fragment identifier set to the input <var>fragment identifier</var>
 
-     *  Client state set to null.
+     *  Font subset set to null.
 
      *  Desired subset definition set to the input <var>desired subset definition</var>.
 
@@ -1420,11 +1416,14 @@ The algorithm:
 4.  If the returned cache fields are non-null update the cache entry for the input
      font url with the returned client state and returned cache fields.
 
-5.  Return the [=font subset=] contained in the returned client state.
+5.  Return the returned [=font subset=].
 
 
 Server: Responding to a PatchRequest {#handling-patch-request}
 --------------------------------------------------------------
+
+<!-- TODO update for client state, and proceeding sections -->
+<!-- TODO add details of populating the client state table -->
 
 <span class="conform server" id="conform-successful-response">If the server receives a well formed
 [=PatchRequest=] over HTTPS for a font the server has and that was

--- a/Overview.bs
+++ b/Overview.bs
@@ -1530,8 +1530,6 @@ Additionally:
     If [=PatchRequest/accept_patch_format=] contains any unrecognized patch formats the server must
     ignore the unrecognized ones.</span>
 
-<!-- TODO unrecognized codepoint ordering -->
-
 Note: the server can respond with either a patch or a replacement but should try to produce a patch
 where possible. Replacement's should only be used in situations where the server is unable to recreate
 the client's state in order to generate a patch against it.

--- a/Overview.bs
+++ b/Overview.bs
@@ -1128,8 +1128,7 @@ The inputs to this algorithm are:
     font url, or null.
 
 * <var>desired subset definition</var>: a [=font subset definition|description=] of the desired
-    minimum [=font subset=]. The subset definition must be a superset of the [=font subset=] in
-    <var>client state</var>.
+    minimum [=font subset=].
 
 * <var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as [[fetch]]. The remainder
     of this section is desribed in terms of [[fetch#fetching]], but it is allowed to substitute
@@ -1146,7 +1145,7 @@ The algorithm outputs:
 The algorithm:
 
 1. Compare the <var>desired subset definition</var> to the <var>font subset</var>. If the
-     <var>font subset</var> already satisifies the <var>desired subset definition</var>. Then return
+     <var>font subset</var> is a superset of <var>desired subset definition</var> then return
      <var>font subset</var>, and null for the cache fields.
 
 2. If <var>font subset</var> is set then load the <var>client state</var> from the

--- a/Overview.bs
+++ b/Overview.bs
@@ -1109,35 +1109,6 @@ For a PatchResponse object to be well formed:
 Client {#client}
 ----------------
 
-### <dfn>Client State</dfn> ### {#client-state-section}
-
-The client will need to maintain at minimum the following state for each font file being incrementally
-transferred:
-
-*  <dfn for="Client State">Client font subset</dfn>: a byte array containing the binary data for the
-    most recent version of the [=font subset|subset=] of the font being incrementally transferred. For
-    a new font this is initialized to empty byte array.
-    
-*  <dfn for="Client State">Original font checksum</dfn>: the most recent value of
-    [=PatchResponse/original_font_checksum=] received from the server for this font.
-
-*  <dfn for="Client State">Codepoint Reordering Map</dfn>: The most recent [[#codepoint-reordering]]
-    received from the server for this font. Supplied by [=PatchResponse/codepoint_ordering=].
-
-*  <dfn for="Client State">Original Font Axis Space</dfn>: the variations axis space that the original
-    font covers. Supplied by [=PatchResponse/original_axis_space=]</a>.
-
-*  <dfn for="Client State">Subset Axis Space</dfn>: the most recent variations axis space that the
-    subsetted font covers. Supplied by [=PatchResponse/subset_axis_space=].
-
-Additionally, the client can optionally store:
-
-*  <dfn for="Client State">Original font feature list</dfn>: a list of the
-    <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a>
-    that the original font has data for. This information can be used by the client to avoid sending
-    unnecessary requests for features which the original font does not contain. Supplied by
-    [=PatchResponse/original_features=].
-
 <h4 algorithm id="extend-subset">Extending the Font Subset</h4>
 
 This algorithm is used by the client to extends its [=font subset=] to cover additional codepoints,
@@ -1152,7 +1123,7 @@ The inputs to this algorithm are:
 * <var>fragment identifier</var> (optional): if the font at the font url is a collection of fonts,
     the fragment identifier ([[rfc8081#section-4.2]]) identifies a single font within the collection.
 
-* <var>client state</var> (optional): previously saved [=client state=] for the given
+* <var>font subset</var> (optional): previously loaded [=font subset=] for the given
     font url, or null.
 
 * <var>desired subset definition</var>: a [=font subset definition|description=] of the desired
@@ -1165,20 +1136,25 @@ The inputs to this algorithm are:
 
 The algorithm outputs:
 
-* Client State: [=client state=] that has been updated to contain a [=font subset=] which covers at
-    least the requested subset definition.
+* Extended Font Subset: [=font subset=] that has been updated to cover at least the requested subset
+    definition.
 
 * Cache fields: HTTP cache fields [[rfc9111#name-field-definitions]] describing how client state
     can be cached, or null.
 
 The algorithm:
 
-1. Compare the <var>desired subset definition</var> to the <var>client state</var>. If the
-     [=Client State/client font subset|font subset=] in the <var>client state</var>
-     already satisifies the [=font subset definition=]. Then return <var>client state</var>, and null
-     for the cache fields.
+1. Compare the <var>desired subset definition</var> to the <var>font subset</var>. If the
+     <var>font subset</var> already satisifies the <var>desired subset definition</var>. Then return
+     <var>font subset</var>, and null for the cache fields.
 
-2. Otherwise make an HTTP request using the <var>fetch algorithm</var>:
+2. If <var>font subset</var> is set then load the <var>client state</var> from the
+    <var>font subset</var>. Client state is stored in the <var>font subset</var> as a
+    <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>
+    identified by the 4-byte tag "IFTP". The contents of the table are a single [=ClientState=] object
+    encoded via CBOR.
+
+3. Otherwise make an HTTP request using the <var>fetch algorithm</var>:
 
      * The request [=request/method=] must be either "GET" or "POST".
 
@@ -1214,63 +1190,65 @@ The algorithm:
          capable of decoding. Must contain at least one format.
 
      *  [=PatchRequest/codepoints_have=]: set to exactly the set of codepoints that the current
-         [=Client State/client font subset=] contains data for. If the current
-         [=Client State/client font subset=] is an empty byte array this
-         field is left unset. If the client has a codepoint ordering for this font then this field
-         should not be set.
+         <var>font subset</var> contains data for. If the current
+         <var>font subset</var> is not set then this field is left unset. If
+         <var>client state</var> is available and has a [=ClientState/codepoint_ordering=] then
+         this field should not be set.
 
      *  [=PatchRequest/codepoints_needed=]: set to the set of codepoints that the client wants to
          add to its [=font subset=]. That is the codepoint set from <var>desired subset
-         definition</var> minus the codepoints already in [=Client State/Client font subset=]. If the
-         <var>client state</var> has a [=Client State/codepoint reordering map=] for this font then
+         definition</var> minus the codepoints already in the <var>font subset</var>. If
+         <var>client state</var> is available and has a [=ClientState/codepoint_ordering=] then
          this field should not be set.
 
      *  [=PatchRequest/indices_have=]: encodes the set of additional codepoints that the current
-         [=Client State/client font subset=] contains data for. The codepoint values are transformed
-         to indices by applying [=Client State/codepoint reordering map=] to each codepoint value. If
-         the <var>client state</var> does not have a [=Client State/codepoint reordering map=] for this
-         font then this field should not be set.
+         <var>font subset</var> contains data for. The codepoint values are transformed
+         to indices by applying the [[#codepoint-reordering]] specified by
+         [=ClientState/codepoint_ordering=] to each codepoint value. If
+         the <var>client state</var> is not available or it does not have a
+         [=ClientState/codepoint_ordering=] then this field should not be set.
 
      *  [=PatchRequest/indices_needed=]: encodes the set of codepoints that the client wants to add to
          its [=font subset=]. That is the codepoint set from <var>desired subset
-         definition</var> minus the codepoints already in [=Client State/Client font subset=]. The
-         codepoint values are transformed to indices by applying the [=Client State/codepoint
-         reordering map=] to each codepoint value. If the client does not have a codepoint ordering
-         for this font then this field should not be set.
+         definition</var> minus the codepoints already in <var>font subset</var>.
+         The codepoint values are transformed to indices by applying the [[#codepoint-reordering]]
+         specified by [=ClientState/codepoint_ordering=] to each codepoint value. If
+         the <var>client state</var> is not available or it does not have a
+         [=ClientState/codepoint_ordering=] then this field should not be set.
 
      *  [=PatchRequest/features_have=]: set to the list of
          <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">
-         opentype layout feature tags</a> that the current [=Client State/client font subset=] has data
-         for. If the current [=Client State/client font subset=] is an empty byte array this
-         field is left unset. Additionally, if the current [=Client State/client font subset=] has all
+         opentype layout feature tags</a> that the current <var>font subset</var> has data
+         for. If the current <var>font subset</var> is not set then this
+         field is left unset. Additionally, if the current <var>font subset</var> has all
          data for features present in the [=original font=] then this field can be unset.
 
      *  [=PatchRequest/features_needed=]: set to the list of feature tags that the client wants to add
-         to the current [=font subset=]. That is the feature set from <var>desired subset
-         definition</var> minus the set of features already in [=Client State/Client font subset=].
+         to the current <var>font subset</var>. That is the feature set from <var>desired subset
+         definition</var> minus the set of features already in <var>font subset</var>.
          If the client wishes to add all remaining layout features from the [=original font=] to it's
          subset then this field should be unset.
 
      *  [=PatchRequest/axis_space_have=]: set to the current value of
-         [=Client State/subset axis space=] saved in the <var>client state</var> for this font.
+         [=ClientState/subset_axis_space=] saved in the <var>client state</var> for this font. If
+         <var>client state</var> is not available then this field is unset.
 
      *  [=PatchRequest/axis_space_needed=]: set to the intervals of each variable axis in the
-         [=original font=] that the client wants to add to its [=font subset=] as defined in the
+         [=original font=] that the client wants to add to its <var>font subset</var> as defined in the
          <var>desired subset definition</var>. If the client wants an
          entire axis from the [=original font=] then that axis should not be listed.
 
      *  [=PatchRequest/ordering_checksum=]: If either of [=PatchRequest/indices_have=] or
          [=PatchRequest/indices_needed=] is set then this must be set to the checksum of the
-         [=Client State/codepoint reordering map=] saved in the state for this font. The checksum
+         [=ClientState/codepoint_ordering=] saved in the <var>client state</var>. The checksum
          is computed via [[#reordering-checksum]].
 
      *  [=PatchRequest/original_font_checksum=]:
-         Set to saved value for [=Client State/original font checksum=] in the state for this font. If
-         there is no saved value leave this field unset.
+         Set to saved value for [=ClientState/original_font_checksum=] in the <var>client state</var>
+         for this font. If there is no <var>client state</var> leave this field unset.
 
      *  [=PatchRequest/base_checksum=]:
-         Set to the checksum of the [=Client State/client font subset=] byte array saved in
-         the <var>client state</var> for this font. See: [[#computing-checksums]].
+         Set to the checksum of the <var>font subset</var>. See: [[#computing-checksums]].
 
      *  [=PatchRequest/fragment_id=]:
          If a <var>fragment identifier</var> was provided as an input then this field must be set to
@@ -1281,7 +1259,7 @@ The algorithm:
      example, on slower connections it may be more performant to request extra codepoints if
      that is likely to prevent a future request from needing to be sent.
 
-3. Invoke [$Handle server response$] with the response from the server and return the result.
+4. Invoke [$Handle server response$] with the response from the server and return the result.
 
 Note: POST is preferred for the HTTP method since it will not cause a CORS preflight request
 and the request object is more compactly encoded. GET should only be used during

--- a/Overview.bs
+++ b/Overview.bs
@@ -1031,6 +1031,9 @@ For an [=AxisInterval=] object to be well formed:
     <td>13</td>
     <td><dfn for="PatchRequest">fragment_id</dfn>
     </td><td>[=String=]</td></tr>
+  <tr>
+    <td>14</td>
+    <td><dfn for="PatchRequest">codepoint_ordering</dfn></td><td>[=IntegerList=]</td></tr>
 </table>
 
 For a [=PatchRequest=] object to be well formed:
@@ -1063,29 +1066,45 @@ For a [=PatchRequest=] object to be well formed:
     <td><dfn for="PatchResponse">replacement</dfn></td><td>[=ByteString=]</td></tr>
   <tr>
     <td>4</td>
-    <td><dfn for="PatchResponse">original_font_checksum</dfn></td><td>[=Integer=]</td></tr>
-  <tr>
-    <td>5</td>
-    <td><dfn for="PatchResponse">codepoint_ordering</dfn></td><td>[=IntegerList=]</td></tr>
-  <tr>
-    <td>6</td>
-    <td><dfn for="PatchResponse">subset_axis_space</dfn></td><td>[=AxisSpace=]</td></tr>
-  <tr>
-    <td>7</td>
-    <td><dfn for="PatchResponse">original_axis_space</dfn></td><td>[=AxisSpace=]</td></tr>
-  <tr>
-    <td>8</td>
-    <td><dfn for="PatchResponse">original_features</dfn></td><td>[=FeatureTagSet=]</td></tr>
+    <td><dfn for="PatchResponse">unrecognized_ordering</dfn></td><td>[=Integer=]</td></tr>
 </table>
 
 For a PatchResponse object to be well formed:
 *  <span class="conform server" id="conform-response-protocol-version">
      [=PatchResponse/protocol_version=] must be set to 0.</span>
 *  <span class="conform server" id="conform-response-patch-or-replacement">
-     Only one of [=PatchResponse/patch=] or [=PatchResponse/replacement=] must be set.</span>
+     Only one of [=PatchResponse/patch=], [=PatchResponse/replacement=], or
+     [=PatchResponse/unrecognized_ordering=] must be set.</span>
 *  <span class="conform server" id="conform-response-valid-format">
      If [=PatchResponse/patch_format=] is set then it must be one of the values listed in
      [[#patch-formats]].</span>
+
+### <dfn>ClientState</dfn> ### {#ClientState}
+
+<table>
+  <tr><th>ID</th><th>Field Name</th><th>Value Type</th></tr>
+
+  <tr>
+    <td>0</td>
+    <td><dfn for="ClientState">original_font_checksum</dfn></td><td>[=Integer=]</td></tr>
+
+  <tr>
+    <td>1</td>
+    <td><dfn for="ClientState">codepoint_ordering</dfn></td><td>[=IntegerList=]</td></tr>
+
+  <tr>
+    <td>2</td>
+    <td><dfn for="ClientState">subset_axis_space</dfn></td><td>[=AxisSpace=]</td></tr>
+
+  <tr>
+    <td>3</td>
+    <td><dfn for="ClientState">original_axis_space</dfn></td><td>[=AxisSpace=]</td></tr>
+
+  <tr>
+    <td>4</td>
+    <td><dfn for="ClientState">original_features</dfn></td><td>[=FeatureTagSet=]</td></tr>
+
+</table>
 
 Client {#client}
 ----------------

--- a/Overview.bs
+++ b/Overview.bs
@@ -1422,9 +1422,6 @@ The algorithm:
 Server: Responding to a PatchRequest {#handling-patch-request}
 --------------------------------------------------------------
 
-<!-- TODO update for client state, and proceeding sections -->
-<!-- TODO add details of populating the client state table -->
-
 <span class="conform server" id="conform-successful-response">If the server receives a well formed
 [=PatchRequest=] over HTTPS for a font the server has and that was
 populated according to the requirements in [[#extend-subset]] then it must respond with HTTP
@@ -1476,7 +1473,7 @@ If the server does not recognize the codepoint ordering used by the client, it m
 with a response that will cause the client to update it's codepoint ordering to one the server
 will recognize via the process described in [[#handling-patch-response]] and not include any patch.
 That is the [=PatchResponse/patch=] and [=PatchResponse/replacement=] fields must not be set.
-</span>
+The [=PatchResponse/unrecognized_ordering=] field must be set to a non-zero value.</span>
 
 <span class="conform server" id="conform-response-valid-patch">
 Otherwise when the response is applied by the client following the process in
@@ -1494,27 +1491,34 @@ result in an extended [=font subset=]:
     space that covers at least the union of the axis space the client has and the axis space the
     client needs.</span>
 
-If the checksum of the [=original font=] computed by the procedure in [[#computing-checksums]] does not
-match the checksum in [=PatchRequest/original_font_checksum=] or
-[=PatchRequest/original_font_checksum=] is unset, then:
 
-*  <span class="conform server" id="conform-response-original-checksum">The value of
-    [=PatchResponse/original_font_checksum=] must be set to the checksum of the [=original font=]
-    computed by the procedure in [[#computing-checksums]].</span>
+*  <span class="conform server" id="conform-response-client-state">That has a
+    <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>
+    which is mapped to the tag "IFTP" whose content is a single [=ClientState=] object encoded via
+    CBOR:</span>
 
-*  <span class="conform server" id="conform-response-codepoint-ordering">
-    The response must set the [=PatchResponse/codepoint_ordering=] field following
-    [[#codepoint-reordering]].</span>
+    *  <span class="conform server" id="conform-response-client-state-original-checksum">The
+        [=ClientState/original_font_checksum=] field must be set to the checksum of the
+        [=original font=] computed by the procedure in [[#computing-checksums]].</span>
 
-*  <span class="conform server" id="conform-response-original-features">
-    The response must set the [=PatchResponse/original_features=] field to the list of
-    <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
-    feature tags</a> that the [=original font=] has data for.</span>
+    *  <span class="conform server" id="conform-response-client-state-codepoint-ordering">
+         The [=ClientState/codepoint_ordering=] field must be set following
+         [[#codepoint-reordering]].</span>
 
-*  <span class="conform server" id="conform-response-original-axis-space">
-    If the [=original font=] has variation axes, the
-    response must set the [=PatchResponse/original_axis_space=] field to the axis space covered by
-    the [=original font=].</span>
+    *  <span class="conform server" id="conform-response-client-state-subset-axis-space-field">
+         If the [=original font=] has variation axes, the
+         [=ClientState/subset_axis_space=] field must be set to the axis space covered by the
+         [=font subset=].</span>
+
+    *  <span class="conform server" id="conform-response-client-state-original-axis-space">
+         If the [=original font=] has variation axes, the
+         [=ClientState/original_axis_space=] field must be set to the axis space covered by
+         the [=original font=].</span>
+
+    *  <span class="conform server" id="conform-response-client-state-original-features">
+        The [=ClientState/original_features=] field must be set to the list of
+        <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
+        feature tags</a> that the [=original font=] has data for.</span>
 
 Additionally:
 
@@ -1522,14 +1526,11 @@ Additionally:
     either the [=PatchResponse/patch=] or [=PatchResponse/replacement=] fields must be one of those
     listed in [=PatchRequest/accept_patch_format=]</span>.
 
-*  <span class="conform server" id="conform-response-subset-axis-space-field">
-    If [=PatchResponse/patch=] or [=PatchResponse/replacement=] fields are set and the
-    [=original font=] has variation axes, the response must set the [=PatchResponse/subset_axis_space=]
-    field to the axis space covered by the [=font subset=].</span>
-
 *  <span class="conform server" id="conform-response-ignore-unrecognized-formats">
     If [=PatchRequest/accept_patch_format=] contains any unrecognized patch formats the server must
     ignore the unrecognized ones.</span>
+
+<!-- TODO unrecognized codepoint ordering -->
 
 Note: the server can respond with either a patch or a replacement but should try to produce a patch
 where possible. Replacement's should only be used in situations where the server is unable to recreate

--- a/Overview.bs
+++ b/Overview.bs
@@ -1319,13 +1319,14 @@ The algorithm:
      <var>font subset</var>. This produces the extended font subset. Return the extended font subset
      and any cache headers that were set on the <var>server response</var>.
 
-6. TODO handle new field unrecognized_ordering.
-    <!-- If the field [=PatchResponse/codepoint_ordering=] is set then update the
-    [=Client State/codepoint reordering map=] in the input <var>client state</var> with
-    the new values specified the field. If neither [=PatchResponse/replacement=] nor
-    [=PatchResponse/patch=] are set, then the client should resend the request that triggered this
-    response but use the new codepoint ordering provided in this response. Go back to step 1 to process
-    the response. -->
+6.  If field [=PatchResponse/unrecognized_ordering=] is set to a non-zero value then the client should
+     resend the request that triggered this response but also set the
+     [=PatchRequest/codepoint_ordering=] field on the request to the [=ClientState/codepoint_ordering=]
+     in the client state table within <var>font subset</var>.
+
+7.  Otherwise if none of [=PatchResponse/replacement=], [=PatchResponse/patch=], or
+     [=PatchResponse/unrecognized_ordering=] this is an error, invoke [$Handle failed font load$] and
+     return the result.
 
 <dfn abstract-op>Handle failed font load</dfn>
 <!-- TODO update for client state, and proceeding sections -->

--- a/Overview.bs
+++ b/Overview.bs
@@ -1259,7 +1259,8 @@ The algorithm:
      example, on slower connections it may be more performant to request extra codepoints if
      that is likely to prevent a future request from needing to be sent.
 
-4. Invoke [$Handle server response$] with the response from the server and return the result.
+4. Invoke [$Handle server response$] with the response from the server and the <var>font subset</var>
+    then return the result.
 
 Note: POST is preferred for the HTTP method since it will not cause a CORS preflight request
 and the request object is more compactly encoded. GET should only be used during
@@ -1279,12 +1280,12 @@ Inputs:
 
 * <var>server response</var>: HTTP [=response=] to a patch request.
 
-* <var>client state</var> (optional): previously saved [=client state=].
+* <var>font subset</var> (optional): existing [=font subset=] which is  being extended. May be null.
 
 The algorithm outputs:
 
-* Client State: [=client state=] that has been updated to contain a [=font subset=] which covers at
-    least the requested subset definition.
+* Extended Font Subset: [=font subset=] that has been updated to cover at least the requested subset
+    definition.
 
 * Cache fields: HTTP cache fields [[rfc9111#name-field-definitions]] describing how client state
     can be cached, or null.
@@ -1310,43 +1311,24 @@ The algorithm:
 
 4.  If field [=PatchResponse/replacement=] is set then: the byte array in this field is a binary patch
      in the format specified by [=PatchResponse/patch_format=]. Apply the binary patch to a base which
-     is an empty byte array. Replace the [=Client State/client font subset|font subset=] in the input
-     <var>client state</var> with the result of the patch application.
+     is an empty byte array. This produces the extended font subset. Return the extended font subset
+     and any cache headers that were set on the <var>server response</var>.
 
-5. If field [=PatchResponse/patch=] is set then:  the byte array in this field is a binary patch
-    in the format specifiedy [=PatchResponse/patch_format=]. Apply the binary patch to the
-    [=Client State/client font subset|font subset=] from the input client state. Replace the
-    [=Client State/client font subset|font subset=] in the input <var>client state</var> with the
-    result of the patch application.
+5.  If field [=PatchResponse/patch=] is set then:  the byte array in this field is a binary patch
+     in the format specifiedy [=PatchResponse/patch_format=]. Apply the binary patch to the input
+     <var>font subset</var>. This produces the extended font subset. Return the extended font subset
+     and any cache headers that were set on the <var>server response</var>.
 
-
-6. If [=PatchResponse/original_font_checksum=] is set then update the
-    [=Client State/original font checksum=] in the input <var>client state</var> with the value in
-    [=PatchResponse/original_font_checksum=].
-
-7. If the field [=PatchResponse/codepoint_ordering=] is set then update the
+6. TODO handle new field unrecognized_ordering.
+    <!-- If the field [=PatchResponse/codepoint_ordering=] is set then update the
     [=Client State/codepoint reordering map=] in the input <var>client state</var> with
     the new values specified the field. If neither [=PatchResponse/replacement=] nor
     [=PatchResponse/patch=] are set, then the client should resend the request that triggered this
     response but use the new codepoint ordering provided in this response. Go back to step 1 to process
-    the response.
-
-8. If [=PatchResponse/original_features=] is set and the client has opted to save them then replace the
-    [=Client State/original font feature list=] in the input <var>client state</var> with the value
-    from the response.
-
-9. If [=PatchResponse/original_axis_space=] is set then update the
-    [=Client State/original font axis space=] in the input <var>client state</var> with the value
-    specified in this field.
-
-10. If [=PatchResponse/subset_axis_space=] is set then update the
-     [=Client State/subset axis space=] in the input <var>client state</var> with the value specified
-     in this field.
-
-After processing the response, return the updated input <var>client state</var> and any cache headers
-that were set on the <var>server response</var>.
+    the response. -->
 
 <dfn abstract-op>Handle failed font load</dfn>
+<!-- TODO update for client state, and proceeding sections -->
 
 If the font load or extension has failed the client should choose one of the following options:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -6,6 +6,7 @@ Prepare for TR: yes
 Date: 2022-06-28
 Group: webfontswg
 Level: none
+Markup Shorthands: css no
 TR: https://www.w3.org/TR/IFT/
 ED: https://w3c.github.io/IFT/Overview.html
 Editor: Chris Lilley, W3C, https://svgees.us/, w3cid 1438
@@ -1120,7 +1121,7 @@ The inputs to this algorithm are:
 
 * <var>font URL</var>: a URL where the font to be extended is located.
 
-* <var>fragment identifier</var> (optional): if the font at the font url is a collection of fonts,
+* <var>fragment identifier</var> (optional): if the font at the font url is a font collection,
     the fragment identifier ([[rfc8081#section-4.2]]) identifies a single font within the collection.
 
 * <var>font subset</var> (optional): previously loaded [=font subset=] for the given
@@ -1151,7 +1152,7 @@ The algorithm:
 2. If <var>font subset</var> is set then load the <var>client state</var> from the
     <var>font subset</var>. Client state is stored in the <var>font subset</var> as a
     <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>
-    identified by the 4-byte tag "IFTP". The contents of the table are a single [=ClientState=] object
+    identified by the 4-byte tag 'IFTP'. The contents of the table are a single [=ClientState=] object
     encoded via CBOR.
 
 3. Otherwise make an HTTP request using the <var>fetch algorithm</var>:
@@ -1354,7 +1355,7 @@ The inputs to this algorithm:
 
 * <var>font URL</var>: a URL where the font to be extended is located.
 
-* <var>fragment identifier</var> (optional): if the font at the font url is a collection of fonts,
+* <var>fragment identifier</var> (optional): if the font at the font url is a font collection,
     the fragment identifier ([[rfc8081#section-4.2]]) identifies a single font within the collection.
 
 * <var>desired subset definition</var>: a [=font subset definition|description=] of the desired
@@ -1432,7 +1433,7 @@ single [=PatchResponse=] object encoded via CBOR.</span>
 
 The [=url/path=] in the request [=request/url=] identifies the specific font that a patch is desired
 for. If the request has the [=PatchRequest/fragment_id=] field set and the file identified by
-[=url/path=] is a collection of fonts, then [=PatchRequest/fragment_id=] identifies the font within
+[=url/path=] is a font collection, then [=PatchRequest/fragment_id=] identifies the font within
 that collection that a patch is desired for. The identified font is referred to as the
 <dfn>original font</dfn> in the rest of this section.
 
@@ -1494,7 +1495,7 @@ result in an extended [=font subset=]:
 
 *  <span class="conform server" id="conform-response-client-state">That has a
     <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>
-    which is mapped to the tag "IFTP" whose content is a single [=ClientState=] object encoded via
+    which is identified by the tag 'IFTP' whose content is a single [=ClientState=] object encoded via
     CBOR:</span>
 
     *  <span class="conform server" id="conform-response-client-state-original-checksum">The

--- a/Overview.bs
+++ b/Overview.bs
@@ -384,8 +384,8 @@ If the content does not specify a specific method:
 </table>
 
 
-Offline Usage
--------------
+Offline Usage {#offline-usage}
+------------------------------
 
 Special consideration must be taken when saving a page for offline usage that uses an incrementally
 transferred font since the saved page won't be able to increment the font if content changes (eg.

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="4b9c5a97001b6daf78e6af884df9cc52522425b9" name="document-revision">
+  <meta content="068bef1f6d47c2e3a67811fdc5656346098c91ce" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1336,11 +1336,11 @@ set then <a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-
       <td><a data-link-type="dfn" href="#axisspace" id="ref-for-axisspace②">AxisSpace</a>
      <tr>
       <td>3
-      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_axis_space">original_axis_space<a class="self-link" href="#clientstate-original_axis_space"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_axis_space">original_axis_space</dfn>
       <td><a data-link-type="dfn" href="#axisspace" id="ref-for-axisspace③">AxisSpace</a>
      <tr>
       <td>4
-      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_features">original_features<a class="self-link" href="#clientstate-original_features"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_features">original_features</dfn>
       <td><a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset②">FeatureTagSet</a>
    </table>
    <h3 class="heading settled" data-level="4.4" id="client"><span class="secno">4.4. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
@@ -1658,7 +1658,8 @@ that collection that a patch is desired for. The identified font is referred to 
    <p><span class="conform server" id="conform-bad-reordering"> If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
 will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> and not include any patch.
-That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> fields must not be set. </span></p>
+That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> fields must not be set.
+The <a data-link-type="dfn" href="#patchresponse-unrecognized_ordering" id="ref-for-patchresponse-unrecognized_ordering③">unrecognized_ordering</a> field must be set to a non-zero value.</span></p>
    <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
 result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>: </span></p>
    <ul>
@@ -1672,21 +1673,23 @@ the union of the set of features needed and the sets of features the client alre
      <p><span class="conform server" id="conform-response-subset-axis-space">That contains a variation axis
 space that covers at least the union of the axis space the client has and the axis space the
 client needs.</span></p>
-   </ul>
-   <p>If the checksum of the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font⑨">original font</a> computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a> does not
-match the checksum in <a data-link-type="dfn" href="#patchrequest-original_font_checksum" id="ref-for-patchrequest-original_font_checksum②">original_font_checksum</a> or <a data-link-type="dfn" href="#patchrequest-original_font_checksum" id="ref-for-patchrequest-original_font_checksum③">original_font_checksum</a> is unset, then:</p>
-   <ul>
     <li data-md>
-     <p><span class="conform server" id="conform-response-original-checksum">The value of <a data-link-type="dfn">original_font_checksum</a> must be set to the checksum of the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①⓪">original font</a> computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
-    <li data-md>
-     <p><span class="conform server" id="conform-response-codepoint-ordering"> The response must set the <a data-link-type="dfn">codepoint_ordering</a> field following <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a>.</span></p>
-    <li data-md>
-     <p><span class="conform server" id="conform-response-original-features"> The response must set the <a data-link-type="dfn">original_features</a> field to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
-feature tags</a> that the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①①">original font</a> has data for.</span></p>
-    <li data-md>
-     <p><span class="conform server" id="conform-response-original-axis-space"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①②">original font</a> has variation axes, the
-response must set the <a data-link-type="dfn">original_axis_space</a> field to the axis space covered by
-the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①③">original font</a>.</span></p>
+     <p><span class="conform server" id="conform-response-client-state">That has a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> which is mapped to the tag "IFTP" whose content is a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate①">ClientState</a> object encoded via
+CBOR:</span></p>
+     <ul>
+      <li data-md>
+       <p><span class="conform server" id="conform-response-client-state-original-checksum">The <a data-link-type="dfn" href="#clientstate-original_font_checksum" id="ref-for-clientstate-original_font_checksum①">original_font_checksum</a> field must be set to the checksum of the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font⑨">original font</a> computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
+      <li data-md>
+       <p><span class="conform server" id="conform-response-client-state-codepoint-ordering"> The <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑧">codepoint_ordering</a> field must be set following <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a>.</span></p>
+      <li data-md>
+       <p><span class="conform server" id="conform-response-client-state-subset-axis-space-field"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①⓪">original font</a> has variation axes, the <a data-link-type="dfn" href="#clientstate-subset_axis_space" id="ref-for-clientstate-subset_axis_space①">subset_axis_space</a> field must be set to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a>.</span></p>
+      <li data-md>
+       <p><span class="conform server" id="conform-response-client-state-original-axis-space"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①①">original font</a> has variation axes, the <a data-link-type="dfn" href="#clientstate-original_axis_space" id="ref-for-clientstate-original_axis_space">original_axis_space</a> field must be set to the axis space covered by
+ the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①②">original font</a>.</span></p>
+      <li data-md>
+       <p><span class="conform server" id="conform-response-client-state-original-features"> The <a data-link-type="dfn" href="#clientstate-original_features" id="ref-for-clientstate-original_features">original_features</a> field must be set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
+feature tags</a> that the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①③">original font</a> has data for.</span></p>
+     </ul>
    </ul>
    <p>Additionally:</p>
    <ul>
@@ -1694,8 +1697,6 @@ the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①�
      <p><span class="conform server" id="conform-response-patch-format">The format of the patch in the
 either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch④">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement④">replacement</a> fields must be one of those
 listed in <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format②">accept_patch_format</a></span>.</p>
-    <li data-md>
-     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-ignore-unrecognized-formats"> If <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format③">accept_patch_format</a> contains any unrecognized patch formats the server must
 ignore the unrecognized ones.</span></p>
@@ -2857,7 +2858,6 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchrequest-original_font_checksum">4.3.3. PatchRequest</a>
     <li><a href="#ref-for-patchrequest-original_font_checksum①">4.4.1. Extending the Font Subset</a>
-    <li><a href="#ref-for-patchrequest-original_font_checksum②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-original_font_checksum③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-base_checksum">
@@ -2907,7 +2907,7 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchresponse-patch">4.3.4. PatchResponse</a>
     <li><a href="#ref-for-patchresponse-patch①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-patch②">(2)</a>
-    <li><a href="#ref-for-patchresponse-patch③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-patch④">(2)</a> <a href="#ref-for-patchresponse-patch⑤">(3)</a>
+    <li><a href="#ref-for-patchresponse-patch③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-patch④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-replacement">
@@ -2915,7 +2915,7 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchresponse-replacement">4.3.4. PatchResponse</a>
     <li><a href="#ref-for-patchresponse-replacement①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-replacement②">(2)</a>
-    <li><a href="#ref-for-patchresponse-replacement③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement④">(2)</a> <a href="#ref-for-patchresponse-replacement⑤">(3)</a>
+    <li><a href="#ref-for-patchresponse-replacement③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-unrecognized_ordering">
@@ -2923,18 +2923,21 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchresponse-unrecognized_ordering">4.3.4. PatchResponse</a>
     <li><a href="#ref-for-patchresponse-unrecognized_ordering①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-unrecognized_ordering②">(2)</a>
+    <li><a href="#ref-for-patchresponse-unrecognized_ordering③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="clientstate">
    <b><a href="#clientstate">#clientstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clientstate">4.4.1. Extending the Font Subset</a>
+    <li><a href="#ref-for-clientstate①">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="clientstate-original_font_checksum">
    <b><a href="#clientstate-original_font_checksum">#clientstate-original_font_checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clientstate-original_font_checksum">4.4.1. Extending the Font Subset</a>
+    <li><a href="#ref-for-clientstate-original_font_checksum①">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="clientstate-codepoint_ordering">
@@ -2942,12 +2945,26 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-clientstate-codepoint_ordering">4.4.1. Extending the Font Subset</a> <a href="#ref-for-clientstate-codepoint_ordering①">(2)</a> <a href="#ref-for-clientstate-codepoint_ordering②">(3)</a> <a href="#ref-for-clientstate-codepoint_ordering③">(4)</a> <a href="#ref-for-clientstate-codepoint_ordering④">(5)</a> <a href="#ref-for-clientstate-codepoint_ordering⑤">(6)</a> <a href="#ref-for-clientstate-codepoint_ordering⑥">(7)</a>
     <li><a href="#ref-for-clientstate-codepoint_ordering⑦">4.4.2. Handling Server Response</a>
+    <li><a href="#ref-for-clientstate-codepoint_ordering⑧">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="clientstate-subset_axis_space">
    <b><a href="#clientstate-subset_axis_space">#clientstate-subset_axis_space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clientstate-subset_axis_space">4.4.1. Extending the Font Subset</a>
+    <li><a href="#ref-for-clientstate-subset_axis_space①">4.5. Server: Responding to a PatchRequest</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="clientstate-original_axis_space">
+   <b><a href="#clientstate-original_axis_space">#clientstate-original_axis_space</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-clientstate-original_axis_space">4.5. Server: Responding to a PatchRequest</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="clientstate-original_features">
+   <b><a href="#clientstate-original_features">#clientstate-original_features</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-clientstate-original_features">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-extend-the-font-subset">
@@ -2980,7 +2997,7 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-original-font">4.4.1. Extending the Font Subset</a> <a href="#ref-for-original-font①">(2)</a> <a href="#ref-for-original-font②">(3)</a> <a href="#ref-for-original-font③">(4)</a>
     <li><a href="#ref-for-original-font④">4.4.2. Handling Server Response</a>
-    <li><a href="#ref-for-original-font⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-original-font⑥">(2)</a> <a href="#ref-for-original-font⑦">(3)</a> <a href="#ref-for-original-font⑧">(4)</a> <a href="#ref-for-original-font⑨">(5)</a> <a href="#ref-for-original-font①⓪">(6)</a> <a href="#ref-for-original-font①①">(7)</a> <a href="#ref-for-original-font①②">(8)</a> <a href="#ref-for-original-font①③">(9)</a> <a href="#ref-for-original-font①④">(10)</a>
+    <li><a href="#ref-for-original-font⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-original-font⑥">(2)</a> <a href="#ref-for-original-font⑦">(3)</a> <a href="#ref-for-original-font⑧">(4)</a> <a href="#ref-for-original-font⑨">(5)</a> <a href="#ref-for-original-font①⓪">(6)</a> <a href="#ref-for-original-font①①">(7)</a> <a href="#ref-for-original-font①②">(8)</a> <a href="#ref-for-original-font①③">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="range-request-optimized-font">

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="4886f2d6375040852822113813dffc2965b41cd8" name="document-revision">
+  <meta content="214b6477cc947f3951287a76d10b3285a7a3bb62" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -357,10 +357,9 @@ dfn > a.self-link::before      { content: "#"; }
       <li>
        <a href="#client"><span class="secno">4.4</span> <span class="content">Client</span></a>
        <ol class="toc">
-        <li><a href="#client-state-section"><span class="secno">4.4.1</span> <span class="content"><span>Client State</span></span></a>
-        <li><a href="#extend-subset"><span class="secno">4.4.2</span> <span class="content">Extending the Font Subset</span></a>
-        <li><a href="#handling-patch-response"><span class="secno">4.4.3</span> <span class="content">Handling Server Response</span></a>
-        <li><a href="#load-a-font"><span class="secno">4.4.4</span> <span class="content">Load a Font in a User Agent with a HTTP Cache</span></a>
+        <li><a href="#extend-subset"><span class="secno">4.4.1</span> <span class="content">Extending the Font Subset</span></a>
+        <li><a href="#handling-patch-response"><span class="secno">4.4.2</span> <span class="content">Handling Server Response</span></a>
+        <li><a href="#load-a-font"><span class="secno">4.4.3</span> <span class="content">Load a Font in a User Agent with a HTTP Cache</span></a>
        </ol>
       <li>
        <a href="#handling-patch-request"><span class="secno">4.5</span> <span class="content">Server: Responding to a PatchRequest</span></a>
@@ -1316,7 +1315,7 @@ set then <a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-
     <li data-md>
      <p><span class="conform server" id="conform-response-valid-format"> If <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format">patch_format</a> is set then it must be one of the values listed in <a href="#patch-formats">§ 4.8 Patch Formats</a>.</span></p>
    </ul>
-   <h4 class="heading settled" data-level="4.3.5" id="ClientState"><span class="secno">4.3.5. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport id="clientstate">ClientState<a class="self-link" href="#clientstate"></a></dfn></span><a class="self-link" href="#ClientState"></a></h4>
+   <h4 class="heading settled" data-level="4.3.5" id="ClientState"><span class="secno">4.3.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="clientstate">ClientState</dfn></span><a class="self-link" href="#ClientState"></a></h4>
    <table>
     <tbody>
      <tr>
@@ -1325,15 +1324,15 @@ set then <a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-
       <th>Value Type
      <tr>
       <td>0
-      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_font_checksum">original_font_checksum<a class="self-link" href="#clientstate-original_font_checksum"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_font_checksum">original_font_checksum</dfn>
       <td><a data-link-type="dfn" href="#integer" id="ref-for-integer⑨">Integer</a>
      <tr>
       <td>1
-      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-codepoint_ordering">codepoint_ordering<a class="self-link" href="#clientstate-codepoint_ordering"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-codepoint_ordering">codepoint_ordering</dfn>
       <td><a data-link-type="dfn" href="#integerlist" id="ref-for-integerlist④">IntegerList</a>
      <tr>
       <td>2
-      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-subset_axis_space">subset_axis_space<a class="self-link" href="#clientstate-subset_axis_space"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-subset_axis_space">subset_axis_space</dfn>
       <td><a data-link-type="dfn" href="#axisspace" id="ref-for-axisspace②">AxisSpace</a>
      <tr>
       <td>3
@@ -1345,33 +1344,8 @@ set then <a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-
       <td><a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset②">FeatureTagSet</a>
    </table>
    <h3 class="heading settled" data-level="4.4" id="client"><span class="secno">4.4. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
-   <h4 class="heading settled" data-level="4.4.1" id="client-state-section"><span class="secno">4.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="client-state">Client State</dfn></span><a class="self-link" href="#client-state-section"></a></h4>
-   <p>The client will need to maintain at minimum the following state for each font file being incrementally
-transferred:</p>
-   <ul>
-    <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-client-font-subset">Client font subset</dfn>: a byte array containing the binary data for the
-most recent version of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②">subset</a> of the font being incrementally transferred. For
-a new font this is initialized to empty byte array.</p>
-    <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-original-font-checksum">Original font checksum</dfn>: the most recent value of <a data-link-type="dfn">original_font_checksum</a> received from the server for this font.</p>
-    <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-codepoint-reordering-map">Codepoint Reordering Map</dfn>: The most recent <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> received from the server for this font. Supplied by <a data-link-type="dfn">codepoint_ordering</a>.</p>
-    <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-original-font-axis-space">Original Font Axis Space</dfn>: the variations axis space that the original
-font covers. Supplied by <a data-link-type="dfn">original_axis_space</a>.</p>
-    <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-subset-axis-space">Subset Axis Space</dfn>: the most recent variations axis space that the
-subsetted font covers. Supplied by <a data-link-type="dfn">subset_axis_space</a>.</p>
-   </ul>
-   <p>Additionally, the client can optionally store:</p>
-   <ul>
-    <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-original-font-feature-list">Original font feature list</dfn>: a list of the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a> that the original font has data for. This information can be used by the client to avoid sending
-unnecessary requests for features which the original font does not contain. Supplied by <a data-link-type="dfn">original_features</a>.</p>
-   </ul>
-   <h4 class="heading settled algorithm" data-algorithm="Extending the Font Subset" data-level="4.4.2" id="extend-subset"><span class="secno">4.4.2. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
-   <p>This algorithm is used by the client to extends its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> to cover additional codepoints,
+   <h4 class="heading settled algorithm" data-algorithm="Extending the Font Subset" data-level="4.4.1" id="extend-subset"><span class="secno">4.4.1. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
+   <p>This algorithm is used by the client to extends its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-extend-the-font-subset">Extend the font subset</dfn></p>
    <p>The inputs to this algorithm are:</p>
@@ -1382,7 +1356,7 @@ features, and/or design-variation space.</p>
      <p><var>fragment identifier</var> (optional): if the font at the font url is a collection of fonts,
 the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section-4.2">The "font" Top-Level Media Type § section-4.2</a>) identifies a single font within the collection.</p>
     <li data-md>
-     <p><var>client state</var> (optional): previously saved <a data-link-type="dfn" href="#client-state" id="ref-for-client-state">client state</a> for the given
+     <p><var>font subset</var> (optional): previously loaded <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> for the given
 font url, or null.</p>
     <li data-md>
      <p><var>desired subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">description</a> of the desired
@@ -1395,8 +1369,8 @@ whatever HTTP fetching algorithm the user agent supports.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>Client State: <a data-link-type="dfn" href="#client-state" id="ref-for-client-state①">client state</a> that has been updated to contain a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> which covers at
-least the requested subset definition.</p>
+     <p>Extended Font Subset: <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> that has been updated to cover at least the requested subset
+definition.</p>
     <li data-md>
      <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions">HTTP Caching § name-field-definitions</a> describing how client state
 can be cached, or null.</p>
@@ -1404,8 +1378,10 @@ can be cached, or null.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Compare the <var>desired subset definition</var> to the <var>client state</var>. If the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset">font subset</a> in the <var>client state</var> already satisifies the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a>. Then return <var>client state</var>, and null
- for the cache fields.</p>
+     <p>Compare the <var>desired subset definition</var> to the <var>font subset</var>. If the <var>font subset</var> already satisifies the <var>desired subset definition</var>. Then return <var>font subset</var>, and null for the cache fields.</p>
+    <li data-md>
+     <p>If <var>font subset</var> is set then load the <var>client state</var> from the <var>font subset</var>. Client state is stored in the <var>font subset</var> as a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag "IFTP". The contents of the table are a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate">ClientState</a> object
+encoded via CBOR.</p>
     <li data-md>
      <p>Otherwise make an HTTP request using the <var>fetch algorithm</var>:</p>
      <ul>
@@ -1440,53 +1416,48 @@ can be cached, or null.</p>
        <p><a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format①">accept_patch_format</a>: set to the list of <a href="#patch-formats">§ 4.8 Patch Formats</a> that this client is
  capable of decoding. Must contain at least one format.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-codepoints_have" id="ref-for-patchrequest-codepoints_have①">codepoints_have</a>: set to exactly the set of codepoints that the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①">client font subset</a> contains data for. If the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset②">client font subset</a> is an empty byte array this
- field is left unset. If the client has a codepoint ordering for this font then this field
- should not be set.</p>
+       <p><a data-link-type="dfn" href="#patchrequest-codepoints_have" id="ref-for-patchrequest-codepoints_have①">codepoints_have</a>: set to exactly the set of codepoints that the current <var>font subset</var> contains data for. If the current <var>font subset</var> is not set then this field is left unset. If <var>client state</var> is available and has a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering">codepoint_ordering</a> then
+ this field should not be set.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed">codepoints_needed</a>: set to the set of codepoints that the client wants to
  add to its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a>. That is the codepoint set from <var>desired subset
- definition</var> minus the codepoints already in <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset③">Client font subset</a>. If the <var>client state</var> has a <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map">codepoint reordering map</a> for this font then
+ definition</var> minus the codepoints already in the <var>font subset</var>. If <var>client state</var> is available and has a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering①">codepoint_ordering</a> then
  this field should not be set.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have②">indices_have</a>: encodes the set of additional codepoints that the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset④">client font subset</a> contains data for. The codepoint values are transformed
- to indices by applying <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map①">codepoint reordering map</a> to each codepoint value. If
- the <var>client state</var> does not have a <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map②">codepoint reordering map</a> for this
- font then this field should not be set.</p>
+       <p><a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have②">indices_have</a>: encodes the set of additional codepoints that the current <var>font subset</var> contains data for. The codepoint values are transformed
+ to indices by applying the <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> specified by <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering②">codepoint_ordering</a> to each codepoint value. If
+ the <var>client state</var> is not available or it does not have a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering③">codepoint_ordering</a> then this field should not be set.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed①">indices_needed</a>: encodes the set of codepoints that the client wants to add to
  its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a>. That is the codepoint set from <var>desired subset
- definition</var> minus the codepoints already in <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑤">Client font subset</a>. The
- codepoint values are transformed to indices by applying the <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map③">codepoint
- reordering map</a> to each codepoint value. If the client does not have a codepoint ordering
- for this font then this field should not be set.</p>
+ definition</var> minus the codepoints already in <var>font subset</var>.
+ The codepoint values are transformed to indices by applying the <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> specified by <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering④">codepoint_ordering</a> to each codepoint value. If
+ the <var>client state</var> is not available or it does not have a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑤">codepoint_ordering</a> then this field should not be set.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"> opentype layout feature tags</a> that the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑥">client font subset</a> has data
- for. If the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑦">client font subset</a> is an empty byte array this
- field is left unset. Additionally, if the current <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑧">client font subset</a> has all
+       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"> opentype layout feature tags</a> that the current <var>font subset</var> has data
+ for. If the current <var>font subset</var> is not set then this
+ field is left unset. Additionally, if the current <var>font subset</var> has all
  data for features present in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font">original font</a> then this field can be unset.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-features_needed" id="ref-for-patchrequest-features_needed">features_needed</a>: set to the list of feature tags that the client wants to add
- to the current <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a>. That is the feature set from <var>desired subset
- definition</var> minus the set of features already in <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset⑨">Client font subset</a>.
+ to the current <var>font subset</var>. That is the feature set from <var>desired subset
+ definition</var> minus the set of features already in <var>font subset</var>.
  If the client wishes to add all remaining layout features from the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①">original font</a> to it’s
  subset then this field should be unset.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-axis_space_have" id="ref-for-patchrequest-axis_space_have">axis_space_have</a>: set to the current value of <a data-link-type="dfn" href="#client-state-subset-axis-space" id="ref-for-client-state-subset-axis-space">subset axis space</a> saved in the <var>client state</var> for this font.</p>
+       <p><a data-link-type="dfn" href="#patchrequest-axis_space_have" id="ref-for-patchrequest-axis_space_have">axis_space_have</a>: set to the current value of <a data-link-type="dfn" href="#clientstate-subset_axis_space" id="ref-for-clientstate-subset_axis_space">subset_axis_space</a> saved in the <var>client state</var> for this font. If <var>client state</var> is not available then this field is unset.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-axis_space_needed" id="ref-for-patchrequest-axis_space_needed">axis_space_needed</a>: set to the intervals of each variable axis in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font②">original font</a> that the client wants to add to its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> as defined in the <var>desired subset definition</var>. If the client wants an
+       <p><a data-link-type="dfn" href="#patchrequest-axis_space_needed" id="ref-for-patchrequest-axis_space_needed">axis_space_needed</a>: set to the intervals of each variable axis in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font②">original font</a> that the client wants to add to its <var>font subset</var> as defined in the <var>desired subset definition</var>. If the client wants an
  entire axis from the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font③">original font</a> then that axis should not be listed.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-for-patchrequest-ordering_checksum①">ordering_checksum</a>: If either of <a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have③">indices_have</a> or <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed②">indices_needed</a> is set then this must be set to the checksum of the <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map④">codepoint reordering map</a> saved in the state for this font. The checksum
+       <p><a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-for-patchrequest-ordering_checksum①">ordering_checksum</a>: If either of <a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have③">indices_have</a> or <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed②">indices_needed</a> is set then this must be set to the checksum of the <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑥">codepoint_ordering</a> saved in the <var>client state</var>. The checksum
  is computed via <a href="#reordering-checksum">§ 4.7.1 Codepoint Reordering Checksum</a>.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-original_font_checksum" id="ref-for-patchrequest-original_font_checksum①">original_font_checksum</a>:
- Set to saved value for <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum">original font checksum</a> in the state for this font. If
- there is no saved value leave this field unset.</p>
+ Set to saved value for <a data-link-type="dfn" href="#clientstate-original_font_checksum" id="ref-for-clientstate-original_font_checksum">original_font_checksum</a> in the <var>client state</var> for this font. If there is no <var>client state</var> leave this field unset.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum①">base_checksum</a>:
- Set to the checksum of the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①⓪">client font subset</a> byte array saved in
- the <var>client state</var> for this font. See: <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</p>
+ Set to the checksum of the <var>font subset</var>. See: <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id">fragment_id</a>:
  If a <var>fragment identifier</var> was provided as an input then this field must be set to
@@ -1500,7 +1471,7 @@ can be cached, or null.</p>
    </ol>
    <p class="note" role="note"><span>Note:</span> POST is preferred for the HTTP method since it will not cause a CORS preflight request
 and the request object is more compactly encoded. GET should only be used during <a href="#method-negotiation">method negotiation</a>.</p>
-   <h4 class="heading settled algorithm" data-algorithm="Handling Server Response" data-level="4.4.3" id="handling-patch-response"><span class="secno">4.4.3. </span><span class="content">Handling Server Response</span><a class="self-link" href="#handling-patch-response"></a></h4>
+   <h4 class="heading settled algorithm" data-algorithm="Handling Server Response" data-level="4.4.2" id="handling-patch-response"><span class="secno">4.4.2. </span><span class="content">Handling Server Response</span><a class="self-link" href="#handling-patch-response"></a></h4>
    <p>If a server is able to succsessfully process a <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑤">PatchRequest</a> it will respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> code 200 and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body">body</a> of the response will
 be a 4 byte magic number (0x49, 0x46, 0x54, 0x20) followed by a single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse①">PatchResponse</a> object encoded
 via CBOR. The client uses the following algorithm to interpret and process the fields of the
@@ -1511,12 +1482,12 @@ object.</p>
     <li data-md>
      <p><var>server response</var>: HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a> to a patch request.</p>
     <li data-md>
-     <p><var>client state</var> (optional): previously saved <a data-link-type="dfn" href="#client-state" id="ref-for-client-state②">client state</a>.</p>
+     <p><var>client state</var> (optional): previously saved <a data-link-type="dfn">client state</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>Client State: <a data-link-type="dfn" href="#client-state" id="ref-for-client-state③">client state</a> that has been updated to contain a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> which covers at
+     <p>Client State: <a data-link-type="dfn">client state</a> that has been updated to contain a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a> which covers at
 least the requested subset definition.</p>
     <li data-md>
      <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions">HTTP Caching § name-field-definitions</a> describing how client state
@@ -1530,7 +1501,7 @@ can be cached, or null.</p>
       <li data-md>
        <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to step 1.</p>
       <li data-md>
-       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> extension has failed. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load">Handle failed font load</a> and return the result.</p>
+       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> extension has failed. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load">Handle failed font load</a> and return the result.</p>
      </ul>
     <li data-md>
      <p>Check the first four bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a>. If they are
@@ -1542,26 +1513,26 @@ can be cached, or null.</p>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement①">replacement</a> is set then: the byte array in this field is a binary patch
  in the format specified by <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format①">patch_format</a>. Apply the binary patch to a base which
- is an empty byte array. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①①">font subset</a> in the input <var>client state</var> with the result of the patch application.</p>
+ is an empty byte array. Replace the <a data-link-type="dfn">font subset</a> in the input <var>client state</var> with the result of the patch application.</p>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch①">patch</a> is set then:  the byte array in this field is a binary patch
-in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①②">font subset</a> from the input client state. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①③">font subset</a> in the input <var>client state</var> with the
+in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to the <a data-link-type="dfn">font subset</a> from the input client state. Replace the <a data-link-type="dfn">font subset</a> in the input <var>client state</var> with the
 result of the patch application.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn">original_font_checksum</a> is set then update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in the input <var>client state</var> with the value in <a data-link-type="dfn">original_font_checksum</a>.</p>
+     <p>If <a data-link-type="dfn">original_font_checksum</a> is set then update the <a data-link-type="dfn">original font checksum</a> in the input <var>client state</var> with the value in <a data-link-type="dfn">original_font_checksum</a>.</p>
     <li data-md>
-     <p>If the field <a data-link-type="dfn">codepoint_ordering</a> is set then update the <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map⑤">codepoint reordering map</a> in the input <var>client state</var> with
+     <p>If the field <a data-link-type="dfn">codepoint_ordering</a> is set then update the <a data-link-type="dfn">codepoint reordering map</a> in the input <var>client state</var> with
 the new values specified the field. If neither <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> nor <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch②">patch</a> are set, then the client should resend the request that triggered this
 response but use the new codepoint ordering provided in this response. Go back to step 1 to process
 the response.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn">original_features</a> is set and the client has opted to save them then replace the <a data-link-type="dfn" href="#client-state-original-font-feature-list" id="ref-for-client-state-original-font-feature-list">original font feature list</a> in the input <var>client state</var> with the value
+     <p>If <a data-link-type="dfn">original_features</a> is set and the client has opted to save them then replace the <a data-link-type="dfn">original font feature list</a> in the input <var>client state</var> with the value
 from the response.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn">original_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-original-font-axis-space" id="ref-for-client-state-original-font-axis-space">original font axis space</a> in the input <var>client state</var> with the value
+     <p>If <a data-link-type="dfn">original_axis_space</a> is set then update the <a data-link-type="dfn">original font axis space</a> in the input <var>client state</var> with the value
 specified in this field.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn">subset_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-subset-axis-space" id="ref-for-client-state-subset-axis-space①">subset axis space</a> in the input <var>client state</var> with the value specified
+     <p>If <a data-link-type="dfn">subset_axis_space</a> is set then update the <a data-link-type="dfn">subset axis space</a> in the input <var>client state</var> with the value specified
  in this field.</p>
    </ol>
    <p>After processing the response, return the updated input <var>client state</var> and any cache headers
@@ -1570,18 +1541,18 @@ that were set on the <var>server response</var>.</p>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
    <ol>
     <li data-md>
-     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>, it may choose to use that and then use the user
+     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a>, it may choose to use that and then use the user
   agent’s existing font fallback mechanism for codepoints not covered by the subset.</p>
     <li data-md>
      <p>The client may re-issue the request as a regular non incremental font fetch to the same <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>. It must not include the patch subset request parameter or header. This will load
   the entire <a data-link-type="dfn" href="#original-font" id="ref-for-original-font④">original font</a>.</p>
     <li data-md>
-     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
+     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
    </ol>
    <p>Regardless of which of the above options are used, the saved client state for this font must be
 discarded.</p>
-   <h4 class="heading settled algorithm" data-algorithm="Load a Font in a User Agent with a HTTP Cache" data-level="4.4.4" id="load-a-font"><span class="secno">4.4.4. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
-   <p>The previous section <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> provides no guidance on how a user agent should handle
+   <h4 class="heading settled algorithm" data-algorithm="Load a Font in a User Agent with a HTTP Cache" data-level="4.4.3" id="load-a-font"><span class="secno">4.4.3. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
+   <p>The previous section <a href="#extend-subset">§ 4.4.1 Extending the Font Subset</a> provides no guidance on how a user agent should handle
 saving client state between invocations of the subset extension algorithm. This section provides an
 algorithm that user agents which implement <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a> should use to save client state to the user
 agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc9111">[RFC9111]</a>).</p>
@@ -1594,8 +1565,8 @@ agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc9111">[RFC9111
      <p><var>fragment identifier</var> (optional): if the font at the font url is a collection of fonts,
 the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section-4.2">The "font" Top-Level Media Type § section-4.2</a>) identifies a single font within the collection.</p>
     <li data-md>
-     <p><var>desired subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">description</a> of the desired
-minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a>.</p>
+     <p><var>desired subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">description</a> of the desired
+minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>.</p>
     <li data-md>
      <p><var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>. The remainder
 of this section is desribed in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>, but it is allowed to substitute
@@ -1604,7 +1575,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> which covers at minimum the input subset definition.</p>
+     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> which covers at minimum the input subset definition.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1659,11 +1630,11 @@ whatever HTTP fetching algorithm the user agent supports.</p>
      <p>If the returned cache fields are non-null update the cache entry for the input
  font url with the returned client state and returned cache fields.</p>
     <li data-md>
-     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> contained in the returned client state.</p>
+     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> contained in the returned client state.</p>
    </ol>
    <h3 class="heading settled" data-level="4.5" id="handling-patch-request"><span class="secno">4.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
    <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a> over HTTPS for a font the server has and that was
-populated according to the requirements in <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a> then it must respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> code 200.</span> <span class="conform server" id="conform-magic-number">The first 4 bytes of the response <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body③">body</a> must be set to 0x49, 0x46, 0x54, 0x20 ("IFT " encoded as ASCII) followed by a
+populated according to the requirements in <a href="#extend-subset">§ 4.4.1 Extending the Font Subset</a> then it must respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> code 200.</span> <span class="conform server" id="conform-magic-number">The first 4 bytes of the response <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body③">body</a> must be set to 0x49, 0x46, 0x54, 0x20 ("IFT " encoded as ASCII) followed by a
 single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse④">PatchResponse</a> object encoded via CBOR.</span></p>
    <p>The <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path③">path</a> in the request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a> identifies the specific font that a patch is desired
 for. If the request has the <a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id①">fragment_id</a> field set and the file identified by <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path④">path</a> is a collection of fonts, then <a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id②">fragment_id</a> identifies the font within
@@ -1699,10 +1670,10 @@ that collection that a patch is desired for. The identified font is referred to 
    </ol>
    <p><span class="conform server" id="conform-bad-reordering"> If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
-will recognize via the process described in <a href="#handling-patch-response">§ 4.4.3 Handling Server Response</a> and not include any patch.
+will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> and not include any patch.
 That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> fields must not be set. </span></p>
-   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.3 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
-result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a>: </span></p>
+   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
+result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a>: </span></p>
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-subset">That contains data for at least the union
@@ -1737,7 +1708,7 @@ the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①�
 either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch④">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement④">replacement</a> fields must be one of those
 listed in <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format②">accept_patch_format</a></span>.</p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>.</span></p>
+     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-ignore-unrecognized-formats"> If <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format③">accept_patch_format</a> contains any unrecognized patch formats the server must
 ignore the unrecognized ones.</span></p>
@@ -1952,7 +1923,7 @@ which carry different types of glyph outlines:</p>
 itself be statically compressed.</p>
    <h2 class="no-num heading settled" id="priv"><span class="content">Privacy Considerations</span><a class="self-link" href="#priv"></a></h2>
    <h3 class="heading settled" id="content-inference-from-character-set"><span class="content">Content inference from character set</span><a class="self-link" href="#content-inference-from-character-set"></a></h3>
-   <p>IFT exposes, to the server hosting a Web font, the set of characters that the browser can already render in a given Web font, and also the set of characters that it cannot render, but wants to (for example, to render a new Web page). For details, see <a href="#extend-subset">§ 4.4.2 Extending the Font Subset</a>.</p>
+   <p>IFT exposes, to the server hosting a Web font, the set of characters that the browser can already render in a given Web font, and also the set of characters that it cannot render, but wants to (for example, to render a new Web page). For details, see <a href="#extend-subset">§ 4.4.1 Extending the Font Subset</a>.</p>
    <p>The purpose of doing so is to allow the server to compute a binary patch to the existing font, adding more characters. Thus, fonts are transferred incrementally, as needed, which <a href="https://www.w3.org/TR/PFE-evaluation/#analysis-cjk">greatly reduces</a>> the bytes transferred and the overall network cost..</p>
    <p>For some languages, which use a very large character set (Chinese and Japanese are examples) the vast reduction in total bytes transferred means that Web fonts become usable, including on mobile networks, for the first time.</p>
    <p>However, for those languages, it is <em>possible</em> that individual requests might be analyzed by a rogue font server to obtain intelligence about the type of content which is being read. It is unclear how feasible this attack is, or the computational complexity required to exploit it, unless the characters being requested are very unusual.</p>
@@ -2410,8 +2381,6 @@ itself be statically compressed.</p>
    <li><a href="#patchrequest-axis_space_needed">axis_space_needed</a><span>, in § 4.3.3</span>
    <li><a href="#patchrequest-base_checksum">base_checksum</a><span>, in § 4.3.3</span>
    <li><a href="#bytestring">ByteString</a><span>, in § 4.2.2</span>
-   <li><a href="#client-state-client-font-subset">Client font subset</a><span>, in § 4.4.1</span>
-   <li><a href="#client-state">Client State</a><span>, in § 4.4.1</span>
    <li><a href="#clientstate">ClientState</a><span>, in § 4.3.5</span>
    <li>
     codepoint_ordering
@@ -2419,13 +2388,12 @@ itself be statically compressed.</p>
      <li><a href="#clientstate-codepoint_ordering">dfn for ClientState</a><span>, in § 4.3.5</span>
      <li><a href="#patchrequest-codepoint_ordering">dfn for PatchRequest</a><span>, in § 4.3.3</span>
     </ul>
-   <li><a href="#client-state-codepoint-reordering-map">Codepoint Reordering Map</a><span>, in § 4.4.1</span>
    <li><a href="#patchrequest-codepoints_have">codepoints_have</a><span>, in § 4.3.3</span>
    <li><a href="#patchrequest-codepoints_needed">codepoints_needed</a><span>, in § 4.3.3</span>
    <li><a href="#compressedset">CompressedSet</a><span>, in § 4.3.1</span>
    <li><a href="#corpus">corpus</a><span>, in § 5.2.6</span>
    <li><a href="#axisinterval-end">end</a><span>, in § 4.3.2</span>
-   <li><a href="#abstract-opdef-extend-the-font-subset">Extend the font subset</a><span>, in § 4.4.2</span>
+   <li><a href="#abstract-opdef-extend-the-font-subset">Extend the font subset</a><span>, in § 4.4.1</span>
    <li><a href="#patchrequest-features_have">features_have</a><span>, in § 4.3.3</span>
    <li><a href="#patchrequest-features_needed">features_needed</a><span>, in § 4.3.3</span>
    <li><a href="#featuretagset">FeatureTagSet</a><span>, in § 4.2.8</span>
@@ -2433,31 +2401,28 @@ itself be statically compressed.</p>
    <li><a href="#font-subset">font subset</a><span>, in § 4.1</span>
    <li><a href="#font-subset-definition">font subset definition</a><span>, in § 4.1</span>
    <li><a href="#patchrequest-fragment_id">fragment_id</a><span>, in § 4.3.3</span>
-   <li><a href="#abstract-opdef-handle-failed-font-load">Handle failed font load</a><span>, in § 4.4.3</span>
-   <li><a href="#abstract-opdef-handle-server-response">Handle server response</a><span>, in § 4.4.3</span>
+   <li><a href="#abstract-opdef-handle-failed-font-load">Handle failed font load</a><span>, in § 4.4.2</span>
+   <li><a href="#abstract-opdef-handle-server-response">Handle server response</a><span>, in § 4.4.2</span>
    <li><a href="#patchrequest-indices_have">indices_have</a><span>, in § 4.3.3</span>
    <li><a href="#patchrequest-indices_needed">indices_needed</a><span>, in § 4.3.3</span>
    <li><a href="#integer">Integer</a><span>, in § 4.2.2</span>
    <li><a href="#integerlist">IntegerList</a><span>, in § 4.2.5</span>
-   <li><a href="#abstract-opdef-load-a-font-with-a-http-cache">Load a font with a HTTP Cache</a><span>, in § 4.4.4</span>
+   <li><a href="#abstract-opdef-load-a-font-with-a-http-cache">Load a font with a HTTP Cache</a><span>, in § 4.4.3</span>
    <li><a href="#patchrequest-ordering_checksum">ordering_checksum</a><span>, in § 4.3.3</span>
    <li><a href="#clientstate-original_axis_space">original_axis_space</a><span>, in § 4.3.5</span>
    <li><a href="#clientstate-original_features">original_features</a><span>, in § 4.3.5</span>
    <li><a href="#original-font">original font</a><span>, in § 4.5</span>
-   <li><a href="#client-state-original-font-axis-space">Original Font Axis Space</a><span>, in § 4.4.1</span>
-   <li><a href="#client-state-original-font-checksum">Original font checksum</a><span>, in § 4.4.1</span>
    <li>
     original_font_checksum
     <ul>
      <li><a href="#clientstate-original_font_checksum">dfn for ClientState</a><span>, in § 4.3.5</span>
      <li><a href="#patchrequest-original_font_checksum">dfn for PatchRequest</a><span>, in § 4.3.3</span>
     </ul>
-   <li><a href="#client-state-original-font-feature-list">Original font feature list</a><span>, in § 4.4.1</span>
    <li><a href="#outline-table">outline table</a><span>, in § 5.2.4</span>
    <li><a href="#patchresponse-patch">patch</a><span>, in § 4.3.4</span>
    <li><a href="#patchresponse-patch_format">patch_format</a><span>, in § 4.3.4</span>
    <li><a href="#patchrequest">PatchRequest</a><span>, in § 4.3.3</span>
-   <li><a href="#patch-request-header">patch request header</a><span>, in § 4.4.2</span>
+   <li><a href="#patch-request-header">patch request header</a><span>, in § 4.4.1</span>
    <li><a href="#patchresponse">PatchResponse</a><span>, in § 4.3.4</span>
    <li>
     protocol_version
@@ -2476,7 +2441,6 @@ itself be statically compressed.</p>
    <li><a href="#sparsebitset">SparseBitSet</a><span>, in § 4.2.4</span>
    <li><a href="#axisinterval-start">start</a><span>, in § 4.3.2</span>
    <li><a href="#string">String</a><span>, in § 4.2.2</span>
-   <li><a href="#client-state-subset-axis-space">Subset Axis Space</a><span>, in § 4.4.1</span>
    <li><a href="#clientstate-subset_axis_space">subset_axis_space</a><span>, in § 4.3.5</span>
    <li><a href="#patchresponse-unrecognized_ordering">unrecognized_ordering</a><span>, in § 4.3.4</span>
    <li><a href="#usage-document-frequency">usage document frequency</a><span>, in § 5.2.6</span>
@@ -2490,66 +2454,66 @@ itself be statically compressed.</p>
   <aside class="dfn-panel" data-for="term-for-concept-request-body">
    <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-body">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-request-body">4.4.1. Extending the Font Subset</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-body">
    <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-body">4.4.3. Handling Server Response</a> <a href="#ref-for-concept-response-body①">(2)</a> <a href="#ref-for-concept-response-body②">(3)</a>
+    <li><a href="#ref-for-concept-response-body">4.4.2. Handling Server Response</a> <a href="#ref-for-concept-response-body①">(2)</a> <a href="#ref-for-concept-response-body②">(3)</a>
     <li><a href="#ref-for-concept-response-body③">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-cache-mode">
    <a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-cache-mode">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-request-cache-mode①">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-request-cache-mode">4.4.1. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-request-cache-mode①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-destination">
    <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-destination">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-request-destination①">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-request-destination">4.4.1. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-request-destination①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-header">
    <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-header">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-header">4.4.1. Extending the Font Subset</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-method">
    <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-method">4.4.2. Extending the Font Subset</a> <a href="#ref-for-concept-request-method①">(2)</a> <a href="#ref-for-concept-request-method②">(3)</a>
-    <li><a href="#ref-for-concept-request-method③">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-request-method">4.4.1. Extending the Font Subset</a> <a href="#ref-for-concept-request-method①">(2)</a> <a href="#ref-for-concept-request-method②">(3)</a>
+    <li><a href="#ref-for-concept-request-method③">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-mode">
    <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request-mode">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-request-mode①">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-request-mode">4.4.1. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-request-mode①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response">
    <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response">4.4.3. Handling Server Response</a>
+    <li><a href="#ref-for-concept-response">4.4.2. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-status">
    <a href="https://fetch.spec.whatwg.org/#concept-status">https://fetch.spec.whatwg.org/#concept-status</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-status">4.4.3. Handling Server Response</a>
+    <li><a href="#ref-for-concept-status">4.4.2. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-status">
    <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-response-status">4.4.3. Handling Server Response</a> <a href="#ref-for-concept-response-status①">(2)</a>
+    <li><a href="#ref-for-concept-response-status">4.4.2. Handling Server Response</a> <a href="#ref-for-concept-response-status①">(2)</a>
     <li><a href="#ref-for-concept-response-status②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-response-status③">(2)</a> <a href="#ref-for-concept-response-status④">(3)</a>
    </ul>
   </aside>
@@ -2562,17 +2526,17 @@ itself be statically compressed.</p>
   <aside class="dfn-panel" data-for="term-for-concept-url-path">
    <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-path">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-url-path①">4.4.3. Handling Server Response</a>
-    <li><a href="#ref-for-concept-url-path②">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-url-path">4.4.1. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-url-path①">4.4.2. Handling Server Response</a>
+    <li><a href="#ref-for-concept-url-path②">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
     <li><a href="#ref-for-concept-url-path③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-concept-url-path④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
    <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-scheme">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-concept-url-scheme①">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-concept-url-scheme">4.4.1. Extending the Font Subset</a>
+    <li><a href="#ref-for-concept-url-scheme①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2668,18 +2632,17 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-font-subset">1.1. Patch Subset</a>
     <li><a href="#ref-for-font-subset①">4.1. Font Subset</a>
-    <li><a href="#ref-for-font-subset②">4.4.1. Client State</a>
-    <li><a href="#ref-for-font-subset③">4.4.2. Extending the Font Subset</a> <a href="#ref-for-font-subset④">(2)</a> <a href="#ref-for-font-subset⑤">(3)</a> <a href="#ref-for-font-subset⑥">(4)</a> <a href="#ref-for-font-subset⑦">(5)</a> <a href="#ref-for-font-subset⑧">(6)</a> <a href="#ref-for-font-subset⑨">(7)</a> <a href="#ref-for-font-subset①⓪">(8)</a>
-    <li><a href="#ref-for-font-subset①①">4.4.3. Handling Server Response</a> <a href="#ref-for-font-subset①②">(2)</a> <a href="#ref-for-font-subset①③">(3)</a> <a href="#ref-for-font-subset①④">(4)</a>
-    <li><a href="#ref-for-font-subset①⑤">4.4.4. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑥">(2)</a> <a href="#ref-for-font-subset①⑦">(3)</a>
-    <li><a href="#ref-for-font-subset①⑧">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset①⑨">(2)</a> <a href="#ref-for-font-subset②⓪">(3)</a>
+    <li><a href="#ref-for-font-subset②">4.4.1. Extending the Font Subset</a> <a href="#ref-for-font-subset③">(2)</a> <a href="#ref-for-font-subset④">(3)</a> <a href="#ref-for-font-subset⑤">(4)</a> <a href="#ref-for-font-subset⑥">(5)</a> <a href="#ref-for-font-subset⑦">(6)</a> <a href="#ref-for-font-subset⑧">(7)</a>
+    <li><a href="#ref-for-font-subset⑨">4.4.2. Handling Server Response</a> <a href="#ref-for-font-subset①⓪">(2)</a> <a href="#ref-for-font-subset①①">(3)</a> <a href="#ref-for-font-subset①②">(4)</a>
+    <li><a href="#ref-for-font-subset①③">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①④">(2)</a> <a href="#ref-for-font-subset①⑤">(3)</a>
+    <li><a href="#ref-for-font-subset①⑥">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset①⑦">(2)</a> <a href="#ref-for-font-subset①⑧">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="font-subset-definition">
    <b><a href="#font-subset-definition">#font-subset-definition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-font-subset-definition">4.4.2. Extending the Font Subset</a> <a href="#ref-for-font-subset-definition①">(2)</a>
-    <li><a href="#ref-for-font-subset-definition②">4.4.4. Load a Font in a User Agent with a HTTP Cache</a>
+    <li><a href="#ref-for-font-subset-definition">4.4.1. Extending the Font Subset</a>
+    <li><a href="#ref-for-font-subset-definition①">4.4.3. Load a Font in a User Agent with a HTTP Cache</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="integer">
@@ -2815,8 +2778,8 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-patchrequest">4.2.3. ProtocolVersion</a>
     <li><a href="#ref-for-patchrequest①">4.3.3. PatchRequest</a>
-    <li><a href="#ref-for-patchrequest②">4.4.2. Extending the Font Subset</a> <a href="#ref-for-patchrequest③">(2)</a> <a href="#ref-for-patchrequest④">(3)</a>
-    <li><a href="#ref-for-patchrequest⑤">4.4.3. Handling Server Response</a>
+    <li><a href="#ref-for-patchrequest②">4.4.1. Extending the Font Subset</a> <a href="#ref-for-patchrequest③">(2)</a> <a href="#ref-for-patchrequest④">(3)</a>
+    <li><a href="#ref-for-patchrequest⑤">4.4.2. Handling Server Response</a>
     <li><a href="#ref-for-patchrequest⑥">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2824,14 +2787,14 @@ itself be statically compressed.</p>
    <b><a href="#patchrequest-protocol_version">#patchrequest-protocol_version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-protocol_version">4.3.3. PatchRequest</a>
-    <li><a href="#ref-for-patchrequest-protocol_version①">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-protocol_version①">4.4.1. Extending the Font Subset</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-accept_patch_format">
    <b><a href="#patchrequest-accept_patch_format">#patchrequest-accept_patch_format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-accept_patch_format">4.3.3. PatchRequest</a>
-    <li><a href="#ref-for-patchrequest-accept_patch_format①">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-accept_patch_format①">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-accept_patch_format②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-accept_patch_format③">(2)</a>
    </ul>
   </aside>
@@ -2839,14 +2802,14 @@ itself be statically compressed.</p>
    <b><a href="#patchrequest-codepoints_have">#patchrequest-codepoints_have</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-codepoints_have">4.3.3. PatchRequest</a>
-    <li><a href="#ref-for-patchrequest-codepoints_have①">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-codepoints_have①">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-codepoints_have②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-codepoints_needed">
    <b><a href="#patchrequest-codepoints_needed">#patchrequest-codepoints_needed</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-patchrequest-codepoints_needed">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-codepoints_needed">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-codepoints_needed①">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2854,7 +2817,7 @@ itself be statically compressed.</p>
    <b><a href="#patchrequest-indices_have">#patchrequest-indices_have</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-indices_have">4.3.3. PatchRequest</a> <a href="#ref-for-patchrequest-indices_have①">(2)</a>
-    <li><a href="#ref-for-patchrequest-indices_have②">4.4.2. Extending the Font Subset</a> <a href="#ref-for-patchrequest-indices_have③">(2)</a>
+    <li><a href="#ref-for-patchrequest-indices_have②">4.4.1. Extending the Font Subset</a> <a href="#ref-for-patchrequest-indices_have③">(2)</a>
     <li><a href="#ref-for-patchrequest-indices_have④">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-indices_have⑤">(2)</a>
    </ul>
   </aside>
@@ -2862,35 +2825,35 @@ itself be statically compressed.</p>
    <b><a href="#patchrequest-indices_needed">#patchrequest-indices_needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-indices_needed">4.3.3. PatchRequest</a>
-    <li><a href="#ref-for-patchrequest-indices_needed①">4.4.2. Extending the Font Subset</a> <a href="#ref-for-patchrequest-indices_needed②">(2)</a>
+    <li><a href="#ref-for-patchrequest-indices_needed①">4.4.1. Extending the Font Subset</a> <a href="#ref-for-patchrequest-indices_needed②">(2)</a>
     <li><a href="#ref-for-patchrequest-indices_needed③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-indices_needed④">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-features_have">
    <b><a href="#patchrequest-features_have">#patchrequest-features_have</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-patchrequest-features_have">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-features_have">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-features_have①">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-features_needed">
    <b><a href="#patchrequest-features_needed">#patchrequest-features_needed</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-patchrequest-features_needed">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-features_needed">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-features_needed①">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-axis_space_have">
    <b><a href="#patchrequest-axis_space_have">#patchrequest-axis_space_have</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-patchrequest-axis_space_have">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-axis_space_have">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-axis_space_have①">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-axis_space_have②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-axis_space_needed">
    <b><a href="#patchrequest-axis_space_needed">#patchrequest-axis_space_needed</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-patchrequest-axis_space_needed">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-axis_space_needed">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-axis_space_needed①">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-axis_space_needed②">(2)</a>
    </ul>
   </aside>
@@ -2898,7 +2861,7 @@ itself be statically compressed.</p>
    <b><a href="#patchrequest-ordering_checksum">#patchrequest-ordering_checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-ordering_checksum">4.3.3. PatchRequest</a>
-    <li><a href="#ref-for-patchrequest-ordering_checksum①">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-ordering_checksum①">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-ordering_checksum②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-ordering_checksum③">(2)</a>
    </ul>
   </aside>
@@ -2906,7 +2869,7 @@ itself be statically compressed.</p>
    <b><a href="#patchrequest-original_font_checksum">#patchrequest-original_font_checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-original_font_checksum">4.3.3. PatchRequest</a>
-    <li><a href="#ref-for-patchrequest-original_font_checksum①">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-original_font_checksum①">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-original_font_checksum②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-original_font_checksum③">(2)</a>
    </ul>
   </aside>
@@ -2914,14 +2877,14 @@ itself be statically compressed.</p>
    <b><a href="#patchrequest-base_checksum">#patchrequest-base_checksum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchrequest-base_checksum">4.3.3. PatchRequest</a>
-    <li><a href="#ref-for-patchrequest-base_checksum①">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-base_checksum①">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-base_checksum②">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchrequest-fragment_id">
    <b><a href="#patchrequest-fragment_id">#patchrequest-fragment_id</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-patchrequest-fragment_id">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-patchrequest-fragment_id">4.4.1. Extending the Font Subset</a>
     <li><a href="#ref-for-patchrequest-fragment_id①">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-fragment_id②">(2)</a>
    </ul>
   </aside>
@@ -2929,7 +2892,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse">#patchresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse">4.2.3. ProtocolVersion</a>
-    <li><a href="#ref-for-patchresponse①">4.4.3. Handling Server Response</a> <a href="#ref-for-patchresponse②">(2)</a> <a href="#ref-for-patchresponse③">(3)</a>
+    <li><a href="#ref-for-patchresponse①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse②">(2)</a> <a href="#ref-for-patchresponse③">(3)</a>
     <li><a href="#ref-for-patchresponse④">4.5. Server: Responding to a PatchRequest</a>
    </ul>
   </aside>
@@ -2943,14 +2906,14 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-patch_format">#patchresponse-patch_format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patch_format">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-patch_format①">4.4.3. Handling Server Response</a> <a href="#ref-for-patchresponse-patch_format②">(2)</a>
+    <li><a href="#ref-for-patchresponse-patch_format①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-patch_format②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-patch">
    <b><a href="#patchresponse-patch">#patchresponse-patch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patch">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-patch①">4.4.3. Handling Server Response</a> <a href="#ref-for-patchresponse-patch②">(2)</a>
+    <li><a href="#ref-for-patchresponse-patch①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-patch②">(2)</a>
     <li><a href="#ref-for-patchresponse-patch③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-patch④">(2)</a> <a href="#ref-for-patchresponse-patch⑤">(3)</a>
    </ul>
   </aside>
@@ -2958,7 +2921,7 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-replacement">#patchresponse-replacement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-replacement">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-replacement①">4.4.3. Handling Server Response</a> <a href="#ref-for-patchresponse-replacement②">(2)</a>
+    <li><a href="#ref-for-patchresponse-replacement①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-replacement②">(2)</a>
     <li><a href="#ref-for-patchresponse-replacement③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement④">(2)</a> <a href="#ref-for-patchresponse-replacement⑤">(3)</a>
    </ul>
   </aside>
@@ -2968,57 +2931,34 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-patchresponse-unrecognized_ordering">4.3.4. PatchResponse</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-state">
-   <b><a href="#client-state">#client-state</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="clientstate">
+   <b><a href="#clientstate">#clientstate</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-state">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state①">(2)</a>
-    <li><a href="#ref-for-client-state②">4.4.3. Handling Server Response</a> <a href="#ref-for-client-state③">(2)</a>
+    <li><a href="#ref-for-clientstate">4.4.1. Extending the Font Subset</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-state-client-font-subset">
-   <b><a href="#client-state-client-font-subset">#client-state-client-font-subset</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="clientstate-original_font_checksum">
+   <b><a href="#clientstate-original_font_checksum">#clientstate-original_font_checksum</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-state-client-font-subset">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state-client-font-subset①">(2)</a> <a href="#ref-for-client-state-client-font-subset②">(3)</a> <a href="#ref-for-client-state-client-font-subset③">(4)</a> <a href="#ref-for-client-state-client-font-subset④">(5)</a> <a href="#ref-for-client-state-client-font-subset⑤">(6)</a> <a href="#ref-for-client-state-client-font-subset⑥">(7)</a> <a href="#ref-for-client-state-client-font-subset⑦">(8)</a> <a href="#ref-for-client-state-client-font-subset⑧">(9)</a> <a href="#ref-for-client-state-client-font-subset⑨">(10)</a> <a href="#ref-for-client-state-client-font-subset①⓪">(11)</a>
-    <li><a href="#ref-for-client-state-client-font-subset①①">4.4.3. Handling Server Response</a> <a href="#ref-for-client-state-client-font-subset①②">(2)</a> <a href="#ref-for-client-state-client-font-subset①③">(3)</a>
+    <li><a href="#ref-for-clientstate-original_font_checksum">4.4.1. Extending the Font Subset</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-state-original-font-checksum">
-   <b><a href="#client-state-original-font-checksum">#client-state-original-font-checksum</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="clientstate-codepoint_ordering">
+   <b><a href="#clientstate-codepoint_ordering">#clientstate-codepoint_ordering</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-state-original-font-checksum">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-client-state-original-font-checksum①">4.4.3. Handling Server Response</a>
+    <li><a href="#ref-for-clientstate-codepoint_ordering">4.4.1. Extending the Font Subset</a> <a href="#ref-for-clientstate-codepoint_ordering①">(2)</a> <a href="#ref-for-clientstate-codepoint_ordering②">(3)</a> <a href="#ref-for-clientstate-codepoint_ordering③">(4)</a> <a href="#ref-for-clientstate-codepoint_ordering④">(5)</a> <a href="#ref-for-clientstate-codepoint_ordering⑤">(6)</a> <a href="#ref-for-clientstate-codepoint_ordering⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-state-codepoint-reordering-map">
-   <b><a href="#client-state-codepoint-reordering-map">#client-state-codepoint-reordering-map</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="clientstate-subset_axis_space">
+   <b><a href="#clientstate-subset_axis_space">#clientstate-subset_axis_space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-client-state-codepoint-reordering-map">4.4.2. Extending the Font Subset</a> <a href="#ref-for-client-state-codepoint-reordering-map①">(2)</a> <a href="#ref-for-client-state-codepoint-reordering-map②">(3)</a> <a href="#ref-for-client-state-codepoint-reordering-map③">(4)</a> <a href="#ref-for-client-state-codepoint-reordering-map④">(5)</a>
-    <li><a href="#ref-for-client-state-codepoint-reordering-map⑤">4.4.3. Handling Server Response</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="client-state-original-font-axis-space">
-   <b><a href="#client-state-original-font-axis-space">#client-state-original-font-axis-space</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-client-state-original-font-axis-space">4.4.3. Handling Server Response</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="client-state-subset-axis-space">
-   <b><a href="#client-state-subset-axis-space">#client-state-subset-axis-space</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-client-state-subset-axis-space">4.4.2. Extending the Font Subset</a>
-    <li><a href="#ref-for-client-state-subset-axis-space①">4.4.3. Handling Server Response</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="client-state-original-font-feature-list">
-   <b><a href="#client-state-original-font-feature-list">#client-state-original-font-feature-list</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-client-state-original-font-feature-list">4.4.3. Handling Server Response</a>
+    <li><a href="#ref-for-clientstate-subset_axis_space">4.4.1. Extending the Font Subset</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-extend-the-font-subset">
    <b><a href="#abstract-opdef-extend-the-font-subset">#abstract-opdef-extend-the-font-subset</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-extend-the-font-subset">4.4.4. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-abstract-opdef-extend-the-font-subset①">(2)</a>
+    <li><a href="#ref-for-abstract-opdef-extend-the-font-subset">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-abstract-opdef-extend-the-font-subset①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patch-request-header">
@@ -3031,20 +2971,20 @@ itself be statically compressed.</p>
   <aside class="dfn-panel" data-for="abstract-opdef-handle-server-response">
    <b><a href="#abstract-opdef-handle-server-response">#abstract-opdef-handle-server-response</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-handle-server-response">4.4.2. Extending the Font Subset</a>
+    <li><a href="#ref-for-abstract-opdef-handle-server-response">4.4.1. Extending the Font Subset</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-handle-failed-font-load">
    <b><a href="#abstract-opdef-handle-failed-font-load">#abstract-opdef-handle-failed-font-load</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-handle-failed-font-load">4.4.3. Handling Server Response</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load①">(2)</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load②">(3)</a>
+    <li><a href="#ref-for-abstract-opdef-handle-failed-font-load">4.4.2. Handling Server Response</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load①">(2)</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="original-font">
    <b><a href="#original-font">#original-font</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-original-font">4.4.2. Extending the Font Subset</a> <a href="#ref-for-original-font①">(2)</a> <a href="#ref-for-original-font②">(3)</a> <a href="#ref-for-original-font③">(4)</a>
-    <li><a href="#ref-for-original-font④">4.4.3. Handling Server Response</a>
+    <li><a href="#ref-for-original-font">4.4.1. Extending the Font Subset</a> <a href="#ref-for-original-font①">(2)</a> <a href="#ref-for-original-font②">(3)</a> <a href="#ref-for-original-font③">(4)</a>
+    <li><a href="#ref-for-original-font④">4.4.2. Handling Server Response</a>
     <li><a href="#ref-for-original-font⑤">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-original-font⑥">(2)</a> <a href="#ref-for-original-font⑦">(3)</a> <a href="#ref-for-original-font⑧">(4)</a> <a href="#ref-for-original-font⑨">(5)</a> <a href="#ref-for-original-font①⓪">(6)</a> <a href="#ref-for-original-font①①">(7)</a> <a href="#ref-for-original-font①②">(8)</a> <a href="#ref-for-original-font①③">(9)</a> <a href="#ref-for-original-font①④">(10)</a>
    </ul>
   </aside>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="c802401a9d8fe494f2a13b5327377e54139795d5" name="document-revision">
+  <meta content="2da4fa904b91368179ff00b884ef4ad14a2e0692" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -542,7 +542,8 @@ CPU, RAM usage) per request vs range request.</p>
    <h2 class="heading settled" data-level="2" id="opt-in"><span class="secno">2. </span><span class="content">Opt-In Mechanism</span><a class="self-link" href="#opt-in"></a></h2>
    <p><em>This section is general to both IFT methods.</em></p>
    <p>Webpage’s can choose to opt-in to either patch subset or range request incremental transfer for a font
-via the use of a CSS font tech keyword (<a href="https://www.w3.org/TR/css-fonts-4/#font-tech-definitions"><cite>CSS Fonts 4</cite> § 11.1 Font tech</a>) inside the <a class="css" data-link-type="maybe" href="https://www.w3.org/TR/css-fonts-5/#at-font-face-rule" id="ref-for-at-font-face-rule">@font-face</a> block.</p>
+via the use of a CSS font tech keyword (<a href="https://www.w3.org/TR/css-fonts-4/#font-tech-definitions"><cite>CSS Fonts 4</cite> § 11.1 Font tech</a>) inside the
+''@font-face'' block.</p>
    <p>There are three tech keywords available:</p>
    <ul>
     <li data-md>
@@ -1353,7 +1354,7 @@ features, and/or design-variation space.</p>
     <li data-md>
      <p><var>font URL</var>: a URL where the font to be extended is located.</p>
     <li data-md>
-     <p><var>fragment identifier</var> (optional): if the font at the font url is a collection of fonts,
+     <p><var>fragment identifier</var> (optional): if the font at the font url is a font collection,
 the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section-4.2">The "font" Top-Level Media Type § section-4.2</a>) identifies a single font within the collection.</p>
     <li data-md>
      <p><var>font subset</var> (optional): previously loaded <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> for the given
@@ -1380,7 +1381,7 @@ can be cached, or null.</p>
     <li data-md>
      <p>Compare the <var>desired subset definition</var> to the <var>font subset</var>. If the <var>font subset</var> already satisifies the <var>desired subset definition</var>. Then return <var>font subset</var>, and null for the cache fields.</p>
     <li data-md>
-     <p>If <var>font subset</var> is set then load the <var>client state</var> from the <var>font subset</var>. Client state is stored in the <var>font subset</var> as a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag "IFTP". The contents of the table are a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate">ClientState</a> object
+     <p>If <var>font subset</var> is set then load the <var>client state</var> from the <var>font subset</var>. Client state is stored in the <var>font subset</var> as a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag 'IFTP'. The contents of the table are a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate">ClientState</a> object
 encoded via CBOR.</p>
     <li data-md>
      <p>Otherwise make an HTTP request using the <var>fetch algorithm</var>:</p>
@@ -1549,7 +1550,7 @@ subset to the user agent’s HTTP cache (<a data-link-type="biblio" href="#bibli
     <li data-md>
      <p><var>font URL</var>: a URL where the font to be extended is located.</p>
     <li data-md>
-     <p><var>fragment identifier</var> (optional): if the font at the font url is a collection of fonts,
+     <p><var>fragment identifier</var> (optional): if the font at the font url is a font collection,
 the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section-4.2">The "font" Top-Level Media Type § section-4.2</a>) identifies a single font within the collection.</p>
     <li data-md>
      <p><var>desired subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">description</a> of the desired
@@ -1624,7 +1625,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
 populated according to the requirements in <a href="#extend-subset">§ 4.4.1 Extending the Font Subset</a> then it must respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> code 200.</span> <span class="conform server" id="conform-magic-number">The first 4 bytes of the response <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body③">body</a> must be set to 0x49, 0x46, 0x54, 0x20 ("IFT " encoded as ASCII) followed by a
 single <a data-link-type="dfn" href="#patchresponse" id="ref-for-patchresponse④">PatchResponse</a> object encoded via CBOR.</span></p>
    <p>The <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path③">path</a> in the request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url" id="ref-for-concept-request-url">url</a> identifies the specific font that a patch is desired
-for. If the request has the <a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id①">fragment_id</a> field set and the file identified by <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path④">path</a> is a collection of fonts, then <a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id②">fragment_id</a> identifies the font within
+for. If the request has the <a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id①">fragment_id</a> field set and the file identified by <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path④">path</a> is a font collection, then <a data-link-type="dfn" href="#patchrequest-fragment_id" id="ref-for-patchrequest-fragment_id②">fragment_id</a> identifies the font within
 that collection that a patch is desired for. The identified font is referred to as the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="original-font">original font</dfn> in the rest of this section.</p>
    <p>From the request object the server can produce two codepoint sets:</p>
    <ol>
@@ -1674,7 +1675,7 @@ the union of the set of features needed and the sets of features the client alre
 space that covers at least the union of the axis space the client has and the axis space the
 client needs.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-client-state">That has a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> which is mapped to the tag "IFTP" whose content is a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate①">ClientState</a> object encoded via
+     <p><span class="conform server" id="conform-response-client-state">That has a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> which is identified by the tag 'IFTP' whose content is a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate①">ClientState</a> object encoded via
 CBOR:</span></p>
      <ul>
       <li data-md>
@@ -2433,12 +2434,6 @@ itself be statically compressed.</p>
    <li><a href="#patchresponse-unrecognized_ordering">unrecognized_ordering</a><span>, in § 4.3.4</span>
    <li><a href="#usage-document-frequency">usage document frequency</a><span>, in § 5.2.6</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-font-face-rule">
-   <a href="https://www.w3.org/TR/css-fonts-5/#at-font-face-rule">https://www.w3.org/TR/css-fonts-5/#at-font-face-rule</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-at-font-face-rule">2. Opt-In Mechanism</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request-body">
    <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
    <ul>
@@ -2530,11 +2525,6 @@ itself be statically compressed.</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio">[CSS-FONTS-5]</a> defines the following terms:
-    <ul>
-     <li><span class="dfn-paneled" id="term-for-at-font-face-rule">@font-face</span>
-    </ul>
-   <li>
     <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-concept-request-body">body <small>(for request)</small></span>
@@ -2561,8 +2551,6 @@ itself be statically compressed.</p>
   <dl>
    <dt id="biblio-css-fonts-4">[CSS-FONTS-4]
    <dd>John Daggett; Myles Maxfield; Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-4/"><cite>CSS Fonts Module Level 4</cite></a>. 21 December 2021. WD. URL: <a href="https://www.w3.org/TR/css-fonts-4/">https://www.w3.org/TR/css-fonts-4/</a>
-   <dt id="biblio-css-fonts-5">[CSS-FONTS-5]
-   <dd>Myles Maxfield; Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-5/"><cite>CSS Fonts Module Level 5</cite></a>. 21 December 2021. WD. URL: <a href="https://www.w3.org/TR/css-fonts-5/">https://www.w3.org/TR/css-fonts-5/</a>
    <dt id="biblio-fast-hash">[FAST-HASH]
    <dd>ztanml. <a href="https://github.com/ztanml/fast-hash"><cite>fast-hash</cite></a>. 22 October 2018. Note. URL: <a href="https://github.com/ztanml/fast-hash">https://github.com/ztanml/fast-hash</a>
    <dt id="biblio-fetch">[FETCH]

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="2da4fa904b91368179ff00b884ef4ad14a2e0692" name="document-revision">
+  <meta content="f0b0e28bf148d4a0cf2a64206a53fa7ff399be18" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1361,7 +1361,7 @@ the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section
 font url, or null.</p>
     <li data-md>
      <p><var>desired subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">description</a> of the desired
-minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>. The subset definition must be a superset of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> in <var>client state</var>.</p>
+minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
     <li data-md>
      <p><var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>. The remainder
 of this section is desribed in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>, but it is allowed to substitute
@@ -1370,7 +1370,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>Extended Font Subset: <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> that has been updated to cover at least the requested subset
+     <p>Extended Font Subset: <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> that has been updated to cover at least the requested subset
 definition.</p>
     <li data-md>
      <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions">HTTP Caching § name-field-definitions</a> describing how client state
@@ -1379,7 +1379,7 @@ can be cached, or null.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Compare the <var>desired subset definition</var> to the <var>font subset</var>. If the <var>font subset</var> already satisifies the <var>desired subset definition</var>. Then return <var>font subset</var>, and null for the cache fields.</p>
+     <p>Compare the <var>desired subset definition</var> to the <var>font subset</var>. If the <var>font subset</var> is a superset of <var>desired subset definition</var> then return <var>font subset</var>, and null for the cache fields.</p>
     <li data-md>
      <p>If <var>font subset</var> is set then load the <var>client state</var> from the <var>font subset</var>. Client state is stored in the <var>font subset</var> as a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag 'IFTP'. The contents of the table are a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate">ClientState</a> object
 encoded via CBOR.</p>
@@ -1421,7 +1421,7 @@ encoded via CBOR.</p>
  this field should not be set.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed">codepoints_needed</a>: set to the set of codepoints that the client wants to
- add to its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a>. That is the codepoint set from <var>desired subset
+ add to its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a>. That is the codepoint set from <var>desired subset
  definition</var> minus the codepoints already in the <var>font subset</var>. If <var>client state</var> is available and has a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering①">codepoint_ordering</a> then
  this field should not be set.</p>
       <li data-md>
@@ -1430,7 +1430,7 @@ encoded via CBOR.</p>
  the <var>client state</var> is not available or it does not have a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering③">codepoint_ordering</a> then this field should not be set.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed①">indices_needed</a>: encodes the set of codepoints that the client wants to add to
- its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a>. That is the codepoint set from <var>desired subset
+ its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a>. That is the codepoint set from <var>desired subset
  definition</var> minus the codepoints already in <var>font subset</var>.
  The codepoint values are transformed to indices by applying the <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> specified by <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering④">codepoint_ordering</a> to each codepoint value. If
  the <var>client state</var> is not available or it does not have a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑤">codepoint_ordering</a> then this field should not be set.</p>
@@ -1483,12 +1483,12 @@ object.</p>
     <li data-md>
      <p><var>server response</var>: HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a> to a patch request.</p>
     <li data-md>
-     <p><var>font subset</var> (optional): existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a> which is  being extended. May be null.</p>
+     <p><var>font subset</var> (optional): existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a> which is  being extended. May be null.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>Extended Font Subset: <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> that has been updated to cover at least the requested subset
+     <p>Extended Font Subset: <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a> that has been updated to cover at least the requested subset
 definition.</p>
     <li data-md>
      <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions">HTTP Caching § name-field-definitions</a> describing how client state
@@ -1502,7 +1502,7 @@ can be cached, or null.</p>
       <li data-md>
        <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to step 1.</p>
       <li data-md>
-       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> extension has failed. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load">Handle failed font load</a> and return the result.</p>
+       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> extension has failed. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load">Handle failed font load</a> and return the result.</p>
      </ul>
     <li data-md>
      <p>Check the first four bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a>. If they are
@@ -1531,13 +1531,13 @@ can be cached, or null.</p>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
    <ol>
     <li data-md>
-     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a>, it may choose to use that and then use the user
+     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a>, it may choose to use that and then use the user
   agent’s existing font fallback mechanism for codepoints not covered by the subset.</p>
     <li data-md>
      <p>The client may re-issue the request as a regular non incremental font fetch to the same <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>. It must not include the patch subset request parameter or header. This will load
   the entire <a data-link-type="dfn" href="#original-font" id="ref-for-original-font④">original font</a>.</p>
     <li data-md>
-     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
+     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
    </ol>
    <h4 class="heading settled algorithm" data-algorithm="Load a Font in a User Agent with a HTTP Cache" data-level="4.4.3" id="load-a-font"><span class="secno">4.4.3. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
    <p>The previous section <a href="#extend-subset">§ 4.4.1 Extending the Font Subset</a> provides no guidance on how a user agent should handle
@@ -1554,7 +1554,7 @@ subset to the user agent’s HTTP cache (<a data-link-type="biblio" href="#bibli
 the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section-4.2">The "font" Top-Level Media Type § section-4.2</a>) identifies a single font within the collection.</p>
     <li data-md>
      <p><var>desired subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">description</a> of the desired
-minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>.</p>
+minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>.</p>
     <li data-md>
      <p><var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>. The remainder
 of this section is desribed in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>, but it is allowed to substitute
@@ -1563,7 +1563,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> which covers at minimum the input subset definition.</p>
+     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> which covers at minimum the input subset definition.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1618,7 +1618,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
      <p>If the returned cache fields are non-null update the cache entry for the input
  font url with the returned client state and returned cache fields.</p>
     <li data-md>
-     <p>Return the returned <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a>.</p>
+     <p>Return the returned <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a>.</p>
    </ol>
    <h3 class="heading settled" data-level="4.5" id="handling-patch-request"><span class="secno">4.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
    <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a> over HTTPS for a font the server has and that was
@@ -1661,8 +1661,8 @@ with a response that will cause the client to update it’s codepoint ordering t
 will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> and not include any patch.
 That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> fields must not be set.
 The <a data-link-type="dfn" href="#patchresponse-unrecognized_ordering" id="ref-for-patchresponse-unrecognized_ordering③">unrecognized_ordering</a> field must be set to a non-zero value.</span></p>
-   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
-result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>: </span></p>
+   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
+result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a>: </span></p>
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-subset">That contains data for at least the union
@@ -1683,7 +1683,7 @@ CBOR:</span></p>
       <li data-md>
        <p><span class="conform server" id="conform-response-client-state-codepoint-ordering"> The <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑧">codepoint_ordering</a> field must be set following <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a>.</span></p>
       <li data-md>
-       <p><span class="conform server" id="conform-response-client-state-subset-axis-space-field"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①⓪">original font</a> has variation axes, the <a data-link-type="dfn" href="#clientstate-subset_axis_space" id="ref-for-clientstate-subset_axis_space①">subset_axis_space</a> field must be set to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a>.</span></p>
+       <p><span class="conform server" id="conform-response-client-state-subset-axis-space-field"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①⓪">original font</a> has variation axes, the <a data-link-type="dfn" href="#clientstate-subset_axis_space" id="ref-for-clientstate-subset_axis_space①">subset_axis_space</a> field must be set to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>.</span></p>
       <li data-md>
        <p><span class="conform server" id="conform-response-client-state-original-axis-space"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①①">original font</a> has variation axes, the <a data-link-type="dfn" href="#clientstate-original_axis_space" id="ref-for-clientstate-original_axis_space">original_axis_space</a> field must be set to the axis space covered by
  the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①②">original font</a>.</span></p>
@@ -2608,10 +2608,10 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-font-subset">1.1. Patch Subset</a>
     <li><a href="#ref-for-font-subset①">4.1. Font Subset</a>
-    <li><a href="#ref-for-font-subset②">4.4.1. Extending the Font Subset</a> <a href="#ref-for-font-subset③">(2)</a> <a href="#ref-for-font-subset④">(3)</a> <a href="#ref-for-font-subset⑤">(4)</a> <a href="#ref-for-font-subset⑥">(5)</a> <a href="#ref-for-font-subset⑦">(6)</a> <a href="#ref-for-font-subset⑧">(7)</a>
-    <li><a href="#ref-for-font-subset⑨">4.4.2. Handling Server Response</a> <a href="#ref-for-font-subset①⓪">(2)</a> <a href="#ref-for-font-subset①①">(3)</a> <a href="#ref-for-font-subset①②">(4)</a> <a href="#ref-for-font-subset①③">(5)</a>
-    <li><a href="#ref-for-font-subset①④">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑤">(2)</a> <a href="#ref-for-font-subset①⑥">(3)</a>
-    <li><a href="#ref-for-font-subset①⑦">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset①⑧">(2)</a> <a href="#ref-for-font-subset①⑨">(3)</a>
+    <li><a href="#ref-for-font-subset②">4.4.1. Extending the Font Subset</a> <a href="#ref-for-font-subset③">(2)</a> <a href="#ref-for-font-subset④">(3)</a> <a href="#ref-for-font-subset⑤">(4)</a> <a href="#ref-for-font-subset⑥">(5)</a> <a href="#ref-for-font-subset⑦">(6)</a>
+    <li><a href="#ref-for-font-subset⑧">4.4.2. Handling Server Response</a> <a href="#ref-for-font-subset⑨">(2)</a> <a href="#ref-for-font-subset①⓪">(3)</a> <a href="#ref-for-font-subset①①">(4)</a> <a href="#ref-for-font-subset①②">(5)</a>
+    <li><a href="#ref-for-font-subset①③">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①④">(2)</a> <a href="#ref-for-font-subset①⑤">(3)</a>
+    <li><a href="#ref-for-font-subset①⑥">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset①⑦">(2)</a> <a href="#ref-for-font-subset①⑧">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="font-subset-definition">

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="01964f89d404b1910205a24a3118be338b7884a3" name="document-revision">
+  <meta content="ed25d092ddcd81bdd575b8ef8f301c3b5759bfc5" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1263,7 +1263,7 @@ on some variable axis in a font.</p>
       <td><a data-link-type="dfn" href="#string" id="ref-for-string">String</a>
      <tr>
       <td>14
-      <td><dfn data-dfn-for="PatchRequest" data-dfn-type="dfn" data-noexport id="patchrequest-codepoint_ordering">codepoint_ordering<a class="self-link" href="#patchrequest-codepoint_ordering"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="PatchRequest" data-dfn-type="dfn" data-noexport id="patchrequest-codepoint_ordering">codepoint_ordering</dfn>
       <td><a data-link-type="dfn" href="#integerlist" id="ref-for-integerlist③">IntegerList</a>
    </table>
    <p>For a <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest①">PatchRequest</a> object to be well formed:</p>
@@ -1520,7 +1520,11 @@ can be cached, or null.</p>
  in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to the input <var>font subset</var>. This produces the extended font subset. Return the extended font subset
  and any cache headers that were set on the <var>server response</var>.</p>
     <li data-md>
-     <p>TODO handle new field unrecognized_ordering.</p>
+     <p>If field <a data-link-type="dfn" href="#patchresponse-unrecognized_ordering" id="ref-for-patchresponse-unrecognized_ordering①">unrecognized_ordering</a> is set to a non-zero value then the client should
+ resend the request that triggered this response but also set the <a data-link-type="dfn" href="#patchrequest-codepoint_ordering" id="ref-for-patchrequest-codepoint_ordering">codepoint_ordering</a> field on the request to the <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑦">codepoint_ordering</a> in the client state table within <var>font subset</var>.</p>
+    <li data-md>
+     <p>Otherwise if none of <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a>, <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch②">patch</a>, or <a data-link-type="dfn" href="#patchresponse-unrecognized_ordering" id="ref-for-patchresponse-unrecognized_ordering②">unrecognized_ordering</a> this is an error, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load③">Handle failed font load</a> and
+ return the result.</p>
    </ol>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-failed-font-load">Handle failed font load</dfn></p>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
@@ -1656,7 +1660,7 @@ that collection that a patch is desired for. The identified font is referred to 
    <p><span class="conform server" id="conform-bad-reordering"> If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
 will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> and not include any patch.
-That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch②">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> fields must not be set. </span></p>
+That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> fields must not be set. </span></p>
    <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
 result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>: </span></p>
    <ul>
@@ -1690,10 +1694,10 @@ the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①�
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-patch-format">The format of the patch in the
-either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> fields must be one of those
+either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch④">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement④">replacement</a> fields must be one of those
 listed in <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format②">accept_patch_format</a></span>.</p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch④">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement④">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a>.</span></p>
+     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-ignore-unrecognized-formats"> If <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format③">accept_patch_format</a> contains any unrecognized patch formats the server must
 ignore the unrecognized ones.</span></p>
@@ -2873,6 +2877,12 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-patchrequest-fragment_id①">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchrequest-fragment_id②">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="patchrequest-codepoint_ordering">
+   <b><a href="#patchrequest-codepoint_ordering">#patchrequest-codepoint_ordering</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-patchrequest-codepoint_ordering">4.4.2. Handling Server Response</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="patchresponse">
    <b><a href="#patchresponse">#patchresponse</a></b><b>Referenced in:</b>
    <ul>
@@ -2898,22 +2908,23 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-patch">#patchresponse-patch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patch">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-patch①">4.4.2. Handling Server Response</a>
-    <li><a href="#ref-for-patchresponse-patch②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-patch③">(2)</a> <a href="#ref-for-patchresponse-patch④">(3)</a>
+    <li><a href="#ref-for-patchresponse-patch①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-patch②">(2)</a>
+    <li><a href="#ref-for-patchresponse-patch③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-patch④">(2)</a> <a href="#ref-for-patchresponse-patch⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-replacement">
    <b><a href="#patchresponse-replacement">#patchresponse-replacement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-replacement">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-replacement①">4.4.2. Handling Server Response</a>
-    <li><a href="#ref-for-patchresponse-replacement②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement③">(2)</a> <a href="#ref-for-patchresponse-replacement④">(3)</a>
+    <li><a href="#ref-for-patchresponse-replacement①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-replacement②">(2)</a>
+    <li><a href="#ref-for-patchresponse-replacement③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement④">(2)</a> <a href="#ref-for-patchresponse-replacement⑤">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-unrecognized_ordering">
    <b><a href="#patchresponse-unrecognized_ordering">#patchresponse-unrecognized_ordering</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-unrecognized_ordering">4.3.4. PatchResponse</a>
+    <li><a href="#ref-for-patchresponse-unrecognized_ordering①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-unrecognized_ordering②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="clientstate">
@@ -2932,6 +2943,7 @@ itself be statically compressed.</p>
    <b><a href="#clientstate-codepoint_ordering">#clientstate-codepoint_ordering</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clientstate-codepoint_ordering">4.4.1. Extending the Font Subset</a> <a href="#ref-for-clientstate-codepoint_ordering①">(2)</a> <a href="#ref-for-clientstate-codepoint_ordering②">(3)</a> <a href="#ref-for-clientstate-codepoint_ordering③">(4)</a> <a href="#ref-for-clientstate-codepoint_ordering④">(5)</a> <a href="#ref-for-clientstate-codepoint_ordering⑤">(6)</a> <a href="#ref-for-clientstate-codepoint_ordering⑥">(7)</a>
+    <li><a href="#ref-for-clientstate-codepoint_ordering⑦">4.4.2. Handling Server Response</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="clientstate-subset_axis_space">
@@ -2962,7 +2974,7 @@ itself be statically compressed.</p>
   <aside class="dfn-panel" data-for="abstract-opdef-handle-failed-font-load">
    <b><a href="#abstract-opdef-handle-failed-font-load">#abstract-opdef-handle-failed-font-load</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-abstract-opdef-handle-failed-font-load">4.4.2. Handling Server Response</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load①">(2)</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load②">(3)</a>
+    <li><a href="#ref-for-abstract-opdef-handle-failed-font-load">4.4.2. Handling Server Response</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load①">(2)</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load②">(3)</a> <a href="#ref-for-abstract-opdef-handle-failed-font-load③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="original-font">

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="c13ee175556e93e33f09de789e6c4cb41336eee2" name="document-revision">
+  <meta content="c802401a9d8fe494f2a13b5327377e54139795d5" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="ed25d092ddcd81bdd575b8ef8f301c3b5759bfc5" name="document-revision">
+  <meta content="4b9c5a97001b6daf78e6af884df9cc52522425b9" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1538,13 +1538,11 @@ can be cached, or null.</p>
     <li data-md>
      <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
    </ol>
-   <p>Regardless of which of the above options are used, the saved client state for this font must be
-discarded.</p>
    <h4 class="heading settled algorithm" data-algorithm="Load a Font in a User Agent with a HTTP Cache" data-level="4.4.3" id="load-a-font"><span class="secno">4.4.3. </span><span class="content">Load a Font in a User Agent with a HTTP Cache</span><a class="self-link" href="#load-a-font"></a></h4>
    <p>The previous section <a href="#extend-subset">§ 4.4.1 Extending the Font Subset</a> provides no guidance on how a user agent should handle
-saving client state between invocations of the subset extension algorithm. This section provides an
-algorithm that user agents which implement <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a> should use to save client state to the user
-agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc9111">[RFC9111]</a>).</p>
+saving the font subset and client state between invocations of the subset extension algorithm. This
+section provides an algorithm that user agents which implement <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a> should use to save the font
+subset to the user agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc9111">[RFC9111]</a>).</p>
    <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-load-a-font-with-a-http-cache">Load a font with a HTTP Cache<a class="self-link" href="#abstract-opdef-load-a-font-with-a-http-cache"></a></dfn></p>
    <p>The inputs to this algorithm:</p>
    <ul>
@@ -1593,7 +1591,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
       <li data-md>
        <p>Fragment identifier set to the input <var>fragment identifier</var></p>
       <li data-md>
-       <p>Client state set to the response.</p>
+       <p>Font subset set to the response.</p>
       <li data-md>
        <p>Desired subset definition set to the input <var>desired subset definition</var>.</p>
       <li data-md>
@@ -1608,7 +1606,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
       <li data-md>
        <p>Fragment identifier set to the input <var>fragment identifier</var></p>
       <li data-md>
-       <p>Client state set to null.</p>
+       <p>Font subset set to null.</p>
       <li data-md>
        <p>Desired subset definition set to the input <var>desired subset definition</var>.</p>
       <li data-md>
@@ -1619,7 +1617,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
      <p>If the returned cache fields are non-null update the cache entry for the input
  font url with the returned client state and returned cache fields.</p>
     <li data-md>
-     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> contained in the returned client state.</p>
+     <p>Return the returned <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a>.</p>
    </ol>
    <h3 class="heading settled" data-level="4.5" id="handling-patch-request"><span class="secno">4.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
    <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a> over HTTPS for a font the server has and that was

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="214b6477cc947f3951287a76d10b3285a7a3bb62" name="document-revision">
+  <meta content="01964f89d404b1910205a24a3118be338b7884a3" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -1467,7 +1467,7 @@ encoded via CBOR.</p>
  example, on slower connections it may be more performant to request extra codepoints if
  that is likely to prevent a future request from needing to be sent.</p>
     <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-server-response" id="ref-for-abstract-opdef-handle-server-response">Handle server response</a> with the response from the server and return the result.</p>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-server-response" id="ref-for-abstract-opdef-handle-server-response">Handle server response</a> with the response from the server and the <var>font subset</var> then return the result.</p>
    </ol>
    <p class="note" role="note"><span>Note:</span> POST is preferred for the HTTP method since it will not cause a CORS preflight request
 and the request object is more compactly encoded. GET should only be used during <a href="#method-negotiation">method negotiation</a>.</p>
@@ -1482,13 +1482,13 @@ object.</p>
     <li data-md>
      <p><var>server response</var>: HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">response</a> to a patch request.</p>
     <li data-md>
-     <p><var>client state</var> (optional): previously saved <a data-link-type="dfn">client state</a>.</p>
+     <p><var>font subset</var> (optional): existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a> which is  being extended. May be null.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>Client State: <a data-link-type="dfn">client state</a> that has been updated to contain a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a> which covers at
-least the requested subset definition.</p>
+     <p>Extended Font Subset: <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> that has been updated to cover at least the requested subset
+definition.</p>
     <li data-md>
      <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#name-field-definitions">HTTP Caching § name-field-definitions</a> describing how client state
 can be cached, or null.</p>
@@ -1501,7 +1501,7 @@ can be cached, or null.</p>
       <li data-md>
        <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch Standard</cite> § 4.4 HTTP-redirect fetch</a> and then go back to step 1.</p>
       <li data-md>
-       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> extension has failed. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load">Handle failed font load</a> and return the result.</p>
+       <p>All other statuses, the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> extension has failed. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load">Handle failed font load</a> and return the result.</p>
      </ul>
     <li data-md>
      <p>Check the first four bytes of the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a>. If they are
@@ -1513,41 +1513,26 @@ can be cached, or null.</p>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement①">replacement</a> is set then: the byte array in this field is a binary patch
  in the format specified by <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format①">patch_format</a>. Apply the binary patch to a base which
- is an empty byte array. Replace the <a data-link-type="dfn">font subset</a> in the input <var>client state</var> with the result of the patch application.</p>
+ is an empty byte array. This produces the extended font subset. Return the extended font subset
+ and any cache headers that were set on the <var>server response</var>.</p>
     <li data-md>
      <p>If field <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch①">patch</a> is set then:  the byte array in this field is a binary patch
-in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to the <a data-link-type="dfn">font subset</a> from the input client state. Replace the <a data-link-type="dfn">font subset</a> in the input <var>client state</var> with the
-result of the patch application.</p>
+ in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to the input <var>font subset</var>. This produces the extended font subset. Return the extended font subset
+ and any cache headers that were set on the <var>server response</var>.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn">original_font_checksum</a> is set then update the <a data-link-type="dfn">original font checksum</a> in the input <var>client state</var> with the value in <a data-link-type="dfn">original_font_checksum</a>.</p>
-    <li data-md>
-     <p>If the field <a data-link-type="dfn">codepoint_ordering</a> is set then update the <a data-link-type="dfn">codepoint reordering map</a> in the input <var>client state</var> with
-the new values specified the field. If neither <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> nor <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch②">patch</a> are set, then the client should resend the request that triggered this
-response but use the new codepoint ordering provided in this response. Go back to step 1 to process
-the response.</p>
-    <li data-md>
-     <p>If <a data-link-type="dfn">original_features</a> is set and the client has opted to save them then replace the <a data-link-type="dfn">original font feature list</a> in the input <var>client state</var> with the value
-from the response.</p>
-    <li data-md>
-     <p>If <a data-link-type="dfn">original_axis_space</a> is set then update the <a data-link-type="dfn">original font axis space</a> in the input <var>client state</var> with the value
-specified in this field.</p>
-    <li data-md>
-     <p>If <a data-link-type="dfn">subset_axis_space</a> is set then update the <a data-link-type="dfn">subset axis space</a> in the input <var>client state</var> with the value specified
- in this field.</p>
+     <p>TODO handle new field unrecognized_ordering.</p>
    </ol>
-   <p>After processing the response, return the updated input <var>client state</var> and any cache headers
-that were set on the <var>server response</var>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-failed-font-load">Handle failed font load</dfn></p>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
    <ol>
     <li data-md>
-     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a>, it may choose to use that and then use the user
+     <p>If the client has a saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a>, it may choose to use that and then use the user
   agent’s existing font fallback mechanism for codepoints not covered by the subset.</p>
     <li data-md>
      <p>The client may re-issue the request as a regular non incremental font fetch to the same <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path①">path</a>. It must not include the patch subset request parameter or header. This will load
   the entire <a data-link-type="dfn" href="#original-font" id="ref-for-original-font④">original font</a>.</p>
     <li data-md>
-     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
+     <p>Discard the saved <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>, and use the user agent’s existing font fallback mechanism.</p>
    </ol>
    <p>Regardless of which of the above options are used, the saved client state for this font must be
 discarded.</p>
@@ -1566,7 +1551,7 @@ agent’s HTTP cache (<a data-link-type="biblio" href="#biblio-rfc9111">[RFC9111
 the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section-4.2">The "font" Top-Level Media Type § section-4.2</a>) identifies a single font within the collection.</p>
     <li data-md>
      <p><var>desired subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">description</a> of the desired
-minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>.</p>
+minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>.</p>
     <li data-md>
      <p><var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as <a data-link-type="biblio" href="#biblio-fetch">[fetch]</a>. The remainder
 of this section is desribed in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch Standard</cite> § 4 Fetching</a>, but it is allowed to substitute
@@ -1575,7 +1560,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> which covers at minimum the input subset definition.</p>
+     <p>A <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> which covers at minimum the input subset definition.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1630,7 +1615,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
      <p>If the returned cache fields are non-null update the cache entry for the input
  font url with the returned client state and returned cache fields.</p>
     <li data-md>
-     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> contained in the returned client state.</p>
+     <p>Return the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> contained in the returned client state.</p>
    </ol>
    <h3 class="heading settled" data-level="4.5" id="handling-patch-request"><span class="secno">4.5. </span><span class="content">Server: Responding to a PatchRequest</span><a class="self-link" href="#handling-patch-request"></a></h3>
    <p><span class="conform server" id="conform-successful-response">If the server receives a well formed <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest⑥">PatchRequest</a> over HTTPS for a font the server has and that was
@@ -1671,9 +1656,9 @@ that collection that a patch is desired for. The identified font is referred to 
    <p><span class="conform server" id="conform-bad-reordering"> If the server does not recognize the codepoint ordering used by the client, it must respond
 with a response that will cause the client to update it’s codepoint ordering to one the server
 will recognize via the process described in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> and not include any patch.
-That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> fields must not be set. </span></p>
-   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
-result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a>: </span></p>
+That is the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch②">patch</a> and <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> fields must not be set. </span></p>
+   <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is applied by the client following the process in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> with checksum <a data-link-type="dfn" href="#patchrequest-base_checksum" id="ref-for-patchrequest-base_checksum②">base_checksum</a> it must
+result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>: </span></p>
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-subset">That contains data for at least the union
@@ -1705,10 +1690,10 @@ the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①�
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-patch-format">The format of the patch in the
-either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch④">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement④">replacement</a> fields must be one of those
+either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch③">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement③">replacement</a> fields must be one of those
 listed in <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format②">accept_patch_format</a></span>.</p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>.</span></p>
+     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch④">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement④">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-ignore-unrecognized-formats"> If <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format③">accept_patch_format</a> contains any unrecognized patch formats the server must
 ignore the unrecognized ones.</span></p>
@@ -2633,9 +2618,9 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-font-subset">1.1. Patch Subset</a>
     <li><a href="#ref-for-font-subset①">4.1. Font Subset</a>
     <li><a href="#ref-for-font-subset②">4.4.1. Extending the Font Subset</a> <a href="#ref-for-font-subset③">(2)</a> <a href="#ref-for-font-subset④">(3)</a> <a href="#ref-for-font-subset⑤">(4)</a> <a href="#ref-for-font-subset⑥">(5)</a> <a href="#ref-for-font-subset⑦">(6)</a> <a href="#ref-for-font-subset⑧">(7)</a>
-    <li><a href="#ref-for-font-subset⑨">4.4.2. Handling Server Response</a> <a href="#ref-for-font-subset①⓪">(2)</a> <a href="#ref-for-font-subset①①">(3)</a> <a href="#ref-for-font-subset①②">(4)</a>
-    <li><a href="#ref-for-font-subset①③">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①④">(2)</a> <a href="#ref-for-font-subset①⑤">(3)</a>
-    <li><a href="#ref-for-font-subset①⑥">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset①⑦">(2)</a> <a href="#ref-for-font-subset①⑧">(3)</a>
+    <li><a href="#ref-for-font-subset⑨">4.4.2. Handling Server Response</a> <a href="#ref-for-font-subset①⓪">(2)</a> <a href="#ref-for-font-subset①①">(3)</a> <a href="#ref-for-font-subset①②">(4)</a> <a href="#ref-for-font-subset①③">(5)</a>
+    <li><a href="#ref-for-font-subset①④">4.4.3. Load a Font in a User Agent with a HTTP Cache</a> <a href="#ref-for-font-subset①⑤">(2)</a> <a href="#ref-for-font-subset①⑥">(3)</a>
+    <li><a href="#ref-for-font-subset①⑦">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-font-subset①⑧">(2)</a> <a href="#ref-for-font-subset①⑨">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="font-subset-definition">
@@ -2913,16 +2898,16 @@ itself be statically compressed.</p>
    <b><a href="#patchresponse-patch">#patchresponse-patch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-patch">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-patch①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-patch②">(2)</a>
-    <li><a href="#ref-for-patchresponse-patch③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-patch④">(2)</a> <a href="#ref-for-patchresponse-patch⑤">(3)</a>
+    <li><a href="#ref-for-patchresponse-patch①">4.4.2. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-patch②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-patch③">(2)</a> <a href="#ref-for-patchresponse-patch④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-replacement">
    <b><a href="#patchresponse-replacement">#patchresponse-replacement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patchresponse-replacement">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-patchresponse-replacement①">4.4.2. Handling Server Response</a> <a href="#ref-for-patchresponse-replacement②">(2)</a>
-    <li><a href="#ref-for-patchresponse-replacement③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement④">(2)</a> <a href="#ref-for-patchresponse-replacement⑤">(3)</a>
+    <li><a href="#ref-for-patchresponse-replacement①">4.4.2. Handling Server Response</a>
+    <li><a href="#ref-for-patchresponse-replacement②">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement③">(2)</a> <a href="#ref-for-patchresponse-replacement④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="patchresponse-unrecognized_ordering">

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="068bef1f6d47c2e3a67811fdc5656346098c91ce" name="document-revision">
+  <meta content="c13ee175556e93e33f09de789e6c4cb41336eee2" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 63e66730b, updated Tue Oct 25 12:35:05 2022 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="2f4835b6f6a3480d6ecdb832b2e50064f4806324" name="document-revision">
+  <meta content="4886f2d6375040852822113813dffc2965b41cd8" name="document-revision">
 <style>
 .conform:hover {background: #31668f}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f }
@@ -352,6 +352,7 @@ dfn > a.self-link::before      { content: "#"; }
         <li><a href="#AxisInterval"><span class="secno">4.3.2</span> <span class="content"><span>AxisInterval</span></span></a>
         <li><a href="#PatchRequest"><span class="secno">4.3.3</span> <span class="content"><span>PatchRequest</span></span></a>
         <li><a href="#PatchResponse"><span class="secno">4.3.4</span> <span class="content"><span>PatchResponse</span></span></a>
+        <li><a href="#ClientState"><span class="secno">4.3.5</span> <span class="content"><span>ClientState</span></span></a>
        </ol>
       <li>
        <a href="#client"><span class="secno">4.4</span> <span class="content">Client</span></a>
@@ -1261,6 +1262,10 @@ on some variable axis in a font.</p>
       <td>13
       <td><dfn class="dfn-paneled" data-dfn-for="PatchRequest" data-dfn-type="dfn" data-noexport id="patchrequest-fragment_id">fragment_id</dfn> 
       <td><a data-link-type="dfn" href="#string" id="ref-for-string">String</a>
+     <tr>
+      <td>14
+      <td><dfn data-dfn-for="PatchRequest" data-dfn-type="dfn" data-noexport id="patchrequest-codepoint_ordering">codepoint_ordering<a class="self-link" href="#patchrequest-codepoint_ordering"></a></dfn>
+      <td><a data-link-type="dfn" href="#integerlist" id="ref-for-integerlist③">IntegerList</a>
    </table>
    <p>For a <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest①">PatchRequest</a> object to be well formed:</p>
    <ul>
@@ -1299,34 +1304,46 @@ set then <a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-
       <td><a data-link-type="dfn" href="#bytestring" id="ref-for-bytestring⑨">ByteString</a>
      <tr>
       <td>4
-      <td><dfn class="dfn-paneled" data-dfn-for="PatchResponse" data-dfn-type="dfn" data-noexport id="patchresponse-original_font_checksum">original_font_checksum</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="PatchResponse" data-dfn-type="dfn" data-noexport id="patchresponse-unrecognized_ordering">unrecognized_ordering</dfn>
       <td><a data-link-type="dfn" href="#integer" id="ref-for-integer⑧">Integer</a>
-     <tr>
-      <td>5
-      <td><dfn class="dfn-paneled" data-dfn-for="PatchResponse" data-dfn-type="dfn" data-noexport id="patchresponse-codepoint_ordering">codepoint_ordering</dfn>
-      <td><a data-link-type="dfn" href="#integerlist" id="ref-for-integerlist③">IntegerList</a>
-     <tr>
-      <td>6
-      <td><dfn class="dfn-paneled" data-dfn-for="PatchResponse" data-dfn-type="dfn" data-noexport id="patchresponse-subset_axis_space">subset_axis_space</dfn>
-      <td><a data-link-type="dfn" href="#axisspace" id="ref-for-axisspace②">AxisSpace</a>
-     <tr>
-      <td>7
-      <td><dfn class="dfn-paneled" data-dfn-for="PatchResponse" data-dfn-type="dfn" data-noexport id="patchresponse-original_axis_space">original_axis_space</dfn>
-      <td><a data-link-type="dfn" href="#axisspace" id="ref-for-axisspace③">AxisSpace</a>
-     <tr>
-      <td>8
-      <td><dfn class="dfn-paneled" data-dfn-for="PatchResponse" data-dfn-type="dfn" data-noexport id="patchresponse-original_features">original_features</dfn>
-      <td><a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset②">FeatureTagSet</a>
    </table>
    <p>For a PatchResponse object to be well formed:</p>
    <ul>
     <li data-md>
      <p><span class="conform server" id="conform-response-protocol-version"> <a data-link-type="dfn" href="#patchresponse-protocol_version" id="ref-for-patchresponse-protocol_version">protocol_version</a> must be set to 0.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-patch-or-replacement"> Only one of <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement">replacement</a> must be set.</span></p>
+     <p><span class="conform server" id="conform-response-patch-or-replacement"> Only one of <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch">patch</a>, <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement">replacement</a>, or <a data-link-type="dfn" href="#patchresponse-unrecognized_ordering" id="ref-for-patchresponse-unrecognized_ordering">unrecognized_ordering</a> must be set.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-valid-format"> If <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format">patch_format</a> is set then it must be one of the values listed in <a href="#patch-formats">§ 4.8 Patch Formats</a>.</span></p>
    </ul>
+   <h4 class="heading settled" data-level="4.3.5" id="ClientState"><span class="secno">4.3.5. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport id="clientstate">ClientState<a class="self-link" href="#clientstate"></a></dfn></span><a class="self-link" href="#ClientState"></a></h4>
+   <table>
+    <tbody>
+     <tr>
+      <th>ID
+      <th>Field Name
+      <th>Value Type
+     <tr>
+      <td>0
+      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_font_checksum">original_font_checksum<a class="self-link" href="#clientstate-original_font_checksum"></a></dfn>
+      <td><a data-link-type="dfn" href="#integer" id="ref-for-integer⑨">Integer</a>
+     <tr>
+      <td>1
+      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-codepoint_ordering">codepoint_ordering<a class="self-link" href="#clientstate-codepoint_ordering"></a></dfn>
+      <td><a data-link-type="dfn" href="#integerlist" id="ref-for-integerlist④">IntegerList</a>
+     <tr>
+      <td>2
+      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-subset_axis_space">subset_axis_space<a class="self-link" href="#clientstate-subset_axis_space"></a></dfn>
+      <td><a data-link-type="dfn" href="#axisspace" id="ref-for-axisspace②">AxisSpace</a>
+     <tr>
+      <td>3
+      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_axis_space">original_axis_space<a class="self-link" href="#clientstate-original_axis_space"></a></dfn>
+      <td><a data-link-type="dfn" href="#axisspace" id="ref-for-axisspace③">AxisSpace</a>
+     <tr>
+      <td>4
+      <td><dfn data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_features">original_features<a class="self-link" href="#clientstate-original_features"></a></dfn>
+      <td><a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset②">FeatureTagSet</a>
+   </table>
    <h3 class="heading settled" data-level="4.4" id="client"><span class="secno">4.4. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
    <h4 class="heading settled" data-level="4.4.1" id="client-state-section"><span class="secno">4.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="client-state">Client State</dfn></span><a class="self-link" href="#client-state-section"></a></h4>
    <p>The client will need to maintain at minimum the following state for each font file being incrementally
@@ -1337,21 +1354,21 @@ transferred:</p>
 most recent version of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②">subset</a> of the font being incrementally transferred. For
 a new font this is initialized to empty byte array.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-original-font-checksum">Original font checksum</dfn>: the most recent value of <a data-link-type="dfn" href="#patchresponse-original_font_checksum" id="ref-for-patchresponse-original_font_checksum">original_font_checksum</a> received from the server for this font.</p>
+     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-original-font-checksum">Original font checksum</dfn>: the most recent value of <a data-link-type="dfn">original_font_checksum</a> received from the server for this font.</p>
     <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-codepoint-reordering-map">Codepoint Reordering Map</dfn>: The most recent <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> received from the server for this font. Supplied by <a data-link-type="dfn" href="#patchresponse-codepoint_ordering" id="ref-for-patchresponse-codepoint_ordering">codepoint_ordering</a>.</p>
+     <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-codepoint-reordering-map">Codepoint Reordering Map</dfn>: The most recent <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> received from the server for this font. Supplied by <a data-link-type="dfn">codepoint_ordering</a>.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-original-font-axis-space">Original Font Axis Space</dfn>: the variations axis space that the original
-font covers. Supplied by <a data-link-type="dfn" href="#patchresponse-original_axis_space" id="ref-for-patchresponse-original_axis_space">original_axis_space</a>.</p>
+font covers. Supplied by <a data-link-type="dfn">original_axis_space</a>.</p>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-subset-axis-space">Subset Axis Space</dfn>: the most recent variations axis space that the
-subsetted font covers. Supplied by <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space">subset_axis_space</a>.</p>
+subsetted font covers. Supplied by <a data-link-type="dfn">subset_axis_space</a>.</p>
    </ul>
    <p>Additionally, the client can optionally store:</p>
    <ul>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-for="Client State" data-dfn-type="dfn" data-noexport id="client-state-original-font-feature-list">Original font feature list</dfn>: a list of the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a> that the original font has data for. This information can be used by the client to avoid sending
-unnecessary requests for features which the original font does not contain. Supplied by <a data-link-type="dfn" href="#patchresponse-original_features" id="ref-for-patchresponse-original_features">original_features</a>.</p>
+unnecessary requests for features which the original font does not contain. Supplied by <a data-link-type="dfn">original_features</a>.</p>
    </ul>
    <h4 class="heading settled algorithm" data-algorithm="Extending the Font Subset" data-level="4.4.2" id="extend-subset"><span class="secno">4.4.2. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
    <p>This algorithm is used by the client to extends its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> to cover additional codepoints,
@@ -1531,20 +1548,20 @@ can be cached, or null.</p>
 in the format specifiedy <a data-link-type="dfn" href="#patchresponse-patch_format" id="ref-for-patchresponse-patch_format②">patch_format</a>. Apply the binary patch to the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①②">font subset</a> from the input client state. Replace the <a data-link-type="dfn" href="#client-state-client-font-subset" id="ref-for-client-state-client-font-subset①③">font subset</a> in the input <var>client state</var> with the
 result of the patch application.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#patchresponse-original_font_checksum" id="ref-for-patchresponse-original_font_checksum①">original_font_checksum</a> is set then update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in the input <var>client state</var> with the value in <a data-link-type="dfn" href="#patchresponse-original_font_checksum" id="ref-for-patchresponse-original_font_checksum②">original_font_checksum</a>.</p>
+     <p>If <a data-link-type="dfn">original_font_checksum</a> is set then update the <a data-link-type="dfn" href="#client-state-original-font-checksum" id="ref-for-client-state-original-font-checksum①">original font checksum</a> in the input <var>client state</var> with the value in <a data-link-type="dfn">original_font_checksum</a>.</p>
     <li data-md>
-     <p>If the field <a data-link-type="dfn" href="#patchresponse-codepoint_ordering" id="ref-for-patchresponse-codepoint_ordering①">codepoint_ordering</a> is set then update the <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map⑤">codepoint reordering map</a> in the input <var>client state</var> with
+     <p>If the field <a data-link-type="dfn">codepoint_ordering</a> is set then update the <a data-link-type="dfn" href="#client-state-codepoint-reordering-map" id="ref-for-client-state-codepoint-reordering-map⑤">codepoint reordering map</a> in the input <var>client state</var> with
 the new values specified the field. If neither <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement②">replacement</a> nor <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch②">patch</a> are set, then the client should resend the request that triggered this
 response but use the new codepoint ordering provided in this response. Go back to step 1 to process
 the response.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#patchresponse-original_features" id="ref-for-patchresponse-original_features①">original_features</a> is set and the client has opted to save them then replace the <a data-link-type="dfn" href="#client-state-original-font-feature-list" id="ref-for-client-state-original-font-feature-list">original font feature list</a> in the input <var>client state</var> with the value
+     <p>If <a data-link-type="dfn">original_features</a> is set and the client has opted to save them then replace the <a data-link-type="dfn" href="#client-state-original-font-feature-list" id="ref-for-client-state-original-font-feature-list">original font feature list</a> in the input <var>client state</var> with the value
 from the response.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#patchresponse-original_axis_space" id="ref-for-patchresponse-original_axis_space①">original_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-original-font-axis-space" id="ref-for-client-state-original-font-axis-space">original font axis space</a> in the input <var>client state</var> with the value
+     <p>If <a data-link-type="dfn">original_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-original-font-axis-space" id="ref-for-client-state-original-font-axis-space">original font axis space</a> in the input <var>client state</var> with the value
 specified in this field.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space①">subset_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-subset-axis-space" id="ref-for-client-state-subset-axis-space①">subset axis space</a> in the input <var>client state</var> with the value specified
+     <p>If <a data-link-type="dfn">subset_axis_space</a> is set then update the <a data-link-type="dfn" href="#client-state-subset-axis-space" id="ref-for-client-state-subset-axis-space①">subset axis space</a> in the input <var>client state</var> with the value specified
  in this field.</p>
    </ol>
    <p>After processing the response, return the updated input <var>client state</var> and any cache headers
@@ -1702,15 +1719,15 @@ client needs.</span></p>
 match the checksum in <a data-link-type="dfn" href="#patchrequest-original_font_checksum" id="ref-for-patchrequest-original_font_checksum②">original_font_checksum</a> or <a data-link-type="dfn" href="#patchrequest-original_font_checksum" id="ref-for-patchrequest-original_font_checksum③">original_font_checksum</a> is unset, then:</p>
    <ul>
     <li data-md>
-     <p><span class="conform server" id="conform-response-original-checksum">The value of <a data-link-type="dfn" href="#patchresponse-original_font_checksum" id="ref-for-patchresponse-original_font_checksum③">original_font_checksum</a> must be set to the checksum of the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①⓪">original font</a> computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
+     <p><span class="conform server" id="conform-response-original-checksum">The value of <a data-link-type="dfn">original_font_checksum</a> must be set to the checksum of the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①⓪">original font</a> computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-codepoint-ordering"> The response must set the <a data-link-type="dfn" href="#patchresponse-codepoint_ordering" id="ref-for-patchresponse-codepoint_ordering②">codepoint_ordering</a> field following <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a>.</span></p>
+     <p><span class="conform server" id="conform-response-codepoint-ordering"> The response must set the <a data-link-type="dfn">codepoint_ordering</a> field following <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a>.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-original-features"> The response must set the <a data-link-type="dfn" href="#patchresponse-original_features" id="ref-for-patchresponse-original_features②">original_features</a> field to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
+     <p><span class="conform server" id="conform-response-original-features"> The response must set the <a data-link-type="dfn">original_features</a> field to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
 feature tags</a> that the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①①">original font</a> has data for.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-original-axis-space"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①②">original font</a> has variation axes, the
-response must set the <a data-link-type="dfn" href="#patchresponse-original_axis_space" id="ref-for-patchresponse-original_axis_space②">original_axis_space</a> field to the axis space covered by
+response must set the <a data-link-type="dfn">original_axis_space</a> field to the axis space covered by
 the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①③">original font</a>.</span></p>
    </ul>
    <p>Additionally:</p>
@@ -1720,7 +1737,7 @@ the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①�
 either the <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch④">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement④">replacement</a> fields must be one of those
 listed in <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format②">accept_patch_format</a></span>.</p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn" href="#patchresponse-subset_axis_space" id="ref-for-patchresponse-subset_axis_space②">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>.</span></p>
+     <p><span class="conform server" id="conform-response-subset-axis-space-field"> If <a data-link-type="dfn" href="#patchresponse-patch" id="ref-for-patchresponse-patch⑤">patch</a> or <a data-link-type="dfn" href="#patchresponse-replacement" id="ref-for-patchresponse-replacement⑤">replacement</a> fields are set and the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a> has variation axes, the response must set the <a data-link-type="dfn">subset_axis_space</a> field to the axis space covered by the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>.</span></p>
     <li data-md>
      <p><span class="conform server" id="conform-response-ignore-unrecognized-formats"> If <a data-link-type="dfn" href="#patchrequest-accept_patch_format" id="ref-for-patchrequest-accept_patch_format③">accept_patch_format</a> contains any unrecognized patch formats the server must
 ignore the unrecognized ones.</span></p>
@@ -1798,7 +1815,7 @@ in little endian order.</p>
    <p>A codepoint reordering for a font defines a function which maps unicode codepoint values from the
 font to a continuous space of [0, number of codepoints in the font). This transformation is intended
 to reduce the cost of representing codepoint sets.</p>
-   <p><span class="conform server " id="conform-remap-all">A codepoint ordering is encoded into a <a data-link-type="dfn" href="#integerlist" id="ref-for-integerlist④">IntegerList</a>. The list must contain all unicode codepoints that are supported by the
+   <p><span class="conform server " id="conform-remap-all">A codepoint ordering is encoded into a <a data-link-type="dfn" href="#integerlist" id="ref-for-integerlist⑤">IntegerList</a>. The list must contain all unicode codepoints that are supported by the
 font.</span> The index of a particular unicode codepoint in the list is the new value for that
 codepoint.</p>
    <p>A server is free to choose any codepoint ordering, but should try to pick one that will minimize the
@@ -2395,7 +2412,13 @@ itself be statically compressed.</p>
    <li><a href="#bytestring">ByteString</a><span>, in § 4.2.2</span>
    <li><a href="#client-state-client-font-subset">Client font subset</a><span>, in § 4.4.1</span>
    <li><a href="#client-state">Client State</a><span>, in § 4.4.1</span>
-   <li><a href="#patchresponse-codepoint_ordering">codepoint_ordering</a><span>, in § 4.3.4</span>
+   <li><a href="#clientstate">ClientState</a><span>, in § 4.3.5</span>
+   <li>
+    codepoint_ordering
+    <ul>
+     <li><a href="#clientstate-codepoint_ordering">dfn for ClientState</a><span>, in § 4.3.5</span>
+     <li><a href="#patchrequest-codepoint_ordering">dfn for PatchRequest</a><span>, in § 4.3.3</span>
+    </ul>
    <li><a href="#client-state-codepoint-reordering-map">Codepoint Reordering Map</a><span>, in § 4.4.1</span>
    <li><a href="#patchrequest-codepoints_have">codepoints_have</a><span>, in § 4.3.3</span>
    <li><a href="#patchrequest-codepoints_needed">codepoints_needed</a><span>, in § 4.3.3</span>
@@ -2418,16 +2441,16 @@ itself be statically compressed.</p>
    <li><a href="#integerlist">IntegerList</a><span>, in § 4.2.5</span>
    <li><a href="#abstract-opdef-load-a-font-with-a-http-cache">Load a font with a HTTP Cache</a><span>, in § 4.4.4</span>
    <li><a href="#patchrequest-ordering_checksum">ordering_checksum</a><span>, in § 4.3.3</span>
-   <li><a href="#patchresponse-original_axis_space">original_axis_space</a><span>, in § 4.3.4</span>
-   <li><a href="#patchresponse-original_features">original_features</a><span>, in § 4.3.4</span>
+   <li><a href="#clientstate-original_axis_space">original_axis_space</a><span>, in § 4.3.5</span>
+   <li><a href="#clientstate-original_features">original_features</a><span>, in § 4.3.5</span>
    <li><a href="#original-font">original font</a><span>, in § 4.5</span>
    <li><a href="#client-state-original-font-axis-space">Original Font Axis Space</a><span>, in § 4.4.1</span>
    <li><a href="#client-state-original-font-checksum">Original font checksum</a><span>, in § 4.4.1</span>
    <li>
     original_font_checksum
     <ul>
+     <li><a href="#clientstate-original_font_checksum">dfn for ClientState</a><span>, in § 4.3.5</span>
      <li><a href="#patchrequest-original_font_checksum">dfn for PatchRequest</a><span>, in § 4.3.3</span>
-     <li><a href="#patchresponse-original_font_checksum">dfn for PatchResponse</a><span>, in § 4.3.4</span>
     </ul>
    <li><a href="#client-state-original-font-feature-list">Original font feature list</a><span>, in § 4.4.1</span>
    <li><a href="#outline-table">outline table</a><span>, in § 5.2.4</span>
@@ -2454,7 +2477,8 @@ itself be statically compressed.</p>
    <li><a href="#axisinterval-start">start</a><span>, in § 4.3.2</span>
    <li><a href="#string">String</a><span>, in § 4.2.2</span>
    <li><a href="#client-state-subset-axis-space">Subset Axis Space</a><span>, in § 4.4.1</span>
-   <li><a href="#patchresponse-subset_axis_space">subset_axis_space</a><span>, in § 4.3.4</span>
+   <li><a href="#clientstate-subset_axis_space">subset_axis_space</a><span>, in § 4.3.5</span>
+   <li><a href="#patchresponse-unrecognized_ordering">unrecognized_ordering</a><span>, in § 4.3.4</span>
    <li><a href="#usage-document-frequency">usage document frequency</a><span>, in § 5.2.6</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-at-font-face-rule">
@@ -2664,6 +2688,7 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-integer">4.2.3. ProtocolVersion</a>
     <li><a href="#ref-for-integer①">4.3.3. PatchRequest</a> <a href="#ref-for-integer②">(2)</a> <a href="#ref-for-integer③">(3)</a> <a href="#ref-for-integer④">(4)</a> <a href="#ref-for-integer⑤">(5)</a>
     <li><a href="#ref-for-integer⑥">4.3.4. PatchResponse</a> <a href="#ref-for-integer⑦">(2)</a> <a href="#ref-for-integer⑧">(3)</a>
+    <li><a href="#ref-for-integer⑨">4.3.5. ClientState</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="float">
@@ -2715,8 +2740,9 @@ itself be statically compressed.</p>
    <ul>
     <li><a href="#ref-for-integerlist">4.2.5. IntegerList</a>
     <li><a href="#ref-for-integerlist①">4.2.6. SortedIntegerList</a> <a href="#ref-for-integerlist②">(2)</a>
-    <li><a href="#ref-for-integerlist③">4.3.4. PatchResponse</a>
-    <li><a href="#ref-for-integerlist④">4.7. Codepoint Reordering</a>
+    <li><a href="#ref-for-integerlist③">4.3.3. PatchRequest</a>
+    <li><a href="#ref-for-integerlist④">4.3.5. ClientState</a>
+    <li><a href="#ref-for-integerlist⑤">4.7. Codepoint Reordering</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="sortedintegerlist">
@@ -2737,14 +2763,14 @@ itself be statically compressed.</p>
    <b><a href="#featuretagset">#featuretagset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-featuretagset">4.3.3. PatchRequest</a> <a href="#ref-for-featuretagset①">(2)</a>
-    <li><a href="#ref-for-featuretagset②">4.3.4. PatchResponse</a>
+    <li><a href="#ref-for-featuretagset②">4.3.5. ClientState</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="axisspace">
    <b><a href="#axisspace">#axisspace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-axisspace">4.3.3. PatchRequest</a> <a href="#ref-for-axisspace①">(2)</a>
-    <li><a href="#ref-for-axisspace②">4.3.4. PatchResponse</a> <a href="#ref-for-axisspace③">(2)</a>
+    <li><a href="#ref-for-axisspace②">4.3.5. ClientState</a> <a href="#ref-for-axisspace③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="compressedset">
@@ -2936,44 +2962,10 @@ itself be statically compressed.</p>
     <li><a href="#ref-for-patchresponse-replacement③">4.5. Server: Responding to a PatchRequest</a> <a href="#ref-for-patchresponse-replacement④">(2)</a> <a href="#ref-for-patchresponse-replacement⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="patchresponse-original_font_checksum">
-   <b><a href="#patchresponse-original_font_checksum">#patchresponse-original_font_checksum</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="patchresponse-unrecognized_ordering">
+   <b><a href="#patchresponse-unrecognized_ordering">#patchresponse-unrecognized_ordering</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-patchresponse-original_font_checksum">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-original_font_checksum①">4.4.3. Handling Server Response</a> <a href="#ref-for-patchresponse-original_font_checksum②">(2)</a>
-    <li><a href="#ref-for-patchresponse-original_font_checksum③">4.5. Server: Responding to a PatchRequest</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="patchresponse-codepoint_ordering">
-   <b><a href="#patchresponse-codepoint_ordering">#patchresponse-codepoint_ordering</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-patchresponse-codepoint_ordering">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-codepoint_ordering①">4.4.3. Handling Server Response</a>
-    <li><a href="#ref-for-patchresponse-codepoint_ordering②">4.5. Server: Responding to a PatchRequest</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="patchresponse-subset_axis_space">
-   <b><a href="#patchresponse-subset_axis_space">#patchresponse-subset_axis_space</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-patchresponse-subset_axis_space">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-subset_axis_space①">4.4.3. Handling Server Response</a>
-    <li><a href="#ref-for-patchresponse-subset_axis_space②">4.5. Server: Responding to a PatchRequest</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="patchresponse-original_axis_space">
-   <b><a href="#patchresponse-original_axis_space">#patchresponse-original_axis_space</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-patchresponse-original_axis_space">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-original_axis_space①">4.4.3. Handling Server Response</a>
-    <li><a href="#ref-for-patchresponse-original_axis_space②">4.5. Server: Responding to a PatchRequest</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="patchresponse-original_features">
-   <b><a href="#patchresponse-original_features">#patchresponse-original_features</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-patchresponse-original_features">4.4.1. Client State</a>
-    <li><a href="#ref-for-patchresponse-original_features①">4.4.3. Handling Server Response</a>
-    <li><a href="#ref-for-patchresponse-original_features②">4.5. Server: Responding to a PatchRequest</a>
+    <li><a href="#ref-for-patchresponse-unrecognized_ordering">4.3.4. PatchResponse</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="client-state">


### PR DESCRIPTION
Adds a custom table to the font subset which houses client state. See: https://docs.google.com/document/d/1uws2h-48FRxFQPXN8ZHlmWRl35wRsCREUi_vr7-m9cY/edit?usp=sharing for more details.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/136.html" title="Last updated on Mar 1, 2023, 8:42 PM UTC (e15068a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/136/4886f2d...e15068a.html" title="Last updated on Mar 1, 2023, 8:42 PM UTC (e15068a)">Diff</a>