### PR TITLE
Add a mechanism to client state that prevents re-requesting codepoints

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1061,6 +1061,10 @@ For a [=PatchRequest=] object to be well formed:
     <td>4</td>
     <td><dfn for="ClientState">original_features</dfn></td><td>[=FeatureTagSet=]</td></tr>
 
+  <tr>
+    <td>5</td>
+    <td><dfn for="ClientState">missing_codepoints</dfn></td><td>[=CompressedSet=]</td></tr>
+
 </table>
 
 Client {#client}
@@ -1147,10 +1151,11 @@ The algorithm:
      as follows:
 
      *  [=PatchRequest/codepoints_have=]: set to exactly the set of codepoints that the current
-         <var>font subset</var> contains data for. If the current
+         <var>font subset</var> contains data for plus the set of missing codepoints
+         specified in [=ClientState/missing_codepoints=]. If the current
          <var>font subset</var> is not set then this field is left unset. If
-         <var>client state</var> is available and has a [=ClientState/codepoint_ordering=] then
-         this field should not be set.
+         <var>client state</var> is available and has a [=ClientState/codepoint_ordering=]
+         and [=ClientState/missing_codepoints=] is empty then this field should not be set.
 
      *  [=PatchRequest/codepoints_needed=]: set to the set of codepoints that the client wants to
          add to its [=font subset=]. That is the codepoint set from <var>desired subset
@@ -1265,8 +1270,21 @@ The algorithm:
      specified by the [[rfc9110#section-8.4|Content-Encoding]] header. If the
      [[rfc9110#section-8.4|Content-Encoding]] is one of those from [[#patch-encodings]] then
      the input <var>font subset</var> will be used as the source file for the decoding operation. The
-     decoded response is the new extended font subset. Return the extended font subset and any cache
-     headers that were set on the <var>server response</var>.
+     decoded response is the new <var>extended font subset</var>.
+
+3.  Load the <var>client state</var> from the <var>extended font subset</var>. Client state is stored in the
+    <var>extended font subset</var> as a
+    <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>
+    identified by the 4-byte tag 'IFTP'. The contents of the table are a single [=ClientState=] object
+    encoded via CBOR.
+
+4. Verify that the union of the codepoints present in the <var>extended font subset</var> and all codepoints
+    listed in the <var>client state</var> field [=ClientState/missing_codepoints=] is equal to the set of
+    codepoints asked for (union of codepoints/indices needed and codepoints/indices have) in the request
+    which generated this response. If they are not euqal, this is an invalid response. Invoke
+    [$Handle failed font load$] and return the result.
+
+5. Return the <var>extended font subset</var> and any cache headers that were set on the <var>server response</var>.
 
 <dfn abstract-op>Handle failed font load</dfn>
 
@@ -1459,6 +1477,11 @@ result in an extended [=font subset=]:
         The [=ClientState/original_features=] field must be set to the list of
         <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
         feature tags</a> that the [=original font=] has data for.</span>
+
+    *  <span class="conform server" id="conform-response-client-state-missing-codepoints">
+        The [=ClientState/missing_codepoints=] field must be set to the list of codepoints
+        in that are in the set of codepoints needed or the set of codepoints the client has,
+        and are not present in the [=original font=].
 
 Additionally:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -123,7 +123,7 @@ method, <a href="#range-request-incxfer">Range Request</a>, has no server-side r
 
 In order for the range request method to be as effective as possible, the font file itself should be internally arranged in a particular way, in order to decrease the number of requests the browser needs to make. Therefore, it is expected that web developers wishing to use the range request method will use font files that have had their contents already arranged optimally.
 
-This method was modelled after video playback on the web, where seeking in a video causes the browser to send a range request to the server.
+This method was modeled after video playback on the web, where seeking in a video causes the browser to send a range request to the server.
 
 Technical Motivation: Evaluation Report {#evaluation-report}
 ------------------------------------------------------------
@@ -133,7 +133,7 @@ to this specification.
 
 The evaluation report found that patch subset was generally more efficient in terms of overall
 performance and transferred bytes than range request. However, Range Request is simpler to deploy
-for many uses cases while still providing material improvments to loading performance for large fonts.
+for many use cases while still providing material improvements to loading performance for large fonts.
 
 Performance Considerations and the use of Incremental Font Transfer {#performance-considerations}
 --------------------------------------------------------
@@ -144,7 +144,7 @@ and the content being rendered. This section provides non-normative guidance to 
 1. When incremental transfer should be utilized.
 2. When used, which of the two methods should be utilized.
 
-Incrementally loading a font has a fundemental performance tradeoff versus loading the whole font.
+Incrementally loading a font has a fundamental performance trade off versus loading the whole font.
 Simplistically, under incremental transfer less bytes may be transferred at the potential cost of
 increasing the total number of network requests being made, and/or increased request processing
 latency. In general incremental font transfer will be beneficial where the reduction in latency from
@@ -188,7 +188,7 @@ performance.
 Performant implementations should incorporate a similar mechanism which can select codepoints which are
 likely to be needed in the future and preemptively load them. This will improve performance by reducing
 the need to make additional requests for missing codepoints. The set of codepoints the client has and
-the set they are requesting can be used in conjuction with codepoint occurence frequency and codepoint
+the set they are requesting can be used in conjunction with codepoint occurrence frequency and codepoint
 usage in languages/scripts  to make predictions on which additional codepoints are likely to be needed.
 
 Under range request the prediction mechanism will need to be part of the client implementation. In
@@ -212,7 +212,7 @@ three main factors for this:
 3. Patch subset is able to compress incremental font data against previously loaded data from that
     font. This leads to better compression overall compared to range request.
 
-See the evaluation report for a quantative assessment of the difference in performance of patch
+See the evaluation report for a quantitative assessment of the difference in performance of patch
 subset versus range request [[PFE-report#analysis]].
 
 The downside of using patch subset is that it requires server side processing to produce the patches,
@@ -229,7 +229,7 @@ Opt-In Mechanism {#opt-in}
 
 <em>This section is general to both IFT methods.</em>
 
-Webpage's can choose to opt-in to either patch subset or range request incremental transfer for a font
+Web page's can choose to opt-in to either patch subset or range request incremental transfer for a font
 via the use of a CSS font tech keyword ([[css-fonts-4#font-tech-definitions]]) inside the
 ''@font-face'' block.
 
@@ -260,11 +260,11 @@ Note: Each individual <code>@font-face</code> block may or may not opt-in to IFT
 variety of ways fonts are used on web pages. Authors have control over which fonts they want to use
 this technology with, and which they do not.
 
-Note: the use of <code>incremental-auto</code> may incur a CORS preflight request for the initial
+Note: the use of <code>incremental-auto</code> may incur a CORS pre-flight request for the initial
 request of method negotiation, as the initial request sets a custom header.
 
-Note: the IFT tech keywords can be used in conjuction with other font tech specifiers to perform
-font feature selection. For example a <code>@font-face</code> could include two urls one with
+Note: the IFT tech keywords can be used in conjunction with other font tech specifiers to perform
+font feature selection. For example a <code>@font-face</code> could include two URLs one with
 <code>tech(incremental-patch, color-COLRv1)</code> and the other with
 <code>tech(incremental-patch, color-COLRv0)</code>. The client would initiate an incremental patch
 subset transfer to one of the URLs depending on which version of COLR is supported.
@@ -301,7 +301,7 @@ IFT Method Negotiation {#method-negotiation}
 
 When the particular IFT method(s) that are supported by a server are not known, the client must
 determine which method to use. Different clients may support different IFT methods, and different
-servers may support different IFT methods, so a negotation occurs as such:
+servers may support different IFT methods, so a negotiation occurs as such:
 
 1.  The browser makes the first request to the server using the GET HTTP method ([[rfc9110#section-9.3.1]]).
      If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant
@@ -396,9 +396,9 @@ Offline Usage {#offline-usage}
 
 Special consideration must be taken when saving a page for offline usage that uses an incrementally
 transferred font since the saved page won't be able to increment the font if content changes (eg.
-due to javascript execution). In these cases the page saving mechanism should download the full font
+due to JavaScript execution). In these cases the page saving mechanism should download the full font
 by making a normal GET request without the [=patch request header=] to the font url. Additionally
-when URL's are rewritten to point to the saved full font any of the incremental tech specifiers should
+when URLs are rewritten to point to the saved full font any of the incremental tech specifiers should
 be removed.
 
 Patch Based Incremental Transfer {#patch-incxfer}
@@ -411,7 +411,7 @@ A <dfn dfn>font subset</dfn> is a modified version of a font file that contains 
 render a subset of:
 
 *  the codepoints,
-*  <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
+*  <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout
     features</a>,
 *  and <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a>.
 
@@ -708,7 +708,7 @@ Zig-Zag encoding reversibly converts signed integers to unsigned integers,
 using the same number of bits. The entire range of values is supported.
 This step is required, as the [[#integerlist-uintbase128]] step works on
 unsigned integers only. The encoding maps positive integer values to even positive integers and
-negative integer values to odd positive integers. Psuedo code:
+negative integer values to odd positive integers. Pseudo code:
 
 ```
 encode(n):
@@ -864,7 +864,7 @@ bytes = [03 07 03 81 7F]
 ### <dfn>FeatureTagSet</dfn> ### {#featuretagset-object}
 
 A FeatureTagSet encodes a set of zero or more
-<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a>.
+<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>.
 Each feature tag is mapped to an integer value and then the set of mapped integers are encoded in a
 [=SortedIntegerList=]. Feature tags are mapped to integers as follows:
 
@@ -878,7 +878,7 @@ Each feature tag is mapped to an integer value and then the set of mapped intege
 *  Otherwise: the tag is converted to an integer by treating the tag's 4 byte string as a 4 byte
     little endian integer.
 
-The final encoding is produced by sorting the mapped integers (exlcuding tags which are skipped)
+The final encoding is produced by sorting the mapped integers (excluding tags which are skipped)
 into ascending order and then encoding the sorted list as a [=SortedIntegerList=].
 
 When decoding a FeatureTagSet the integer values are mapped back to the original tags by reversing
@@ -1091,7 +1091,7 @@ The inputs to this algorithm are:
     minimum [=font subset=].
 
 * <var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as [[fetch]]. The remainder
-    of this section is desribed in terms of [[fetch#fetching]], but it is allowed to substitute
+    of this section is described in terms of [[fetch#fetching]], but it is allowed to substitute
     whatever HTTP fetching algorithm the user agent supports.
 
 The algorithm outputs:
@@ -1180,7 +1180,7 @@ The algorithm:
 
      *  [=PatchRequest/features_have=]: set to the list of
          <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">
-         opentype layout feature tags</a> that the current <var>font subset</var> has data
+         OpenType layout feature tags</a> that the current <var>font subset</var> has data
          for. If the current <var>font subset</var> is not set then this
          field is left unset. Additionally, if the current <var>font subset</var> has all
          data for features present in the [=original font=] then this field can be unset.
@@ -1224,13 +1224,13 @@ The algorithm:
 4. Invoke [$Handle server response$] with the response from the server and the <var>font subset</var>
     then return the result.
 
-Note: POST is preferred for the HTTP method since it will not cause a CORS preflight request
+Note: POST is preferred for the HTTP method since it will not cause a CORS pre-flight request
 and the request object is more compactly encoded. GET should only be used during
 <a href="#method-negotiation">method negotiation</a>.
 
 <h4 algorithm id="handling-patch-response">Handling Server Response</h4>
 
-If a server is able to succsessfully process a [=PatchRequest=]
+If a server is able to successfully process a [=PatchRequest=]
 it will respond with HTTP [=response/status=] code 200 and the [=response/body=] of the response will
 be an encoded representation of the extended font subset. The encoded representation may be a binary
 patch against the current font subset.
@@ -1281,7 +1281,7 @@ The algorithm:
 4. Verify that the union of the codepoints present in the <var>extended font subset</var> and all codepoints
     listed in the <var>client state</var> field [=ClientState/missing_codepoints=] is equal to the set of
     codepoints asked for (union of codepoints/indices needed and codepoints/indices have) in the request
-    which generated this response. If they are not euqal, this is an invalid response. Invoke
+    which generated this response. If they are not equal, this is an invalid response. Invoke
     [$Handle failed font load$] and return the result.
 
 5. Return the <var>extended font subset</var> and any cache headers that were set on the <var>server response</var>.
@@ -1319,7 +1319,7 @@ The inputs to this algorithm:
     minimum [=font subset=].
 
 * <var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as [[fetch]]. The remainder
-    of this section is desribed in terms of [[fetch#fetching]], but it is allowed to substitute
+    of this section is described in terms of [[fetch#fetching]], but it is allowed to substitute
     whatever HTTP fetching algorithm the user agent supports.
 
 The algorithm outputs:
@@ -1409,7 +1409,7 @@ Note: the request may optionally set [=PatchRequest/codepoint_ordering=] which i
 provide the exact codepoint ordering that was used to encode [=PatchRequest/indices_have=] and
 [=PatchRequest/indices_needed=].
 
-Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a>:
+Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>:
 
 1.  Feature tags the client's subset has: specified by [=PatchRequest/features_have=]. If the field is
      unset this indicates the client's subset contains all features in the [=original font=].
@@ -1475,7 +1475,7 @@ result in an extended [=font subset=]:
 
     *  <span class="conform server" id="conform-response-client-state-original-features">
         The [=ClientState/original_features=] field must be set to the list of
-        <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
+        <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout
         feature tags</a> that the [=original font=] has data for.</span>
 
     *  <span class="conform server" id="conform-response-client-state-missing-codepoints">
@@ -1513,7 +1513,7 @@ Possible error responses:
 ### Range Request Support ### {#range-request-support}
 
 A patch subset support server must also support incremental transfer via [[#range-request-incxfer]].
-To support range request incremental tranfser the patch subset server must support HTTP range requests
+To support range request incremental transfer the patch subset server must support HTTP range requests
 ([[RFC9110#section-14]]) against the font files it provides via patch subset.
 
 
@@ -1686,7 +1686,7 @@ One mitigation, which was originally introduced for reasons of networking effici
 In the patch subset method 64 bit checksums are generated and transferred between client and server. These are used to
 ensure the client and server are in sync. They detect cases such as where the original font being patched has changed or
 the server is not able to reproduce the clients font subset. The checksums will be stored in a browsers HTTP cache as
-part of the font subset and thus are subject to the cache paritioning applied by the browser. Since modern browsers
+part of the font subset and thus are subject to the cache partitioning applied by the browser. Since modern browsers
 cache resources keyed by the site domain, this will limit checksum availability to within the site domain and prevent
 them from being used for tracking.
 
@@ -1727,7 +1727,7 @@ Since the <a href="https://www.w3.org/TR/2022/WD-IFT-20220628/">Working
   <li>Added an id for offline usage header</li>
   <li>Updated the responding to patch request section for client state changes</li>
   <li>Updated loading with a cache section for client state changes</li>
-  <li>Added client side handling of new urecognized_ordering field</li>
+  <li>Added client side handling of new unrecognized_ordering field</li>
   <li>Updated handling failed font load section for client state</li>
   <li>Updated the 'Extending font subset' section for client state changes</li>
   <li>Added ClientState object schema</li>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="f9e9e4cf1cf8f31bc54cb45d3a96f52a8ea5bbea" name="document-revision">
+  <meta content="d0d75bfd53b867d2c8475ece13b2d15e88c2a251" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -1571,6 +1571,10 @@ set then <a data-link-type="dfn" href="#patchrequest-ordering_checksum" id="ref-
       <td>4
       <td><dfn class="dfn-paneled" data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-original_features">original_features</dfn>
       <td><a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset②">FeatureTagSet</a>
+     <tr>
+      <td>5
+      <td><dfn class="dfn-paneled" data-dfn-for="ClientState" data-dfn-type="dfn" data-noexport id="clientstate-missing_codepoints">missing_codepoints</dfn>
+      <td><a data-link-type="dfn" href="#compressedset" id="ref-for-compressedset④">CompressedSet</a>
    </table>
    <h3 class="heading settled" data-level="4.4" id="client"><span class="secno">4.4. </span><span class="content">Client</span><a class="self-link" href="#client"></a></h3>
    <h4 class="heading settled algorithm" data-algorithm="Extending the Font Subset" data-level="4.4.1" id="extend-subset"><span class="secno">4.4.1. </span><span class="content">Extending the Font Subset</span><a class="self-link" href="#extend-subset"></a></h4>
@@ -1648,8 +1652,8 @@ encoded via CBOR.</p>
  as follows:</p>
      <ul>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-codepoints_have" id="ref-for-patchrequest-codepoints_have①">codepoints_have</a>: set to exactly the set of codepoints that the current <var>font subset</var> contains data for. If the current <var>font subset</var> is not set then this field is left unset. If <var>client state</var> is available and has a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering">codepoint_ordering</a> then
- this field should not be set.</p>
+       <p><a data-link-type="dfn" href="#patchrequest-codepoints_have" id="ref-for-patchrequest-codepoints_have①">codepoints_have</a>: set to exactly the set of codepoints that the current <var>font subset</var> contains data for plus the set of missing codepoints
+ specified in <a data-link-type="dfn" href="#clientstate-missing_codepoints" id="ref-for-clientstate-missing_codepoints">missing_codepoints</a>. If the current <var>font subset</var> is not set then this field is left unset. If <var>client state</var> is available and has a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering">codepoint_ordering</a> and <a data-link-type="dfn" href="#clientstate-missing_codepoints" id="ref-for-clientstate-missing_codepoints①">missing_codepoints</a> is empty then this field should not be set.</p>
       <li data-md>
        <p><a data-link-type="dfn" href="#patchrequest-codepoints_needed" id="ref-for-patchrequest-codepoints_needed">codepoints_needed</a>: set to the set of codepoints that the client wants to
  add to its <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a>. That is the codepoint set from <var>desired subset
@@ -1742,8 +1746,17 @@ can be cached, or null.</p>
      <p>Decode the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a> by applying the appropriate decoding as
  specified by the <a href="https://www.rfc-editor.org/rfc/rfc9110#section-8.4">Content-Encoding</a> header. If the <a href="https://www.rfc-editor.org/rfc/rfc9110#section-8.4">Content-Encoding</a> is one of those from <a href="#patch-encodings">§ 4.8 Patch Encodings</a> then
  the input <var>font subset</var> will be used as the source file for the decoding operation. The
- decoded response is the new extended font subset. Return the extended font subset and any cache
- headers that were set on the <var>server response</var>.</p>
+ decoded response is the new <var>extended font subset</var>.</p>
+    <li data-md>
+     <p>Load the <var>client state</var> from the <var>extended font subset</var>. Client state is stored in the <var>extended font subset</var> as a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag 'IFTP'. The contents of the table are a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate①">ClientState</a> object
+encoded via CBOR.</p>
+    <li data-md>
+     <p>Verify that the union of the codepoints present in the <var>extended font subset</var> and all codepoints
+listed in the <var>client state</var> field <a data-link-type="dfn" href="#clientstate-missing_codepoints" id="ref-for-clientstate-missing_codepoints②">missing_codepoints</a> is equal to the set of
+codepoints asked for (union of codepoints/indices needed and codepoints/indices have) in the request
+which generated this response. If they are not euqal, this is an invalid response. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load①">Handle failed font load</a> and return the result.</p>
+    <li data-md>
+     <p>Return the <var>extended font subset</var> and any cache headers that were set on the <var>server response</var>.</p>
    </ol>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-failed-font-load">Handle failed font load</dfn></p>
    <p>If the font load or extension has failed the client should choose one of the following options:</p>
@@ -1892,7 +1905,7 @@ the union of the set of features needed and the sets of features the client alre
 space that covers at least the union of the axis space the client has and the axis space the
 client needs.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-client-state">That has a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> which is identified by the tag 'IFTP' whose content is a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate①">ClientState</a> object encoded via
+     <p><span class="conform server" id="conform-response-client-state">That has a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> which is identified by the tag 'IFTP' whose content is a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate②">ClientState</a> object encoded via
 CBOR:</span></p>
      <ul>
       <li data-md>
@@ -1907,6 +1920,10 @@ CBOR:</span></p>
       <li data-md>
        <p><span class="conform server" id="conform-response-client-state-original-features"> The <a data-link-type="dfn" href="#clientstate-original_features" id="ref-for-clientstate-original_features">original_features</a> field must be set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
 feature tags</a> that the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①③">original font</a> has data for.</span></p>
+      <li data-md>
+       <p><span class="conform server" id="conform-response-client-state-missing-codepoints"> The <a data-link-type="dfn" href="#clientstate-missing_codepoints" id="ref-for-clientstate-missing_codepoints③">missing_codepoints</a> field must be set to the list of codepoints
+in that are in the set of codepoints needed or the set of codepoints the client has,
+and are not present in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①④">original font</a>.</span></p>
      </ul>
    </ul>
    <p>Additionally:</p>
@@ -2575,6 +2592,7 @@ them from being used for tracking.</p>
    <li><a href="#integer">Integer</a><span>, in § 4.2.2</span>
    <li><a href="#integerlist">IntegerList</a><span>, in § 4.2.4</span>
    <li><a href="#abstract-opdef-load-a-font-with-a-http-cache">Load a font with a HTTP Cache</a><span>, in § 4.4.3</span>
+   <li><a href="#clientstate-missing_codepoints">missing_codepoints</a><span>, in § 4.3.4</span>
    <li><a href="#patchrequest-ordering_checksum">ordering_checksum</a><span>, in § 4.3.3</span>
    <li><a href="#clientstate-original_axis_space">original_axis_space</a><span>, in § 4.3.4</span>
    <li><a href="#clientstate-original_features">original_features</a><span>, in § 4.3.4</span>
@@ -2997,7 +3015,7 @@ window.dfnpanelData['sortedintegerlist'] = {"dfnID": "sortedintegerlist", "url":
 window.dfnpanelData['rangelist'] = {"dfnID": "rangelist", "url": "#rangelist", "dfnText": "RangeList", "refSections": [{"refs": [{"id": "ref-for-rangelist"}, {"id": "ref-for-rangelist\u2460"}], "title": "4.3.1. CompressedSet"}], "external": false};
 window.dfnpanelData['featuretagset'] = {"dfnID": "featuretagset", "url": "#featuretagset", "dfnText": "FeatureTagSet", "refSections": [{"refs": [{"id": "ref-for-featuretagset"}, {"id": "ref-for-featuretagset\u2460"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-featuretagset\u2461"}], "title": "4.3.4. ClientState"}], "external": false};
 window.dfnpanelData['axisspace'] = {"dfnID": "axisspace", "url": "#axisspace", "dfnText": "AxisSpace", "refSections": [{"refs": [{"id": "ref-for-axisspace"}, {"id": "ref-for-axisspace\u2460"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-axisspace\u2461"}, {"id": "ref-for-axisspace\u2462"}], "title": "4.3.4. ClientState"}], "external": false};
-window.dfnpanelData['compressedset'] = {"dfnID": "compressedset", "url": "#compressedset", "dfnText": "CompressedSet", "refSections": [{"refs": [{"id": "ref-for-compressedset"}, {"id": "ref-for-compressedset\u2460"}, {"id": "ref-for-compressedset\u2461"}, {"id": "ref-for-compressedset\u2462"}], "title": "4.3.3. PatchRequest"}], "external": false};
+window.dfnpanelData['compressedset'] = {"dfnID": "compressedset", "url": "#compressedset", "dfnText": "CompressedSet", "refSections": [{"refs": [{"id": "ref-for-compressedset"}, {"id": "ref-for-compressedset\u2460"}, {"id": "ref-for-compressedset\u2461"}, {"id": "ref-for-compressedset\u2462"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-compressedset\u2463"}], "title": "4.3.4. ClientState"}], "external": false};
 window.dfnpanelData['compressedset-sparse_bit_set'] = {"dfnID": "compressedset-sparse_bit_set", "url": "#compressedset-sparse_bit_set", "dfnText": "sparse_bit_set", "refSections": [{"refs": [{"id": "ref-for-compressedset-sparse_bit_set"}], "title": "4.3.1. CompressedSet"}], "external": false};
 window.dfnpanelData['compressedset-range_deltas'] = {"dfnID": "compressedset-range_deltas", "url": "#compressedset-range_deltas", "dfnText": "range_deltas", "refSections": [{"refs": [{"id": "ref-for-compressedset-range_deltas"}], "title": "4.3.1. CompressedSet"}], "external": false};
 window.dfnpanelData['axisinterval'] = {"dfnID": "axisinterval", "url": "#axisinterval", "dfnText": "AxisInterval", "refSections": [{"refs": [{"id": "ref-for-axisinterval"}], "title": "4.2.8. AxisSpace"}, {"refs": [{"id": "ref-for-axisinterval\u2460"}, {"id": "ref-for-axisinterval\u2461"}], "title": "4.3.2. AxisInterval"}], "external": false};
@@ -3017,17 +3035,18 @@ window.dfnpanelData['patchrequest-original_font_checksum'] = {"dfnID": "patchreq
 window.dfnpanelData['patchrequest-base_checksum'] = {"dfnID": "patchrequest-base_checksum", "url": "#patchrequest-base_checksum", "dfnText": "base_checksum", "refSections": [{"refs": [{"id": "ref-for-patchrequest-base_checksum"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-patchrequest-base_checksum\u2460"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-patchrequest-base_checksum\u2461"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
 window.dfnpanelData['patchrequest-fragment_id'] = {"dfnID": "patchrequest-fragment_id", "url": "#patchrequest-fragment_id", "dfnText": "fragment_id", "refSections": [{"refs": [{"id": "ref-for-patchrequest-fragment_id"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-patchrequest-fragment_id\u2460"}, {"id": "ref-for-patchrequest-fragment_id\u2461"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
 window.dfnpanelData['patchrequest-codepoint_ordering'] = {"dfnID": "patchrequest-codepoint_ordering", "url": "#patchrequest-codepoint_ordering", "dfnText": "codepoint_ordering", "refSections": [{"refs": [{"id": "ref-for-patchrequest-codepoint_ordering"}], "title": "4.4.2. Handling Server Response"}, {"refs": [{"id": "ref-for-patchrequest-codepoint_ordering\u2460"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
-window.dfnpanelData['clientstate'] = {"dfnID": "clientstate", "url": "#clientstate", "dfnText": "ClientState", "refSections": [{"refs": [{"id": "ref-for-clientstate"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-clientstate\u2460"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
+window.dfnpanelData['clientstate'] = {"dfnID": "clientstate", "url": "#clientstate", "dfnText": "ClientState", "refSections": [{"refs": [{"id": "ref-for-clientstate"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-clientstate\u2460"}], "title": "4.4.2. Handling Server Response"}, {"refs": [{"id": "ref-for-clientstate\u2461"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
 window.dfnpanelData['clientstate-original_font_checksum'] = {"dfnID": "clientstate-original_font_checksum", "url": "#clientstate-original_font_checksum", "dfnText": "original_font_checksum", "refSections": [{"refs": [{"id": "ref-for-clientstate-original_font_checksum"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-clientstate-original_font_checksum\u2460"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
 window.dfnpanelData['clientstate-codepoint_ordering'] = {"dfnID": "clientstate-codepoint_ordering", "url": "#clientstate-codepoint_ordering", "dfnText": "codepoint_ordering", "refSections": [{"refs": [{"id": "ref-for-clientstate-codepoint_ordering"}, {"id": "ref-for-clientstate-codepoint_ordering\u2460"}, {"id": "ref-for-clientstate-codepoint_ordering\u2461"}, {"id": "ref-for-clientstate-codepoint_ordering\u2462"}, {"id": "ref-for-clientstate-codepoint_ordering\u2463"}, {"id": "ref-for-clientstate-codepoint_ordering\u2464"}, {"id": "ref-for-clientstate-codepoint_ordering\u2465"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-clientstate-codepoint_ordering\u2466"}], "title": "4.4.2. Handling Server Response"}, {"refs": [{"id": "ref-for-clientstate-codepoint_ordering\u2467"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
 window.dfnpanelData['clientstate-subset_axis_space'] = {"dfnID": "clientstate-subset_axis_space", "url": "#clientstate-subset_axis_space", "dfnText": "subset_axis_space", "refSections": [{"refs": [{"id": "ref-for-clientstate-subset_axis_space"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-clientstate-subset_axis_space\u2460"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
 window.dfnpanelData['clientstate-original_axis_space'] = {"dfnID": "clientstate-original_axis_space", "url": "#clientstate-original_axis_space", "dfnText": "original_axis_space", "refSections": [{"refs": [{"id": "ref-for-clientstate-original_axis_space"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
 window.dfnpanelData['clientstate-original_features'] = {"dfnID": "clientstate-original_features", "url": "#clientstate-original_features", "dfnText": "original_features", "refSections": [{"refs": [{"id": "ref-for-clientstate-original_features"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
+window.dfnpanelData['clientstate-missing_codepoints'] = {"dfnID": "clientstate-missing_codepoints", "url": "#clientstate-missing_codepoints", "dfnText": "missing_codepoints", "refSections": [{"refs": [{"id": "ref-for-clientstate-missing_codepoints"}, {"id": "ref-for-clientstate-missing_codepoints\u2460"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-clientstate-missing_codepoints\u2461"}], "title": "4.4.2. Handling Server Response"}, {"refs": [{"id": "ref-for-clientstate-missing_codepoints\u2462"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
 window.dfnpanelData['abstract-opdef-extend-the-font-subset'] = {"dfnID": "abstract-opdef-extend-the-font-subset", "url": "#abstract-opdef-extend-the-font-subset", "dfnText": "Extend the font subset", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-extend-the-font-subset"}, {"id": "ref-for-abstract-opdef-extend-the-font-subset\u2460"}], "title": "4.4.3. Load a Font in a User Agent with a HTTP Cache"}], "external": false};
 window.dfnpanelData['patch-request-header'] = {"dfnID": "patch-request-header", "url": "#patch-request-header", "dfnText": "patch request header", "refSections": [{"refs": [{"id": "ref-for-patch-request-header"}], "title": "3.1. IFT Method Negotiation"}, {"refs": [{"id": "ref-for-patch-request-header\u2460"}], "title": "3.3. Offline Usage"}], "external": false};
 window.dfnpanelData['abstract-opdef-handle-server-response'] = {"dfnID": "abstract-opdef-handle-server-response", "url": "#abstract-opdef-handle-server-response", "dfnText": "Handle server response", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-handle-server-response"}], "title": "4.4.1. Extending the Font Subset"}], "external": false};
-window.dfnpanelData['abstract-opdef-handle-failed-font-load'] = {"dfnID": "abstract-opdef-handle-failed-font-load", "url": "#abstract-opdef-handle-failed-font-load", "dfnText": "Handle failed font load", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-handle-failed-font-load"}], "title": "4.4.2. Handling Server Response"}], "external": false};
-window.dfnpanelData['original-font'] = {"dfnID": "original-font", "url": "#original-font", "dfnText": "original font", "refSections": [{"refs": [{"id": "ref-for-original-font"}, {"id": "ref-for-original-font\u2460"}, {"id": "ref-for-original-font\u2461"}, {"id": "ref-for-original-font\u2462"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-original-font\u2463"}], "title": "4.4.2. Handling Server Response"}, {"refs": [{"id": "ref-for-original-font\u2464"}, {"id": "ref-for-original-font\u2465"}, {"id": "ref-for-original-font\u2466"}, {"id": "ref-for-original-font\u2467"}, {"id": "ref-for-original-font\u2468"}, {"id": "ref-for-original-font\u2460\u24ea"}, {"id": "ref-for-original-font\u2460\u2460"}, {"id": "ref-for-original-font\u2460\u2461"}, {"id": "ref-for-original-font\u2460\u2462"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
+window.dfnpanelData['abstract-opdef-handle-failed-font-load'] = {"dfnID": "abstract-opdef-handle-failed-font-load", "url": "#abstract-opdef-handle-failed-font-load", "dfnText": "Handle failed font load", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-handle-failed-font-load"}, {"id": "ref-for-abstract-opdef-handle-failed-font-load\u2460"}], "title": "4.4.2. Handling Server Response"}], "external": false};
+window.dfnpanelData['original-font'] = {"dfnID": "original-font", "url": "#original-font", "dfnText": "original font", "refSections": [{"refs": [{"id": "ref-for-original-font"}, {"id": "ref-for-original-font\u2460"}, {"id": "ref-for-original-font\u2461"}, {"id": "ref-for-original-font\u2462"}], "title": "4.4.1. Extending the Font Subset"}, {"refs": [{"id": "ref-for-original-font\u2463"}], "title": "4.4.2. Handling Server Response"}, {"refs": [{"id": "ref-for-original-font\u2464"}, {"id": "ref-for-original-font\u2465"}, {"id": "ref-for-original-font\u2466"}, {"id": "ref-for-original-font\u2467"}, {"id": "ref-for-original-font\u2468"}, {"id": "ref-for-original-font\u2460\u24ea"}, {"id": "ref-for-original-font\u2460\u2460"}, {"id": "ref-for-original-font\u2460\u2461"}, {"id": "ref-for-original-font\u2460\u2462"}, {"id": "ref-for-original-font\u2460\u2463"}], "title": "4.5. Server: Responding to a PatchRequest"}], "external": false};
 </script>
 <script>/* Boilerplate: script-dom-helper */
 function query(sel) { return document.querySelector(sel); }

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="d0d75bfd53b867d2c8475ece13b2d15e88c2a251" name="document-revision">
+  <meta content="6b144cd2ec171938a9ec48d3b5773d648b7a5ce8" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -728,13 +728,13 @@ is then produced between the two subsets.</p>
    <p>The second
 method, <a href="#range-request-incxfer">Range Request</a>, has no server-side requirements other than the server should be able to respond to byte-based range requests. The browser makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file to obtain all required font tables, and then calculates glyph coverage and required byte ranges using font character-to-glyph mapping and glyph substitution / layout tables.</p>
    <p>In order for the range request method to be as effective as possible, the font file itself should be internally arranged in a particular way, in order to decrease the number of requests the browser needs to make. Therefore, it is expected that web developers wishing to use the range request method will use font files that have had their contents already arranged optimally.</p>
-   <p>This method was modelled after video playback on the web, where seeking in a video causes the browser to send a range request to the server.</p>
+   <p>This method was modeled after video playback on the web, where seeking in a video causes the browser to send a range request to the server.</p>
    <h3 class="heading settled" data-level="1.3" id="evaluation-report"><span class="secno">1.3. </span><span class="content">Technical Motivation: Evaluation Report</span><a class="self-link" href="#evaluation-report"></a></h3>
    <p>See the Progressive Font Enrichment: Evaluation Report <a data-link-type="biblio" href="#biblio-pfe-report" title="Progressive Font Enrichment: Evaluation Report">[PFE-report]</a> for the investigation which led
 to this specification.</p>
    <p>The evaluation report found that patch subset was generally more efficient in terms of overall
 performance and transferred bytes than range request. However, Range Request is simpler to deploy
-for many uses cases while still providing material improvments to loading performance for large fonts.</p>
+for many use cases while still providing material improvements to loading performance for large fonts.</p>
    <h3 class="heading settled" data-level="1.4" id="performance-considerations"><span class="secno">1.4. </span><span class="content">Performance Considerations and the use of Incremental Font Transfer</span><a class="self-link" href="#performance-considerations"></a></h3>
    <p>Using incremental transfer may not always be beneficial, depending on the characteristics of the font
 and the content being rendered. This section provides non-normative guidance to help decide:</p>
@@ -744,7 +744,7 @@ and the content being rendered. This section provides non-normative guidance to 
     <li data-md>
      <p>When used, which of the two methods should be utilized.</p>
    </ol>
-   <p>Incrementally loading a font has a fundemental performance tradeoff versus loading the whole font.
+   <p>Incrementally loading a font has a fundamental performance trade off versus loading the whole font.
 Simplistically, under incremental transfer less bytes may be transferred at the potential cost of
 increasing the total number of network requests being made, and/or increased request processing
 latency. In general incremental font transfer will be beneficial where the reduction in latency from
@@ -784,7 +784,7 @@ performance.</p>
    <p>Performant implementations should incorporate a similar mechanism which can select codepoints which are
 likely to be needed in the future and preemptively load them. This will improve performance by reducing
 the need to make additional requests for missing codepoints. The set of codepoints the client has and
-the set they are requesting can be used in conjuction with codepoint occurence frequency and codepoint
+the set they are requesting can be used in conjunction with codepoint occurrence frequency and codepoint
 usage in languages/scripts  to make predictions on which additional codepoints are likely to be needed.</p>
    <p>Under range request the prediction mechanism will need to be part of the client implementation. In
 patch subset either the client and/or server implementation can include a prediction mechanism. A side
@@ -806,7 +806,7 @@ the non outline tables.</p>
      <p>Patch subset is able to compress incremental font data against previously loaded data from that
 font. This leads to better compression overall compared to range request.</p>
    </ol>
-   <p>See the evaluation report for a quantative assessment of the difference in performance of patch
+   <p>See the evaluation report for a quantitative assessment of the difference in performance of patch
 subset versus range request <a href="https://www.w3.org/TR/PFE-evaluation/#analysis">Progressive Font Enrichment: Evaluation Report § analysis</a>.</p>
    <p>The downside of using patch subset is that it requires server side processing to produce the patches,
 while range request can work on any standard HTTP server that supports range requests:</p>
@@ -820,7 +820,7 @@ CPU, RAM usage) per request vs range request.</p>
    </ul>
    <h2 class="heading settled" data-level="2" id="opt-in"><span class="secno">2. </span><span class="content">Opt-In Mechanism</span><a class="self-link" href="#opt-in"></a></h2>
    <p><em>This section is general to both IFT methods.</em></p>
-   <p>Webpage’s can choose to opt-in to either patch subset or range request incremental transfer for a font
+   <p>Web page’s can choose to opt-in to either patch subset or range request incremental transfer for a font
 via the use of a CSS font tech keyword (<a href="https://www.w3.org/TR/css-fonts-4/#font-tech-definitions"><cite>CSS Fonts 4</cite> § 11.1 Font tech</a>) inside the
 ''@font-face'' block.</p>
    <p>There are three tech keywords available:</p>
@@ -848,10 +848,10 @@ unavailable codepoints.</p>
    <p class="note" role="note"><span class="marker">Note:</span> Each individual <code>@font-face</code> block may or may not opt-in to IFT. This is due to the
 variety of ways fonts are used on web pages. Authors have control over which fonts they want to use
 this technology with, and which they do not.</p>
-   <p class="note" role="note"><span class="marker">Note:</span> the use of <code>incremental-auto</code> may incur a CORS preflight request for the initial
+   <p class="note" role="note"><span class="marker">Note:</span> the use of <code>incremental-auto</code> may incur a CORS pre-flight request for the initial
 request of method negotiation, as the initial request sets a custom header.</p>
-   <p class="note" role="note"><span class="marker">Note:</span> the IFT tech keywords can be used in conjuction with other font tech specifiers to perform
-font feature selection. For example a <code>@font-face</code> could include two urls one with <code>tech(incremental-patch, color-COLRv1)</code> and the other with <code>tech(incremental-patch, color-COLRv0)</code>. The client would initiate an incremental patch
+   <p class="note" role="note"><span class="marker">Note:</span> the IFT tech keywords can be used in conjunction with other font tech specifiers to perform
+font feature selection. For example a <code>@font-face</code> could include two URLs one with <code>tech(incremental-patch, color-COLRv1)</code> and the other with <code>tech(incremental-patch, color-COLRv0)</code>. The client would initiate an incremental patch
 subset transfer to one of the URLs depending on which version of COLR is supported.</p>
    <h2 class="heading settled" data-level="3" id="method-selection"><span class="secno">3. </span><span class="content">IFT Method Selection</span><a class="self-link" href="#method-selection"></a></h2>
    <p><em>This section is general to both IFT methods.</em></p>
@@ -876,7 +876,7 @@ method.</p>
    <h3 class="heading settled" data-level="3.1" id="method-negotiation"><span class="secno">3.1. </span><span class="content">IFT Method Negotiation</span><a class="self-link" href="#method-negotiation"></a></h3>
    <p>When the particular IFT method(s) that are supported by a server are not known, the client must
 determine which method to use. Different clients may support different IFT methods, and different
-servers may support different IFT methods, so a negotation occurs as such:</p>
+servers may support different IFT methods, so a negotiation occurs as such:</p>
    <ol>
     <li data-md>
      <p>The browser makes the first request to the server using the GET HTTP method (<a href="https://www.rfc-editor.org/rfc/rfc9110#section-9.3.1"><cite>HTTP Semantics</cite> § 9.3.1 GET</a>).
@@ -955,9 +955,9 @@ servers may support different IFT methods, so a negotation occurs as such:</p>
    <h3 class="heading settled" data-level="3.3" id="offline-usage"><span class="secno">3.3. </span><span class="content">Offline Usage</span><a class="self-link" href="#offline-usage"></a></h3>
    <p>Special consideration must be taken when saving a page for offline usage that uses an incrementally
 transferred font since the saved page won’t be able to increment the font if content changes (eg.
-due to javascript execution). In these cases the page saving mechanism should download the full font
+due to JavaScript execution). In these cases the page saving mechanism should download the full font
 by making a normal GET request without the <a data-link-type="dfn" href="#patch-request-header" id="ref-for-patch-request-header①">patch request header</a> to the font url. Additionally
-when URL’s are rewritten to point to the saved full font any of the incremental tech specifiers should
+when URLs are rewritten to point to the saved full font any of the incremental tech specifiers should
 be removed.</p>
    <h2 class="heading settled" data-level="4" id="patch-incxfer"><span class="secno">4. </span><span class="content">Patch Based Incremental Transfer</span><a class="self-link" href="#patch-incxfer"></a></h2>
    <h3 class="heading settled" data-level="4.1" id="font-subset-info"><span class="secno">4.1. </span><span class="content">Font Subset</span><a class="self-link" href="#font-subset-info"></a></h3>
@@ -967,7 +967,7 @@ render a subset of:</p>
     <li data-md>
      <p>the codepoints,</p>
     <li data-md>
-     <p><a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
+     <p><a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout
 features</a>,</p>
     <li data-md>
      <p>and <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a>.</p>
@@ -1241,7 +1241,7 @@ delta_list = [23, 20, -31, -9, 64, 1, 1, -69]
 using the same number of bits. The entire range of values is supported.
 This step is required, as the <a href="#integerlist-uintbase128">§ 4.2.4.3 UIntBase128 Encoding</a> step works on
 unsigned integers only. The encoding maps positive integer values to even positive integers and
-negative integer values to odd positive integers. Psuedo code:</p>
+negative integer values to odd positive integers. Pseudo code:</p>
 <pre>encode(n):
   if n >= 0:
     return n * 2
@@ -1389,7 +1389,7 @@ bytes = [03 07 03 81 7F]
 </pre>
    </div>
    <h4 class="heading settled" data-level="4.2.7" id="featuretagset-object"><span class="secno">4.2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="featuretagset">FeatureTagSet</dfn></span><a class="self-link" href="#featuretagset-object"></a></h4>
-   <p>A FeatureTagSet encodes a set of zero or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a>.
+   <p>A FeatureTagSet encodes a set of zero or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>.
 Each feature tag is mapped to an integer value and then the set of mapped integers are encoded in a <a data-link-type="dfn" href="#sortedintegerlist" id="ref-for-sortedintegerlist②">SortedIntegerList</a>. Feature tags are mapped to integers as follows:</p>
    <ul>
     <li data-md>
@@ -1405,7 +1405,7 @@ not encoded.</p>
      <p>Otherwise: the tag is converted to an integer by treating the tag’s 4 byte string as a 4 byte
 little endian integer.</p>
    </ul>
-   <p>The final encoding is produced by sorting the mapped integers (exlcuding tags which are skipped)
+   <p>The final encoding is produced by sorting the mapped integers (excluding tags which are skipped)
 into ascending order and then encoding the sorted list as a <a data-link-type="dfn" href="#sortedintegerlist" id="ref-for-sortedintegerlist③">SortedIntegerList</a>.</p>
    <p>When decoding a FeatureTagSet the integer values are mapped back to the original tags by reversing
 the above mapping rules. <span class="conform server client" id="conform-feature-tag-set-defaults">Additionally all
@@ -1596,7 +1596,7 @@ font url, or null.</p>
 minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
     <li data-md>
      <p><var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[fetch]</a>. The remainder
-of this section is desribed in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch</cite> § 4 Fetching</a>, but it is allowed to substitute
+of this section is described in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch</cite> § 4 Fetching</a>, but it is allowed to substitute
 whatever HTTP fetching algorithm the user agent supports.</p>
    </ul>
    <p>The algorithm outputs:</p>
@@ -1670,7 +1670,7 @@ encoded via CBOR.</p>
  The codepoint values are transformed to indices by applying the <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> specified by <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering④">codepoint_ordering</a> to each codepoint value. If
  the <var>client state</var> is not available or it does not have a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑤">codepoint_ordering</a> then this field should not be set.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"> opentype layout feature tags</a> that the current <var>font subset</var> has data
+       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"> OpenType layout feature tags</a> that the current <var>font subset</var> has data
  for. If the current <var>font subset</var> is not set then this
  field is left unset. Additionally, if the current <var>font subset</var> has all
  data for features present in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font">original font</a> then this field can be unset.</p>
@@ -1705,10 +1705,10 @@ encoded via CBOR.</p>
     <li data-md>
      <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-server-response" id="ref-for-abstract-opdef-handle-server-response">Handle server response</a> with the response from the server and the <var>font subset</var> then return the result.</p>
    </ol>
-   <p class="note" role="note"><span class="marker">Note:</span> POST is preferred for the HTTP method since it will not cause a CORS preflight request
+   <p class="note" role="note"><span class="marker">Note:</span> POST is preferred for the HTTP method since it will not cause a CORS pre-flight request
 and the request object is more compactly encoded. GET should only be used during <a href="#method-negotiation">method negotiation</a>.</p>
    <h4 class="heading settled algorithm" data-algorithm="Handling Server Response" data-level="4.4.2" id="handling-patch-response"><span class="secno">4.4.2. </span><span class="content">Handling Server Response</span><a class="self-link" href="#handling-patch-response"></a></h4>
-   <p>If a server is able to succsessfully process a <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest④">PatchRequest</a> it will respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> code 200 and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body">body</a> of the response will
+   <p>If a server is able to successfully process a <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest④">PatchRequest</a> it will respond with HTTP <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status">status</a> code 200 and the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body">body</a> of the response will
 be an encoded representation of the extended font subset. The encoded representation may be a binary
 patch against the current font subset.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-server-response">Handle server response</dfn></p>
@@ -1754,7 +1754,7 @@ encoded via CBOR.</p>
      <p>Verify that the union of the codepoints present in the <var>extended font subset</var> and all codepoints
 listed in the <var>client state</var> field <a data-link-type="dfn" href="#clientstate-missing_codepoints" id="ref-for-clientstate-missing_codepoints②">missing_codepoints</a> is equal to the set of
 codepoints asked for (union of codepoints/indices needed and codepoints/indices have) in the request
-which generated this response. If they are not euqal, this is an invalid response. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load①">Handle failed font load</a> and return the result.</p>
+which generated this response. If they are not equal, this is an invalid response. Invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-failed-font-load" id="ref-for-abstract-opdef-handle-failed-font-load①">Handle failed font load</a> and return the result.</p>
     <li data-md>
      <p>Return the <var>extended font subset</var> and any cache headers that were set on the <var>server response</var>.</p>
    </ol>
@@ -1788,7 +1788,7 @@ the fragment identifier (<a href="https://www.rfc-editor.org/rfc/rfc8081#section
 minimum <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>.</p>
     <li data-md>
      <p><var>fetch algorithm</var>: algorithm for fetching HTTP resources, such as <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[fetch]</a>. The remainder
-of this section is desribed in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch</cite> § 4 Fetching</a>, but it is allowed to substitute
+of this section is described in terms of <a href="https://fetch.spec.whatwg.org/#fetching"><cite>Fetch</cite> § 4 Fetching</a>, but it is allowed to substitute
 whatever HTTP fetching algorithm the user agent supports.</p>
    </ul>
    <p>The algorithm outputs:</p>
@@ -1868,7 +1868,7 @@ that collection that a patch is desired for. The identified font is referred to 
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> the request may optionally set <a data-link-type="dfn" href="#patchrequest-codepoint_ordering" id="ref-for-patchrequest-codepoint_ordering①">codepoint_ordering</a> which is used by the client to
 provide the exact codepoint ordering that was used to encode <a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have⑥">indices_have</a> and <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed⑤">indices_needed</a>.</p>
-   <p>Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout feature tags</a>:</p>
+   <p>Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>:</p>
    <ol>
     <li data-md>
      <p>Feature tags the client’s subset has: specified by <a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have①">features_have</a>. If the field is
@@ -1918,7 +1918,7 @@ CBOR:</span></p>
        <p><span class="conform server" id="conform-response-client-state-original-axis-space"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①①">original font</a> has variation axes, the <a data-link-type="dfn" href="#clientstate-original_axis_space" id="ref-for-clientstate-original_axis_space">original_axis_space</a> field must be set to the axis space covered by
  the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①②">original font</a>.</span></p>
       <li data-md>
-       <p><span class="conform server" id="conform-response-client-state-original-features"> The <a data-link-type="dfn" href="#clientstate-original_features" id="ref-for-clientstate-original_features">original_features</a> field must be set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">opentype layout
+       <p><span class="conform server" id="conform-response-client-state-original-features"> The <a data-link-type="dfn" href="#clientstate-original_features" id="ref-for-clientstate-original_features">original_features</a> field must be set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout
 feature tags</a> that the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①③">original font</a> has data for.</span></p>
       <li data-md>
        <p><span class="conform server" id="conform-response-client-state-missing-codepoints"> The <a data-link-type="dfn" href="#clientstate-missing_codepoints" id="ref-for-clientstate-missing_codepoints③">missing_codepoints</a> field must be set to the list of codepoints
@@ -1953,7 +1953,7 @@ same client to the same server task.</p>
    </ul>
    <h4 class="heading settled" data-level="4.5.1" id="range-request-support"><span class="secno">4.5.1. </span><span class="content">Range Request Support</span><a class="self-link" href="#range-request-support"></a></h4>
    <p>A patch subset support server must also support incremental transfer via <a href="#range-request-incxfer">§ 5 Range Request Incremental Transfer</a>.
-To support range request incremental tranfser the patch subset server must support HTTP range requests
+To support range request incremental transfer the patch subset server must support HTTP range requests
 (<a href="https://www.rfc-editor.org/rfc/rfc9110#section-14"><cite>HTTP Semantics</cite> §  14. Range Requests</a>) against the font files it provides via patch subset.</p>
    <h3 class="heading settled" data-level="4.6" id="computing-checksums"><span class="secno">4.6. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h3>
    <p>64 bit checksums of byte strings are computed using the <a data-link-type="biblio" href="#biblio-fast-hash" title="fast-hash">[fast-hash]</a> algorithm. A python like pseudo
@@ -2079,7 +2079,7 @@ file as a patch against a source file:</p>
    <p>In the patch subset method 64 bit checksums are generated and transferred between client and server. These are used to
 ensure the client and server are in sync. They detect cases such as where the original font being patched has changed or
 the server is not able to reproduce the clients font subset. The checksums will be stored in a browsers HTTP cache as
-part of the font subset and thus are subject to the cache paritioning applied by the browser. Since modern browsers
+part of the font subset and thus are subject to the cache partitioning applied by the browser. Since modern browsers
 cache resources keyed by the site domain, this will limit checksum availability to within the site domain and prevent
 them from being used for tracking.</p>
    <h3 class="heading settled" id="per-origin"><span class="content">Per-origin restriction avoids fingerprinting</span><a class="self-link" href="#per-origin"></a></h3>
@@ -2109,7 +2109,7 @@ them from being used for tracking.</p>
     <li>Added an id for offline usage header
     <li>Updated the responding to patch request section for client state changes
     <li>Updated loading with a cache section for client state changes
-    <li>Added client side handling of new urecognized_ordering field
+    <li>Added client side handling of new unrecognized_ordering field
     <li>Updated handling failed font load section for client state
     <li>Updated the 'Extending font subset' section for client state changes
     <li>Added ClientState object schema

--- a/RangeRequest.html
+++ b/RangeRequest.html
@@ -4,14 +4,14 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Range Request Incremental Font Transfer</title>
   <meta content="WD" name="w3c-status">
-  <meta content="Bikeshed version d9bd89757, updated Thu Mar 23 10:06:53 2023 -0700" name="generator">
+  <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/RangeRequest/" rel="canonical">
-  <meta content="0fa655056ac70763900d5de2e6431fb34d44341c" name="document-revision">
+  <meta content="bac9661bf7980ed085b84b6af157e3f6c9acf27b" name="document-revision">
 <style>
     .conform:hover {background: #31668f; color: white}
     .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
     </style>
-<style>/* style-autolinks */
+<style>/* Boilerplate: style-autolinks */
 .css.css, .property.property, .descriptor.descriptor {
     color: var(--a-normal-text);
     font-size: inherit;
@@ -72,8 +72,238 @@ pre .property::before, pre .property::after {
 [data-link-type=biblio] {
     white-space: pre;
 }
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --selflink-text: black;
+        --selflink-bg: silver;
+        --selflink-hover-text: white;
+    }
+}
 </style>
-<style>/* style-counters */
+<style>/* Boilerplate: style-colors */
+
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #bbb;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #707070;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #ddd;
+        --bg: black;
+
+        --unofficial-watermark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E");
+
+        --logo-bg: #1a5e9a;
+        --logo-active-bg: #c00;
+        --logo-text: white;
+
+        --tocnav-normal-text: #999;
+        --tocnav-normal-bg: var(--bg);
+        --tocnav-hover-text: var(--tocnav-normal-text);
+        --tocnav-hover-bg: #080808;
+        --tocnav-active-text: #f44;
+        --tocnav-active-bg: var(--tocnav-normal-bg);
+
+        --tocsidebar-text: var(--text);
+        --tocsidebar-bg: #080808;
+        --tocsidebar-shadow: rgba(255,255,255,.1);
+        --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+        --toclink-text: var(--text);
+        --toclink-underline: #6af;
+        --toclink-visited-text: var(--toclink-text);
+        --toclink-visited-underline: #054572;
+
+        --heading-text: #8af;
+
+        --hr-text: var(--text);
+
+        --algo-border: #456;
+
+        --del-text: #f44;
+        --del-bg: transparent;
+        --ins-text: #4a4;
+        --ins-bg: transparent;
+
+        --a-normal-text: #6af;
+        --a-normal-underline: #555;
+        --a-visited-text: var(--a-normal-text);
+        --a-visited-underline: var(--a-normal-underline);
+        --a-hover-bg: rgba(25%, 25%, 25%, .2);
+        --a-active-text: #f44;
+        --a-active-underline: var(--a-active-text);
+
+        --borderedblock-bg: rgba(255, 255, 255, .05);
+
+        --blockquote-border: silver;
+        --blockquote-bg: var(--borderedblock-bg);
+        --blockquote-text: currentcolor;
+
+        --issue-border: #e05252;
+        --issue-bg: var(--borderedblock-bg);
+        --issue-text: var(--text);
+        --issueheading-text: hsl(0deg, 70%, 70%);
+
+        --example-border: hsl(50deg, 90%, 60%);
+        --example-bg: var(--borderedblock-bg);
+        --example-text: var(--text);
+        --exampleheading-text: hsl(50deg, 70%, 70%);
+
+        --note-border: hsl(120deg, 100%, 35%);
+        --note-bg: var(--borderedblock-bg);
+        --note-text: var(--text);
+        --noteheading-text: hsl(120, 70%, 70%);
+        --notesummary-underline: silver;
+
+        --assertion-border: #444;
+        --assertion-bg: var(--borderedblock-bg);
+        --assertion-text: var(--text);
+
+        --advisement-border: orange;
+        --advisement-bg: #222218;
+        --advisement-text: var(--text);
+        --advisementheading-text: #f84;
+
+        --warning-border: red;
+        --warning-bg: hsla(40,100%,20%,0.95);
+        --warning-text: var(--text);
+
+        --amendment-border: #330099;
+        --amendment-bg: #080010;
+        --amendment-text: var(--text);
+        --amendmentheading-text: #cc00ff;
+
+        --def-border: #8ccbf2;
+        --def-bg: #080818;
+        --def-text: var(--text);
+        --defrow-border: #136;
+
+        --datacell-border: silver;
+
+        --indexinfo-text: #aaa;
+
+        --indextable-hover-text: var(--text);
+        --indextable-hover-bg: #181818;
+
+        --outdatedspec-bg: rgba(255, 255, 255, .5);
+        --outdatedspec-text: black;
+        --outdated-bg: maroon;
+        --outdated-text: white;
+        --outdated-shadow: red;
+
+        --editedrec-bg: darkorange;
+    }
+    /* In case a transparent-bg image doesn't expect to be on a dark bg,
+       which is quite common in practice... */
+    img { background: white; }
+}
+</style>
+<style>/* Boilerplate: style-counters */
 body {
     counter-reset: example figure issue;
 }
@@ -102,17 +332,22 @@ figcaption:not(.no-marker)::before {
     content: "Figure " counter(figure) " ";
 }
 </style>
-<style>/* style-dfn-panel */
+<style>/* Boilerplate: style-dfn-panel */
 :root {
     --dfnpanel-bg: #ddd;
     --dfnpanel-text: var(--text);
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --dfnpanel-bg: #222;
+        --dfnpanel-text: var(--text);
+    }
 }
 .dfn-panel {
     position: absolute;
     z-index: 35;
     width: 20em;
-    min-width: min-content;
-    max-width: 300px;
+    width: 300px;
     height: auto;
     max-height: 500px;
     overflow: auto;
@@ -129,8 +364,15 @@ figcaption:not(.no-marker)::before {
 .dfn-panel a { color: var(--dfnpanel-text); }
 .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
 .dfn-panel > b + b { margin-top: 0.25em; }
-.dfn-panel ul { padding: 0; }
-.dfn-panel li { list-style: inside; }
+.dfn-panel ul { padding: 0 0 0 1em; list-style: none; }
+.dfn-panel li a {
+    white-space: pre;
+    display: inline-block;
+    max-width: calc(300px - 1.5em - 1em);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .dfn-panel.activated {
     display: inline-block;
     position: fixed;
@@ -141,9 +383,9 @@ figcaption:not(.no-marker)::before {
     max-height: 30vh;
 }
 
-.dfn-paneled { cursor: pointer; }
+.dfn-paneled[role="button"] { cursor: pointer; }
 </style>
-<style>/* style-issues */
+<style>/* Boilerplate: style-issues */
 a[href].issue-return {
     float: right;
     float: inline-end;
@@ -152,7 +394,7 @@ a[href].issue-return {
     text-decoration: none;
 }
 </style>
-<style>/* style-md-lists */
+<style>/* Boilerplate: style-md-lists */
 /* This is a weird hack for me not yet following the commonmark spec
    regarding paragraph and lists. */
 [data-md] > :first-child {
@@ -162,7 +404,7 @@ a[href].issue-return {
     margin-bottom: 0;
 }
 </style>
-<style>/* style-selflinks */
+<style>/* Boilerplate: style-selflinks */
 
 :root {
     --selflink-text: white;
@@ -252,7 +494,7 @@ dfn > a.self-link::before      { content: "#"; }
     </div>
    </details>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software" rel="license" title="W3C Software and Document License">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -276,7 +518,11 @@ dfn > a.self-link::before      { content: "#"; }
    <p> Publication as a Working Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. This is a draft document and may be updated, replaced or
   obsoleted by other documents at any time. It is inappropriate to cite this
   document as other than work in progress. </p>
-  <p>This document was produced by a group operating under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>. W3C maintains a <a rel="disclosure" href="https://www.w3.org/groups/wg/webfonts/ipr">public list of any patent disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.</p>
+   <p> This document was produced by groups operating under
+  the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
+  W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
+  that page also includes instructions for disclosing a patent.
+  An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
    <p> This document is governed by the <a href="https://www.w3.org/2021/Process-20211102/" id="w3c_process_revision">2 November 2021 W3C Process Document</a>. </p>
    <p></p>
   </div>
@@ -482,7 +728,7 @@ itself be statically compressed.</p>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-ift">[IFT]
-   <dd>Chris Lilley; Myles Maxfield; Garret Rieger. <a href="https://www.w3.org/TR/IFT/"><cite>Incremental Font Transfer</cite></a>. 28 June 2022. WD. URL: <a href="https://www.w3.org/TR/IFT/">https://www.w3.org/TR/IFT/</a>
+   <dd>Chris Lilley; Garret Rieger; Myles Maxfield. <a href="https://www.w3.org/TR/IFT/"><cite>Incremental Font Transfer</cite></a>. 30 May 2023. WD. URL: <a href="https://www.w3.org/TR/IFT/">https://www.w3.org/TR/IFT/</a>
    <dt id="biblio-opentype">[OPENTYPE]
    <dd><a href="http://www.microsoft.com/typography/otspec/default.htm"><cite>OpenType specification</cite></a>. URL: <a href="http://www.microsoft.com/typography/otspec/default.htm">http://www.microsoft.com/typography/otspec/default.htm</a>
    <dt id="biblio-rfc2119">[RFC2119]
@@ -508,56 +754,68 @@ itself be statically compressed.</p>
    <div class="issue"> <a href="https://github.com/w3c/IFT/issues/58">Supporting fonts with composite glyphs via range-request</a> <a class="issue-return" href="#issue-5533a524" title="Jump to section">↵</a></div>
    <div class="issue"> <a href="https://github.com/w3c/IFT/issues/61">Populate suggested character ordering for range-request method</a> <a class="issue-return" href="#issue-763d5c98" title="Jump to section">↵</a></div>
   </div>
-  <aside aria-labelledby="infopaneltitle-for-range-request-optimized-font" class="dfn-panel" data-for="range-request-optimized-font" id="infopanel-for-range-request-optimized-font">
-   <span id="infopaneltitle-for-range-request-optimized-font" style="display:none">Info about the 'range-request optimized font' definition.</span><b><a href="#range-request-optimized-font">#range-request-optimized-font</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-range-request-optimized-font">1.2.2. Introduction</a> <a href="#ref-for-range-request-optimized-font①">(2)</a>
-    <li><a href="#ref-for-range-request-optimized-font②">1.2.3. Compression</a> <a href="#ref-for-range-request-optimized-font③">(2)</a> <a href="#ref-for-range-request-optimized-font④">(3)</a>
-    <li><a href="#ref-for-range-request-optimized-font⑤">1.2.4. Table Ordering</a> <a href="#ref-for-range-request-optimized-font⑥">(2)</a> <a href="#ref-for-range-request-optimized-font⑦">(3)</a>
-    <li><a href="#ref-for-range-request-optimized-font⑧">1.2.5. Glyph Independence</a> <a href="#ref-for-range-request-optimized-font⑨">(2)</a>
-    <li><a href="#ref-for-range-request-optimized-font①⓪">1.2.6. Glyph Order</a> <a href="#ref-for-range-request-optimized-font①①">(2)</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-outline-table" class="dfn-panel" data-for="outline-table" id="infopanel-for-outline-table">
-   <span id="infopaneltitle-for-outline-table" style="display:none">Info about the 'outline table' definition.</span><b><a href="#outline-table">#outline-table</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-outline-table">1.2.4. Table Ordering</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-corpus" class="dfn-panel" data-for="corpus" id="infopanel-for-corpus">
-   <span id="infopaneltitle-for-corpus" style="display:none">Info about the 'corpus' definition.</span><b><a href="#corpus">#corpus</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-corpus">1.2.6. Glyph Order</a> <a href="#ref-for-corpus①">(2)</a> <a href="#ref-for-corpus②">(3)</a> <a href="#ref-for-corpus③">(4)</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-usage-document-frequency" class="dfn-panel" data-for="usage-document-frequency" id="infopanel-for-usage-document-frequency">
-   <span id="infopaneltitle-for-usage-document-frequency" style="display:none">Info about the 'usage document frequency' definition.</span><b><a href="#usage-document-frequency">#usage-document-frequency</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-usage-document-frequency">1.2.6. Glyph Order</a> <a href="#ref-for-usage-document-frequency①">(2)</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-range-request-threshold" class="dfn-panel" data-for="range-request-threshold" id="infopanel-for-range-request-threshold">
-   <span id="infopaneltitle-for-range-request-threshold" style="display:none">Info about the 'range-request threshold' definition.</span><b><a href="#range-request-threshold">#range-request-threshold</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-range-request-threshold">1.3.1. First Request</a> <a href="#ref-for-range-request-threshold①">(2)</a> <a href="#ref-for-range-request-threshold②">(3)</a> <a href="#ref-for-range-request-threshold③">(4)</a>
-    <li><a href="#ref-for-range-request-threshold④">1.3.2. Subsequent Requests</a> <a href="#ref-for-range-request-threshold⑤">(2)</a>
-   </ul>
-  </aside>
-<script>/* script-dfn-panel */
+<script>/* Boilerplate: script-dfn-panel */
 "use strict";
 {
-    function queryAll(sel) {
-        return [].slice.call(document.querySelectorAll(sel));
+    const dfnsJson = window.dfnsJson || {};
+
+    function genDfnPanel({dfnID, url, dfnText, refSections, external}) {
+        return mk.aside({
+            class: "dfn-panel",
+            id: `infopanel-for-${dfnID}`,
+            "data-for": dfnID,
+            "aria-labelled-by":`infopaneltitle-for-${dfnID}`,
+            },
+            mk.span({id:`infopaneltitle-for-${dfnID}`, style:"display:none"},
+                `Info about the '${dfnText}' ${external?"external":""} reference.`),
+            mk.a({href:url}, url),
+            mk.b({}, "Referenced in:"),
+            mk.ul({},
+                ...refSections.map(section=>
+                    mk.li({},
+                        ...section.refs.map((ref, refI)=>
+                            [
+                                mk.a({
+                                    href: `#${ref.id}`
+                                    },
+                                    (refI == 0) ? section.title : `(${refI + 1})`
+                                ),
+                                " ",
+                            ]
+                        ),
+                    ),
+                ),
+            ),
+        );
     }
 
-    // Add popup behavior to all dfns to show the corresponding dfn-panel.
-    var dfns = document.querySelectorAll('.dfn-paneled');
-    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+    function genAllDfnPanels() {
+        for(const panelData of Object.values(window.dfnpanelData)) {
+            const dfnID = panelData.dfnID;
+            const dfn = document.getElementById(dfnID);
+            if(!dfn) {
+                console.log(`Can't find dfn#${dfnID}.`, panelData);
+            } else {
+                const panel = genDfnPanel(panelData);
+                append(document.body, panel);
+                insertDfnPopupAction(dfn, panel)
+            }
+        }
+    }
 
-    document.body.addEventListener("click", (e) => {
-        // If not handled already, just hide all dfn panels.
-        hideAllDfnPanels();
-    });
+    document.addEventListener("DOMContentLoaded", ()=>{
+        genAllDfnPanels();
+
+        // Add popup behavior to all dfns to show the corresponding dfn-panel.
+        var dfns = queryAll('.dfn-paneled');
+        for(let dfn of dfns) { ; }
+
+        document.body.addEventListener("click", (e) => {
+            // If not handled already, just hide all dfn panels.
+            hideAllDfnPanels();
+        });
+    })
+
 
     function hideAllDfnPanels() {
         // Turn off any currently "on" or "activated" panels.
@@ -607,49 +865,249 @@ itself be statically compressed.</p>
         }
     }
 
-    function insertDfnPopupAction(dfn) {
+    function insertDfnPopupAction(dfn, dfnPanel) {
         // Find dfn panel
-        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
-        if (dfnPanel) {
-            const panelWrapper = document.createElement('span');
-            panelWrapper.appendChild(dfnPanel);
-            panelWrapper.style.position = "relative";
-            panelWrapper.style.height = "0px";
-            dfn.insertAdjacentElement("afterend", panelWrapper);
-            dfn.setAttribute('role', 'button');
-            dfn.setAttribute('aria-expanded', 'false')
-            dfn.tabIndex = 0;
-            dfn.classList.add('has-dfn-panel');
-            dfn.addEventListener('click', (event) => {
-                showDfnPanel(dfnPanel, dfn);
+        const panelWrapper = document.createElement('span');
+        panelWrapper.appendChild(dfnPanel);
+        panelWrapper.style.position = "relative";
+        panelWrapper.style.height = "0px";
+        dfn.insertAdjacentElement("afterend", panelWrapper);
+        dfn.setAttribute('role', 'button');
+        dfn.setAttribute('aria-expanded', 'false')
+        dfn.tabIndex = 0;
+        dfn.classList.add('has-dfn-panel');
+        dfn.addEventListener('click', (event) => {
+            showDfnPanel(dfnPanel, dfn);
+            event.stopPropagation();
+        });
+        dfn.addEventListener('keypress', (event) => {
+            const kc = event.keyCode;
+            // 32->Space, 13->Enter
+            if(kc == 32 || kc == 13) {
+                toggleDfnPanel(dfnPanel, dfn);
                 event.stopPropagation();
-            });
-            dfn.addEventListener('keypress', (event) => {
-                const kc = event.keyCode;
-                // 32->Space, 13->Enter
-                if(kc == 32 || kc == 13) {
-                    toggleDfnPanel(dfnPanel, dfn);
-                    event.stopPropagation();
-                    event.preventDefault();
-                }
-            });
+                event.preventDefault();
+            }
+        });
 
-            dfnPanel.addEventListener('click', (event) => {
+        dfnPanel.addEventListener('click', (event) => {
+            if (event.target.nodeName == 'A') {
                 pinDfnPanel(dfnPanel);
+            }
+            event.stopPropagation();
+        });
+
+        dfnPanel.addEventListener('keydown', (event) => {
+            if(event.keyCode == 27) { // Escape key
+                hideDfnPanel(dfnPanel, dfn);
                 event.stopPropagation();
-            });
-
-            dfnPanel.addEventListener('keydown', (event) => {
-                if(event.keyCode == 27) { // Escape key
-                    hideDfnPanel(dfnPanel, dfn);
-                    event.stopPropagation();
-                    event.preventDefault();
-                }
-            })
-
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
-        }
+                event.preventDefault();
+            }
+        })
     }
+}
+</script>
+<script>/* Boilerplate: script-dfn-panel-json */
+window.dfnpanelData = {};
+window.dfnpanelData['range-request-optimized-font'] = {"dfnID": "range-request-optimized-font", "url": "#range-request-optimized-font", "dfnText": "range-request optimized font", "refSections": [{"refs": [{"id": "ref-for-range-request-optimized-font"}, {"id": "ref-for-range-request-optimized-font\u2460"}], "title": "1.2.2. Introduction"}, {"refs": [{"id": "ref-for-range-request-optimized-font\u2461"}, {"id": "ref-for-range-request-optimized-font\u2462"}, {"id": "ref-for-range-request-optimized-font\u2463"}], "title": "1.2.3. Compression"}, {"refs": [{"id": "ref-for-range-request-optimized-font\u2464"}, {"id": "ref-for-range-request-optimized-font\u2465"}, {"id": "ref-for-range-request-optimized-font\u2466"}], "title": "1.2.4. Table Ordering"}, {"refs": [{"id": "ref-for-range-request-optimized-font\u2467"}, {"id": "ref-for-range-request-optimized-font\u2468"}], "title": "1.2.5. Glyph Independence"}, {"refs": [{"id": "ref-for-range-request-optimized-font\u2460\u24ea"}, {"id": "ref-for-range-request-optimized-font\u2460\u2460"}], "title": "1.2.6. Glyph Order"}], "external": false};
+window.dfnpanelData['outline-table'] = {"dfnID": "outline-table", "url": "#outline-table", "dfnText": "outline table", "refSections": [{"refs": [{"id": "ref-for-outline-table"}], "title": "1.2.4. Table Ordering"}], "external": false};
+window.dfnpanelData['corpus'] = {"dfnID": "corpus", "url": "#corpus", "dfnText": "corpus", "refSections": [{"refs": [{"id": "ref-for-corpus"}, {"id": "ref-for-corpus\u2460"}, {"id": "ref-for-corpus\u2461"}, {"id": "ref-for-corpus\u2462"}], "title": "1.2.6. Glyph Order"}], "external": false};
+window.dfnpanelData['usage-document-frequency'] = {"dfnID": "usage-document-frequency", "url": "#usage-document-frequency", "dfnText": "usage document frequency", "refSections": [{"refs": [{"id": "ref-for-usage-document-frequency"}, {"id": "ref-for-usage-document-frequency\u2460"}], "title": "1.2.6. Glyph Order"}], "external": false};
+window.dfnpanelData['range-request-threshold'] = {"dfnID": "range-request-threshold", "url": "#range-request-threshold", "dfnText": "range-request threshold", "refSections": [{"refs": [{"id": "ref-for-range-request-threshold"}, {"id": "ref-for-range-request-threshold\u2460"}, {"id": "ref-for-range-request-threshold\u2461"}, {"id": "ref-for-range-request-threshold\u2462"}], "title": "1.3.1. First Request"}, {"refs": [{"id": "ref-for-range-request-threshold\u2463"}, {"id": "ref-for-range-request-threshold\u2464"}], "title": "1.3.2. Subsequent Requests"}], "external": false};
+</script>
+<script>/* Boilerplate: script-dom-helper */
+function query(sel) { return document.querySelector(sel); }
+
+function queryAll(sel) { return [...document.querySelectorAll(sel)]; }
+
+function iter(obj) {
+	if(!obj) return [];
+	var it = obj[Symbol.iterator];
+	if(it) return it;
+	return Object.entries(obj);
+}
+
+function mk(tagname, attrs, ...children) {
+	const el = document.createElement(tagname);
+	for(const [k,v] of iter(attrs)) {
+		if(k.slice(0,3) == "_on") {
+			const eventName = k.slice(3);
+			el.addEventListener(eventName, v);
+		} else if(k[0] == "_") {
+			// property, not attribute
+			el[k.slice(1)] = v;
+		} else {
+			if(v === false || v == null) {
+        continue;
+      } else if(v === true) {
+        el.setAttribute(k, "");
+        continue;
+      } else {
+  			el.setAttribute(k, v);
+      }
+		}
+	}
+	append(el, children);
+	return el;
+}
+
+/* Create shortcuts for every known HTML element */
+[
+  "a",
+  "abbr",
+  "acronym",
+  "address",
+  "applet",
+  "area",
+  "article",
+  "aside",
+  "audio",
+  "b",
+  "base",
+  "basefont",
+  "bdo",
+  "big",
+  "blockquote",
+  "body",
+  "br",
+  "button",
+  "canvas",
+  "caption",
+  "center",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "datalist",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "embed",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "font",
+  "footer",
+  "form",
+  "frame",
+  "frameset",
+  "head",
+  "header",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "html",
+  "i",
+  "iframe",
+  "img",
+  "input",
+  "ins",
+  "kbd",
+  "label",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "map",
+  "mark",
+  "meta",
+  "meter",
+  "nav",
+  "nobr",
+  "noscript",
+  "object",
+  "ol",
+  "optgroup",
+  "option",
+  "output",
+  "p",
+  "param",
+  "pre",
+  "progress",
+  "q",
+  "s",
+  "samp",
+  "script",
+  "section",
+  "select",
+  "small",
+  "source",
+  "span",
+  "strike",
+  "strong",
+  "style",
+  "sub",
+  "summary",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "title",
+  "tr",
+  "u",
+  "ul",
+  "var",
+  "video",
+  "wbr",
+  "xmp",
+].forEach(tagname=>{
+	mk[tagname] = (...args) => mk(tagname, ...args);
+});
+
+function* nodesFromChildList(children) {
+	for(const child of children.flat(Infinity)) {
+		if(child instanceof Node) {
+			yield child;
+		} else {
+			yield new Text(child);
+		}
+	}
+}
+function append(el, ...children) {
+	for(const child of nodesFromChildList(children)) {
+		if(el instanceof Node) el.appendChild(child);
+		else el.push(child);
+	}
+	return el;
+}
+
+function insertAfter(el, ...children) {
+	for(const child of nodesFromChildList(children)) {
+		el.parentNode.insertBefore(child, el.nextSibling);
+	}
+	return el;
+}
+
+function clearContents(el) {
+	el.innerHTML = "";
+	return el;
+}
+
+function parseHTML(markup) {
+	if(markup.toLowerCase().trim().indexOf('<!doctype') === 0) {
+		const doc = document.implementation.createHTMLDocument("");
+		doc.documentElement.innerHTML = markup;
+		return doc;
+	} else {
+		const el = mk.template({});
+		el.innerHTML = markup;
+		return el.content;
+	}
 }
 </script>

--- a/RangeRequest.html
+++ b/RangeRequest.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/RangeRequest/" rel="canonical">
-  <meta content="bac9661bf7980ed085b84b6af157e3f6c9acf27b" name="document-revision">
+  <meta content="eecbfe997ace12ab48ff4edc30899079cc9d45fc" name="document-revision">
 <style>
     .conform:hover {background: #31668f; color: white}
     .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }


### PR DESCRIPTION
This is used to prevent a malicious font server from continuously varying the codepoints which are present in the font subset in order to gain information about which codepoints are present in content.

Also fix a bunch of typos/spelling.

Part of the fix for #42 and #50


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/146.html" title="Last updated on Jun 19, 2023, 7:05 PM UTC (c2e9b83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/146/d0d75bf...c2e9b83.html" title="Last updated on Jun 19, 2023, 7:05 PM UTC (c2e9b83)">Diff</a>