### PR TITLE
Revamp the FeatureTagSet encoding scheme.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -229,7 +229,7 @@ Opt-In Mechanism {#opt-in}
 
 <em>This section is general to both IFT methods.</em>
 
-Web page's can choose to opt-in to either patch subset or range request incremental transfer for a font
+Web pages can choose to opt-in to either patch subset or range request incremental transfer for a font
 via the use of a CSS font tech keyword ([[css-fonts-4#font-tech-definitions]]) inside the
 ''@font-face'' block.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1865,9 +1865,24 @@ was assembled from several sources:
     default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz
     subsetter</a>.
 
-The entries in this table are versioned (by the Encoding Version column) since the client and server need to agree on
-the encoding. Currently there is only one version, 1, which is used by default. Future specification updates may
-introduce additional versions and a mechanism for the server to inform the client up to which version it supports.
+The columns should be interpreted as follows:
+
+*  Tag: the 4 byte tag for this feature from [[open-type/featurelist]].
+
+*  Encoded As: the integer ID used to represent this feature in a [=FeatureTagSet=].
+
+*  Encode If: entries marked as "not needed" are assumed to be in a [=FeatureTagSet=] by default. Including their
+    encoding ID in a [=FeatureTagSet=] removes the feature from the set. Entries marked as "needed" are not included
+    by default.
+    
+*  Encoding Version: the entries in this table are versioned (by the Encoding Version column) since the client and
+    server need to agree on the encoding. Currently there is only one version, 1, which is used by default. Future
+    specification updates may introduce additional versions and a mechanism for the server to inform the client up to
+    which version it supports.
+
+Note: the set of features selected to be included by default is purely an optimization mechanism and should not be
+used by clients as a guide for which features they should be asking for in requests. To minimize the number of bytes
+loaded clients should only request features that are needed for the rendering of the content used by the font.
 
 <pre class=include>
 <!-- Edit feature-registry.csv to update this table. -->

--- a/Overview.bs
+++ b/Overview.bs
@@ -864,27 +864,31 @@ bytes = [03 07 03 81 7F]
 ### <dfn>FeatureTagSet</dfn> ### {#featuretagset-object}
 
 A FeatureTagSet encodes a set of zero or more
-<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>.
-Each feature tag is mapped to an integer value and then the set of mapped integers are encoded in a
-[=SortedIntegerList=]. Feature tags are mapped to integers as follows:
+<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>. To encode
+a set of feature tags:
 
-*  If the tag is found in [[#feature-tag-list]]:
+1. Union the set of feature tags to be encoded and the list of feature tags in [[#feature-tag-list]]. For each tag in the
+    union:
 
-    *  If the "Encoded As" column corresponding to the tag is "default" then the tag is skipped and
-        not encoded.
+    *  If the tag is present in the list of feature tags to be encoded, is present in [[#feature-tag-list]], and
+        has a value of "needed" in the "Encode If" column of [[#feature-tag-list]]; then add the value of "Encoded As"
+        to the encoded ID list.
 
-    *  Else, the tag is mapped to the integer value in the "Encoded As" column.
+    *  If the tag is not present in the list of feature tags to be encoded, is present in [[#feature-tag-list]], and
+        has a value of "not needed" in the "Encode If" column of [[#feature-tag-list]]; then add the value of "Encoded As"
+        to the encoded ID list.
 
-*  Otherwise: the tag is converted to an integer by treating the tag's 4 byte string as a 4 byte
-    little endian integer.
+    *  If the tag is present in the list of feature tags to be encoded and is not present in [[#feature-tag-list]], then
+        convert the tag to  an integer by treating the tag's 4 byte string as a 4 byte little endian integer and add that
+        value to the encoded ID list.
 
-The final encoding is produced by sorting the mapped integers (excluding tags which are skipped)
-into ascending order and then encoding the sorted list as a [=SortedIntegerList=].
+    *  Otherwise, do nothing for this tag.
+
+2. The final encoding is produced by sorting the encoded ID list produced in step 1 into ascending order and then encoding
+    the sorted list as a [=SortedIntegerList=].
 
 When decoding a FeatureTagSet the integer values are mapped back to the original tags by reversing
-the above mapping rules.
-<span class="conform server client" id="conform-feature-tag-set-defaults">Additionally all
-default features in [[#feature-tag-list]] must be added to the decoded set.</span>
+the above encoding rules.
 
 ### <dfn>AxisSpace</dfn> ### {#AxisSpace}
 
@@ -1848,6 +1852,17 @@ Since the <a href="https://www.w3.org/TR/2022/WD-IFT-20220628/">Working
 <h2 id="feature-tag-list">
 Appendix A: Default Feature Tags and Encoding IDs</h2>
 
+This appendix is normative. It lists the IDs used to encode feature tags into a [=FeatureTagSet=]. This table
+was assembled from several sources:
+
+* Includes all features listed in the
+    <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist">OpenType layout feature registry</a>.
+
+* The value of "Encode If" is set to "not needed" for all features which are listed as "default on" in
+    <a href="https://tiro.com/John/Enabling_Typography_(OTL).pdf">Enabling Typography</a> or are in the
+    default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz
+    subsetter</a>.
+
 <pre class=include>
 <!-- Edit feature-registry.csv to update this table. -->
 path: feature-registry.html
@@ -1856,6 +1871,6 @@ path: feature-registry.html
 <h2 id="obfuscation-codepoints">
 Appendix B: Codepoints Requiring Obfuscation</h2>
 
-The following codepoints are considered to need obfuscation:
+This appendix is normative.The following codepoints are considered to need obfuscation:
 
 * All unicode codepoints with the [[UAX44#Unified_Ideograph|Unified_Ideograph]] property.

--- a/Overview.bs
+++ b/Overview.bs
@@ -1884,6 +1884,9 @@ Note: the set of features selected to be included by default is purely an optimi
 used by clients as a guide for which features they should be asking for in requests. To minimize the number of bytes
 loaded clients should only request features that are needed for the rendering of the content used by the font.
 
+Note: If the client does not wish to customize the loaded features, then the set of default included features provides a good starting
+point as it is the set of features which are typically used by renderers by default.
+
 <pre class=include>
 <!-- Edit feature-registry.csv to update this table. -->
 path: feature-registry.html

--- a/Overview.bs
+++ b/Overview.bs
@@ -53,14 +53,13 @@ spec:fetch; type:dfn; for:/; text:response
     "date": "27 Jul 2021"
   },
 
-
-  "OpenType-Variations": {
-    "href": "https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview",
+  "open-type": {
+    "href": "https://docs.microsoft.com/en-us/typography/opentype/spec",
     "authors": [],
     "status": "Note",
     "publisher": "Microsoft",
-    "title": "OpenType Font Variations Overview",
-    "date": "23 October 2020"
+    "title": "OpenType Specification",
+    "date": "December 2021"
   },
 
   "fast-hash": {
@@ -79,6 +78,15 @@ spec:fetch; type:dfn; for:/; text:response
     "publisher": "What WG",
     "title": "Fetch Standard",
     "date": "22 May 2023"
+  },
+
+  "enabling-typography": {
+    "href": "https://tiro.com/John/Enabling_Typography_(OTL).pdf",
+    "authors": ["John Hudson"],
+    "status": "Note",
+    "publisher": "John Hudson",
+    "title": "Enabling Typography: towards a general model of OpenType Layout",
+    "date": "April 15th, 2014"
   }
 }
 </pre>
@@ -104,7 +112,7 @@ There are two different methods which can be used to incrementally transfer font
 Patch Subset {#patch-subset}
 ----------------------------
 
-In the the first method, <a href="#patch-subset">Patch Subset</a> a server generates binary patches which a
+In the the first method, [[#patch-incxfer|Patch Subset]], a server generates binary patches which a
 client applies to a subset of the font in order to extend the coverage of that subset. The server
 is stateless, it does not maintain any session data for clients between requests. Thus when a client
 requests the generation of a patch from the server it has to fully describe the current subset of the
@@ -119,7 +127,7 @@ Range Request {#range-request}
 ------------------------------
 
 The second
-method, <a href="#range-request-incxfer">Range Request</a>, has no server-side requirements other than the server should be able to respond to byte-based range requests. The browser makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file to obtain all required font tables, and then calculates glyph coverage and required byte ranges using font character-to-glyph mapping and glyph substitution / layout tables.
+method, [[#range-request-incxfer|Range Request]], has no server-side requirements other than the server should be able to respond to byte-based range requests. The browser makes range requests to the server for the specific bytes in the font file that it needs. In order to know which bytes are necessary, the browser makes one initial special request for the beginning of the file to obtain all required font tables, and then calculates glyph coverage and required byte ranges using font character-to-glyph mapping and glyph substitution / layout tables.
 
 In order for the range request method to be as effective as possible, the font file itself should be internally arranged in a particular way, in order to decrease the number of requests the browser needs to make. Therefore, it is expected that web developers wishing to use the range request method will use font files that have had their contents already arranged optimally.
 
@@ -238,7 +246,7 @@ There are three tech keywords available:
 *  <code>incremental-patch</code>: Load the font incrementally using the patch subset method.
 *  <code>incremental-range</code>: Load the font incrementally using the range request method.
 *  <code>incremental-auto</code>:  Load the font incrementally. The particular method to use is
-    determined by <a href="#method-negotiation">Method Negotiation</a>.
+    determined by [[#method-negotiation|Method Negotiation]].
 
 <div class=example>
 The use of the <code>incremental-patch</code> keyword in this CSS rule indicates to the browser they
@@ -279,13 +287,13 @@ The client should have support for both patch subset and range request IFT. The 
 IFT method to utilize for a font load using the following procedure:
 
 *  If the content has specified which method to use, such as via the <code>incremental-patch</code> or
-    <code>incremental-range</code> font tech keyword (see: <a href="#opt-in">opt-in mechanism</a>),
+    <code>incremental-range</code> font tech keyword (see: [[#opt-in|opt-in mechanism]]),
     then that method should be used if the client supports it. If the specified method is not supported
     then the client should fallback to to loading the font non-incrementally.
 
 *  Otherwise if the client does not know which particular IFT method(s) that the server hosting the
     font supports, such as when the <code>incremental-auto</code> font tech keyword is used, then
-    <a href="#method-negotiation">method negotiation</a> should be used to determine the method.
+    [[#method-negotiation|method negotiation]] should be used to determine the method.
 
 The most recently specified method by the content takes precedence. For example if on a site the
 first page specifies to use the patch subset method for a font URL, but the second page specifies
@@ -304,18 +312,16 @@ determine which method to use. Different clients may support different IFT metho
 servers may support different IFT methods, so a negotiation occurs as such:
 
 1.  The browser makes the first request to the server using the GET HTTP method ([[rfc9110#section-9.3.1]]).
-     If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant
+     If the client prefers the [[#patch-incxfer|patch-subset method]], it sends the relevant
      [=patch request header=]. If the client prefers the range-request method, it does not send the
      header.
 
 2.  If the server receives the patch request header and wishes to honor it, the server must reply
      according to [[#handling-patch-request]]. Otherwise, the server must reply with the
-     [[RFC9110#section-14]]
-     <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a>
-     header, if it supports HTTP Range Requests.
+     [[RFC9110#section-14.3|Accept-Ranges]] header, if it supports HTTP Range Requests.
      
 3.  If the client receives a font with a
-     <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>
+     [[open-type/otff#table-directory|table]]
      identified by the 4-byte tag "IFTP", it commences using the patch-subset method.
      Otherwise, if the client receives the <code>Accept-Ranges: bytes</code> header, it commences
      using the range-request method. Otherwise, the whole font file is downloaded, and the current
@@ -407,25 +413,27 @@ Patch Based Incremental Transfer {#patch-incxfer}
 Font Subset {#font-subset-info}
 --------------------------
 
-A <dfn dfn>font subset</dfn> is a modified version of a font file that contains only the data needed to
+A <dfn dfn>font subset</dfn> is a modified version of a font file [[!iso14496-22]]that contains only the data needed to
 render a subset of:
 
 *  the codepoints,
-*  <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout
-    features</a>,
-*  and <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a>.
+*  [[open-type/featuretags|layout features]],
+*  and [[open-type/otvaroverview#terminology|design-variation space]].
 
 supported by the original font.
 <span class="conform client server" id="conform-font-subset">
 When a subsetted font is used to render text using any combination of the subset codepoints,
-<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">layout features</a>,
-or <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a> it must render identically to the original font. This includes rendering with
+[[open-type/featuretags|layout features]], or  [[open-type/otvaroverview#terminology|design-variation space]]
+it must render identically to the original font. This includes rendering with
 the use of any optional typographic features that a renderer may choose to use from the original font,
 such as hinting instructions.
 </span>
 
 A <dfn dfn>font subset definition</dfn> describes the minimum data (codepoints, layout features,
 variation axis space) that a [=font subset=] must possess.
+
+Note: For convenience the remainder of this document links to the [[open-type]] specification which is a copy of
+[[!iso14496-22]].
 
 Data Types {#data-types}
 ------------------------
@@ -456,7 +464,7 @@ should be encoded by CBOR are given in the definition of those data types.
     <td><dfn>ByteString</dfn></td><td>Variable number of bytes.</td><td>2</td>
   </tr>
   <tr>
-    <td><dfn>String</dfn></td><td>UTF-8 [[rfc3629]] text string.</td><td>3</td>
+    <td><dfn>String</dfn></td><td>UTF-8 [[!rfc3629]] text string.</td><td>3</td>
   </tr>
   <tr>
     <td><dfn>ArrayOf</dfn>&lt;Type&gt;</td><td>Array of a variable number of items of Type.</td><td>4</td>
@@ -864,7 +872,7 @@ bytes = [03 07 03 81 7F]
 ### <dfn>FeatureTagSet</dfn> ### {#featuretagset-object}
 
 A FeatureTagSet encodes a set of zero or more
-<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>. To encode
+[[open-type/featuretags|OpenType layout feature tags]]. To encode
 a set of feature tags:
 
 1. Union the set of feature tags to be encoded and the list of feature tags in [[#feature-tag-list]]. For each tag in the
@@ -892,10 +900,9 @@ the above encoding rules.
 
 ### <dfn>AxisSpace</dfn> ### {#AxisSpace}
 
-Stores a set of intervals on one or more open type variation axes [[opentype-variations]]</a>.
-Encoded as a CBOR map (major type 5). The key in each pair is an
-<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord">
-axis tag</a>. It is encoded as a [=ByteString=] containing exactly 4 ASCII characters. The value in each
+Stores a set of intervals on one or more open type variation axes [[open-type/otvaroverview]]</a>.
+Encoded as a CBOR map (major type 5). The key in each pair is an [[open-type/fvar#variationaxisrecord|axis tag]]. It is
+encoded as a [=ByteString=] containing exactly 4 ASCII characters. The value in each
 pair is an [=ArrayOf=]&lt;[=AxisInterval=]&gt;.
 <span class="conform client server" id="conform-axis-space-disjoint">The list of intervals for a
 each axis tag must be disjoint.</span>
@@ -1110,9 +1117,8 @@ The algorithm:
 
 1. If <var>font subset</var> is set then load the <var>client state</var> from the
     <var>font subset</var>. Client state is stored in the <var>font subset</var> as a
-    <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>
-    identified by the 4-byte tag 'IFTP'. The contents of the table are a single [=ClientState=] object
-    encoded via CBOR.
+    [[open-type/otff#table-directory|table]] identified by the 4-byte tag 'IFTP'. The contents of the table are a
+    single [=ClientState=] object encoded via CBOR.
 
      * If <var>font subset</var> does not have an "IFTP" table, then this is not an incrementally
          loaded font and cannot be extended any further. Return <var>font subset</var>.
@@ -1159,8 +1165,8 @@ The algorithm:
      * Otherwise if [=request/method=] is "GET" then, a [=header=] with name
          <code>Font-Patch-Request</code> (the <dfn export>patch request header</dfn>)
          and whose value is a single
-         [=PatchRequest=] object encoded via CBOR and then
-         base64url encoding [[rfc4648]] must be added to the request's header list.
+        [=PatchRequest=] object encoded via CBOR and then
+        base64url encoding [[!rfc4648]] must be added to the request's header list.
 
      Any request and/or url parameters which are not specified here should be set based on
      the user agent's normal handling for font requests. For example if this font load is
@@ -1198,8 +1204,7 @@ The algorithm:
          [=ClientState/codepoint_ordering=] then this field should not be set.
 
      *  [=PatchRequest/features_have=]: set to the list of
-         <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">
-         OpenType layout feature tags</a> that the current <var>font subset</var> has data
+         [[open-type/featuretags|OpenType layout feature tags]] that the current <var>font subset</var> has data
          for. If the current <var>font subset</var> is not set then this
          field is left unset. Additionally, if the current <var>font subset</var> has all
          data for features present in the [=original font=] then this field can be unset.
@@ -1242,7 +1247,7 @@ The algorithm:
 
 Note: POST is preferred for the HTTP method since it will not cause a CORS pre-flight request
 and the request object is more compactly encoded. GET should only be used during
-<a href="#method-negotiation">method negotiation</a>.
+[[#method-negotiation|method negotiation]].
 
 <h4 algorithm id="handling-patch-response">Handling Server Response</h4>
 
@@ -1289,8 +1294,7 @@ The algorithm:
      decoded response is the new <var>extended font subset</var>.
 
 3. Load the <var>client state</var> from the <var>extended font subset</var>. Client state is stored in the
-    <var>extended font subset</var> as a
-    <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>
+    <var>extended font subset</var> as a [[open-type/otff#table-directory|table]]
     identified by the 4-byte tag 'IFTP'. The contents of the table are a single [=ClientState=] object
     encoded via CBOR.
 
@@ -1478,7 +1482,7 @@ Note: the request may optionally set [=PatchRequest/codepoint_ordering=] which i
 provide the exact codepoint ordering that was used to encode [=PatchRequest/indices_have=] and
 [=PatchRequest/indices_needed=].
 
-Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>:
+Likewise, the server can produce two sets of [[open-type/featuretags|OpenType layout feature tags]]:
 
 1.  Feature tags the client's subset has: specified by [=PatchRequest/features_have=]. If the field is
      unset this indicates the client's subset contains all features in the [=original font=].
@@ -1521,9 +1525,8 @@ result in an extended [=font subset=]:
 
 
 *  <span class="conform server" id="conform-response-client-state">That has a
-    <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>
-    which is identified by the tag 'IFTP' whose content is a single [=ClientState=] object encoded via
-    CBOR:</span>
+    [[open-type/otff#table-directory|table]] which is identified by the tag 'IFTP' whose content is a single
+    [=ClientState=] object encoded via CBOR:</span>
 
     *  <span class="conform server" id="conform-response-client-state-original-checksum">The
         [=ClientState/original_font_checksum=] field must be set to the checksum of the
@@ -1545,8 +1548,7 @@ result in an extended [=font subset=]:
 
     *  <span class="conform server" id="conform-response-client-state-original-features">
         The [=ClientState/original_features=] field must be set to the list of
-        <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout
-        feature tags</a> that the [=original font=] has data for.</span>
+        [[open-type/featuretags|OpenType layout feature tags]] that the [=original font=] has data for.</span>
 
     *  <span class="conform server" id="conform-response-client-state-missing-codepoints">
         The [=ClientState/missing_codepoints=] field must be set to the list of codepoints
@@ -1791,15 +1793,15 @@ them from being used for tracking.
 <h3 id="per-origin">Per-origin restriction avoids fingerprinting</h3>
 
   As required by [[!css-fonts-4]],
-  Web Fonts <a href="https://drafts.csswg.org/css-fonts-4/#web-fonts">must not be accessible
+  Web Fonts [[css-fonts-4#web-fonts|must not be accessible
   in any other Document from the one which either is associated with the @font-face rule
-  or owns the FontFaceSet.
+  or owns the FontFaceSet]].
   Other applications on the device must not be able to access Web Fonts.</a>
   This avoids information leaking across origins.
 
   Similarly, font palette values
-  <a href="https://drafts.csswg.org/css-fonts-4/#font-palette-values">must only be available to the documents that
-  reference it</a>. Using an author-defined color palette outside of the documents that reference it
+  [[css-fonts-4#font-palette-values|must only be available to the documents that
+  reference it]]. Using an author-defined color palette outside of the documents that reference it
   would constitute a security leak since the contents of one page
   would be able to affect other pages,
   something an attacker could use as an attack vector.
@@ -1856,10 +1858,10 @@ Appendix A: Default Feature Tags and Encoding IDs</h2>
 was assembled from several sources:
 
 * Includes all features listed in the
-    <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist">OpenType layout feature registry</a>.
+    [[open-type/featurelist|OpenType layout feature registry]].
 
 * The value of "Encode If" is set to "not needed" for all features which are listed as "default on" in
-    <a href="https://tiro.com/John/Enabling_Typography_(OTL).pdf">Enabling Typography</a> or are in the
+    [[enabling-typography]] or are in the
     default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz
     subsetter</a>.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -872,7 +872,7 @@ bytes = [03 07 03 81 7F]
 ### <dfn>FeatureTagSet</dfn> ### {#featuretagset-object}
 
 A FeatureTagSet encodes a set of zero or more
-[[open-type/featuretags|OpenType layout feature tags]]. To encode
+[[open-type/featuretags|layout feature tags]]. To encode
 a set of feature tags:
 
 1. Union the set of feature tags to be encoded and the list of feature tags in [[#feature-tag-list]]. For each tag in the
@@ -900,7 +900,7 @@ the above encoding rules.
 
 ### <dfn>AxisSpace</dfn> ### {#AxisSpace}
 
-Stores a set of intervals on one or more open type variation axes [[open-type/otvaroverview]]</a>.
+Stores a set of intervals on one or more variation axes [[open-type/otvaroverview]]</a>.
 Encoded as a CBOR map (major type 5). The key in each pair is an [[open-type/fvar#variationaxisrecord|axis tag]]. It is
 encoded as a [=ByteString=] containing exactly 4 ASCII characters. The value in each
 pair is an [=ArrayOf=]&lt;[=AxisInterval=]&gt;.
@@ -1204,7 +1204,7 @@ The algorithm:
          [=ClientState/codepoint_ordering=] then this field should not be set.
 
      *  [=PatchRequest/features_have=]: set to the list of
-         [[open-type/featuretags|OpenType layout feature tags]] that the current <var>font subset</var> has data
+         [[open-type/featuretags|layout feature tags]] that the current <var>font subset</var> has data
          for. If the current <var>font subset</var> is not set then this
          field is left unset. Additionally, if the current <var>font subset</var> has all
          data for features present in the [=original font=] then this field can be unset.
@@ -1482,7 +1482,7 @@ Note: the request may optionally set [=PatchRequest/codepoint_ordering=] which i
 provide the exact codepoint ordering that was used to encode [=PatchRequest/indices_have=] and
 [=PatchRequest/indices_needed=].
 
-Likewise, the server can produce two sets of [[open-type/featuretags|OpenType layout feature tags]]:
+Likewise, the server can produce two sets of [[open-type/featuretags|layout feature tags]]:
 
 1.  Feature tags the client's subset has: specified by [=PatchRequest/features_have=]. If the field is
      unset this indicates the client's subset contains all features in the [=original font=].
@@ -1548,7 +1548,7 @@ result in an extended [=font subset=]:
 
     *  <span class="conform server" id="conform-response-client-state-original-features">
         The [=ClientState/original_features=] field must be set to the list of
-        [[open-type/featuretags|OpenType layout feature tags]] that the [=original font=] has data for.</span>
+        [[open-type/featuretags|layout feature tags]] that the [=original font=] has data for.</span>
 
     *  <span class="conform server" id="conform-response-client-state-missing-codepoints">
         The [=ClientState/missing_codepoints=] field must be set to the list of codepoints
@@ -1858,7 +1858,7 @@ Appendix A: Default Feature Tags and Encoding IDs</h2>
 was assembled from several sources:
 
 * Includes all features listed in the
-    [[open-type/featurelist|OpenType layout feature registry]].
+    [[open-type/featurelist|layout feature registry]].
 
 * The value of "Encode If" is set to "not needed" for all features which are listed as "default on" in
     [[enabling-typography]] or are in the

--- a/Overview.bs
+++ b/Overview.bs
@@ -1852,7 +1852,7 @@ Since the <a href="https://www.w3.org/TR/2022/WD-IFT-20220628/">Working
 <h2 id="feature-tag-list">
 Appendix A: Default Feature Tags and Encoding IDs</h2>
 
-This appendix is normative. It lists the IDs used to encode feature tags into a [=FeatureTagSet=]. This table
+<em>This appendix is normative.</em> It lists the IDs used to encode feature tags into a [=FeatureTagSet=]. This table
 was assembled from several sources:
 
 * Includes all features listed in the
@@ -1871,6 +1871,6 @@ path: feature-registry.html
 <h2 id="obfuscation-codepoints">
 Appendix B: Codepoints Requiring Obfuscation</h2>
 
-This appendix is normative.The following codepoints are considered to need obfuscation:
+<em>This appendix is normative.</em> The following codepoints are considered to need obfuscation:
 
 * All unicode codepoints with the [[UAX44#Unified_Ideograph|Unified_Ideograph]] property.

--- a/Overview.bs
+++ b/Overview.bs
@@ -1863,6 +1863,10 @@ was assembled from several sources:
     default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz
     subsetter</a>.
 
+The entries in this table are versioned (by the Encoding Version column) since the client and server need to agree on
+the encoding. Currently there is only one version, 1, which is used by default. Future specification updates may
+introduce additional versions and a mechanism for the server to inform the client up to which version it supports.
+
 <pre class=include>
 <!-- Edit feature-registry.csv to update this table. -->
 path: feature-registry.html

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="9568adc7983b057a92b724395456b2d06fd15cfd" name="document-revision">
+  <meta content="24692921e74dda1049091d25cfa9c35700fd85b3" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -822,7 +822,7 @@ CPU, RAM usage) per request vs range request.</p>
    </ul>
    <h2 class="heading settled" data-level="2" id="opt-in"><span class="secno">2. </span><span class="content">Opt-In Mechanism</span><a class="self-link" href="#opt-in"></a></h2>
    <p><em>This section is general to both IFT methods.</em></p>
-   <p>Web page’s can choose to opt-in to either patch subset or range request incremental transfer for a font
+   <p>Web pages can choose to opt-in to either patch subset or range request incremental transfer for a font
 via the use of a CSS font tech keyword (<a href="https://www.w3.org/TR/css-fonts-4/#font-tech-definitions"><cite>CSS Fonts 4</cite> § 11.1 Font tech</a>) inside the
 ''@font-face'' block.</p>
    <p>There are three tech keywords available:</p>
@@ -2236,500 +2236,500 @@ subsetter</a>.</p>
       <th>Encoded As
       <th>Encode If
      <tr>
-      <td>aalt
-      <td>1
-      <td>needed
-     <tr>
       <td>abvf
-      <td>2
+      <td>1
       <td>not needed
      <tr>
       <td>abvm
-      <td>3
+      <td>2
       <td>not needed
      <tr>
       <td>abvs
+      <td>3
+      <td>not needed
+     <tr>
+      <td>akhn
       <td>4
       <td>not needed
      <tr>
-      <td>afrc
-      <td>5
-      <td>needed
-     <tr>
-      <td>akhn
-      <td>6
-      <td>not needed
-     <tr>
       <td>blwf
-      <td>7
+      <td>5
       <td>not needed
      <tr>
       <td>blwm
-      <td>8
+      <td>6
       <td>not needed
      <tr>
       <td>blws
-      <td>9
+      <td>7
       <td>not needed
      <tr>
       <td>calt
-      <td>10
+      <td>8
       <td>not needed
      <tr>
-      <td>case
-      <td>11
-      <td>needed
-     <tr>
       <td>ccmp
-      <td>12
+      <td>9
       <td>not needed
      <tr>
       <td>cfar
-      <td>13
+      <td>10
       <td>not needed
      <tr>
       <td>chws
-      <td>14
+      <td>11
       <td>not needed
      <tr>
       <td>cjct
-      <td>15
+      <td>12
       <td>not needed
      <tr>
       <td>clig
-      <td>16
+      <td>13
       <td>not needed
      <tr>
-      <td>cpct
-      <td>17
-      <td>needed
-     <tr>
-      <td>cpsp
-      <td>18
-      <td>needed
-     <tr>
       <td>cswh
-      <td>19
+      <td>14
       <td>not needed
      <tr>
       <td>curs
-      <td>20
+      <td>15
       <td>not needed
-     <tr>
-      <td>cv01-cv99
-      <td>21-119
-      <td>needed
-     <tr>
-      <td>c2pc
-      <td>120
-      <td>needed
-     <tr>
-      <td>c2sc
-      <td>121
-      <td>needed
      <tr>
       <td>dist
-      <td>122
+      <td>16
       <td>not needed
      <tr>
-      <td>dlig
-      <td>123
-      <td>needed
-     <tr>
       <td>dnom
-      <td>124
+      <td>17
       <td>not needed
      <tr>
       <td>dtls
-      <td>125
+      <td>18
       <td>not needed
      <tr>
-      <td>expt
-      <td>126
-      <td>needed
-     <tr>
-      <td>falt
-      <td>127
-      <td>needed
-     <tr>
       <td>fin2
-      <td>128
+      <td>19
       <td>not needed
      <tr>
       <td>fin3
-      <td>129
+      <td>20
       <td>not needed
      <tr>
       <td>fina
-      <td>130
+      <td>21
       <td>not needed
      <tr>
       <td>flac
-      <td>131
+      <td>22
       <td>not needed
      <tr>
       <td>frac
-      <td>132
+      <td>23
       <td>not needed
      <tr>
-      <td>fwid
-      <td>133
-      <td>needed
-     <tr>
       <td>half
-      <td>134
+      <td>24
       <td>not needed
      <tr>
       <td>haln
-      <td>135
+      <td>25
       <td>not needed
      <tr>
-      <td>halt
-      <td>136
-      <td>needed
-     <tr>
-      <td>hist
-      <td>137
-      <td>needed
-     <tr>
-      <td>hkna
-      <td>138
-      <td>needed
-     <tr>
-      <td>hlig
-      <td>139
-      <td>needed
-     <tr>
-      <td>hngl
-      <td>140
-      <td>needed
-     <tr>
-      <td>hojo
-      <td>141
-      <td>needed
-     <tr>
-      <td>hwid
-      <td>142
-      <td>needed
-     <tr>
       <td>init
-      <td>143
+      <td>26
       <td>not needed
      <tr>
       <td>isol
-      <td>144
+      <td>27
       <td>not needed
-     <tr>
-      <td>ital
-      <td>145
-      <td>needed
      <tr>
       <td>jalt
-      <td>146
+      <td>28
       <td>not needed
-     <tr>
-      <td>jp78
-      <td>147
-      <td>needed
-     <tr>
-      <td>jp83
-      <td>148
-      <td>needed
-     <tr>
-      <td>jp90
-      <td>149
-      <td>needed
-     <tr>
-      <td>jp04
-      <td>150
-      <td>needed
      <tr>
       <td>kern
-      <td>151
+      <td>29
       <td>not needed
      <tr>
-      <td>lfbd
-      <td>152
-      <td>needed
-     <tr>
       <td>liga
-      <td>153
+      <td>30
       <td>not needed
      <tr>
       <td>ljmo
-      <td>154
+      <td>31
       <td>not needed
      <tr>
-      <td>lnum
-      <td>155
-      <td>needed
-     <tr>
       <td>locl
-      <td>156
+      <td>32
       <td>not needed
      <tr>
       <td>ltra
-      <td>157
+      <td>33
       <td>not needed
      <tr>
       <td>ltrm
-      <td>158
+      <td>34
       <td>not needed
      <tr>
       <td>mark
-      <td>159
+      <td>35
       <td>not needed
      <tr>
       <td>med2
-      <td>160
+      <td>36
       <td>not needed
      <tr>
       <td>medi
-      <td>161
+      <td>37
       <td>not needed
      <tr>
-      <td>mgrk
-      <td>162
-      <td>needed
-     <tr>
       <td>mkmk
-      <td>163
+      <td>38
       <td>not needed
      <tr>
       <td>mset
-      <td>164
+      <td>39
       <td>not needed
      <tr>
-      <td>nalt
-      <td>165
-      <td>needed
-     <tr>
-      <td>nlck
-      <td>166
-      <td>needed
-     <tr>
       <td>nukt
-      <td>167
+      <td>40
       <td>not needed
      <tr>
       <td>numr
-      <td>168
+      <td>41
       <td>not needed
      <tr>
-      <td>onum
-      <td>169
-      <td>needed
-     <tr>
-      <td>opbd
-      <td>170
-      <td>needed
-     <tr>
-      <td>ordn
-      <td>171
-      <td>needed
-     <tr>
-      <td>ornm
-      <td>172
-      <td>needed
-     <tr>
-      <td>palt
-      <td>173
-      <td>needed
-     <tr>
-      <td>pcap
-      <td>174
-      <td>needed
-     <tr>
-      <td>pkna
-      <td>175
-      <td>needed
-     <tr>
-      <td>pnum
-      <td>176
-      <td>needed
-     <tr>
       <td>pref
-      <td>177
+      <td>42
       <td>not needed
      <tr>
       <td>pres
-      <td>178
+      <td>43
       <td>not needed
      <tr>
       <td>pstf
-      <td>179
+      <td>44
       <td>not needed
      <tr>
       <td>psts
-      <td>180
+      <td>45
       <td>not needed
      <tr>
-      <td>pwid
-      <td>181
-      <td>needed
-     <tr>
-      <td>qwid
-      <td>182
-      <td>needed
-     <tr>
       <td>rand
-      <td>183
+      <td>46
       <td>not needed
      <tr>
       <td>rclt
-      <td>184
+      <td>47
       <td>not needed
      <tr>
       <td>rkrf
-      <td>185
+      <td>48
       <td>not needed
      <tr>
       <td>rlig
-      <td>186
+      <td>49
       <td>not needed
      <tr>
       <td>rphf
-      <td>187
+      <td>50
       <td>not needed
      <tr>
-      <td>rtbd
-      <td>188
-      <td>needed
-     <tr>
       <td>rtla
-      <td>189
+      <td>51
       <td>not needed
      <tr>
       <td>rtlm
-      <td>190
+      <td>52
       <td>not needed
-     <tr>
-      <td>ruby
-      <td>191
-      <td>needed
      <tr>
       <td>rvrn
-      <td>192
+      <td>53
       <td>not needed
      <tr>
-      <td>salt
-      <td>193
-      <td>needed
-     <tr>
-      <td>sinf
-      <td>194
-      <td>needed
-     <tr>
-      <td>size
-      <td>195
-      <td>needed
-     <tr>
-      <td>smcp
-      <td>196
-      <td>needed
-     <tr>
-      <td>smpl
-      <td>197
-      <td>needed
-     <tr>
-      <td>ss01-ss20
-      <td>198-217
-      <td>needed
-     <tr>
       <td>ssty
-      <td>218
+      <td>54
       <td>not needed
      <tr>
       <td>stch
-      <td>219
+      <td>55
       <td>not needed
-     <tr>
-      <td>subs
-      <td>220
-      <td>needed
-     <tr>
-      <td>sups
-      <td>221
-      <td>needed
-     <tr>
-      <td>swsh
-      <td>222
-      <td>needed
-     <tr>
-      <td>titl
-      <td>223
-      <td>needed
      <tr>
       <td>tjmo
-      <td>224
+      <td>56
       <td>not needed
      <tr>
-      <td>tnam
-      <td>225
-      <td>needed
-     <tr>
-      <td>tnum
-      <td>226
-      <td>needed
-     <tr>
-      <td>trad
-      <td>227
-      <td>needed
-     <tr>
-      <td>twid
-      <td>228
-      <td>needed
-     <tr>
-      <td>unic
-      <td>229
-      <td>needed
-     <tr>
       <td>valt
-      <td>230
+      <td>57
       <td>not needed
      <tr>
       <td>vatu
-      <td>231
+      <td>58
       <td>not needed
      <tr>
       <td>vchw
-      <td>232
+      <td>59
       <td>not needed
      <tr>
       <td>vert
-      <td>233
+      <td>60
       <td>not needed
-     <tr>
-      <td>vhal
-      <td>234
-      <td>needed
      <tr>
       <td>vjmo
-      <td>235
+      <td>61
       <td>not needed
      <tr>
-      <td>vkna
-      <td>236
-      <td>needed
-     <tr>
       <td>vkrn
-      <td>237
+      <td>62
       <td>not needed
      <tr>
       <td>vpal
-      <td>238
+      <td>63
       <td>not needed
      <tr>
       <td>vrt2
-      <td>239
+      <td>64
       <td>not needed
      <tr>
       <td>vrtr
-      <td>240
+      <td>65
       <td>not needed
      <tr>
+      <td>aalt
+      <td>66
+      <td>needed
+     <tr>
+      <td>afrc
+      <td>67
+      <td>needed
+     <tr>
+      <td>case
+      <td>68
+      <td>needed
+     <tr>
+      <td>cpct
+      <td>69
+      <td>needed
+     <tr>
+      <td>cpsp
+      <td>70
+      <td>needed
+     <tr>
+      <td>c2pc
+      <td>71
+      <td>needed
+     <tr>
+      <td>c2sc
+      <td>72
+      <td>needed
+     <tr>
+      <td>dlig
+      <td>73
+      <td>needed
+     <tr>
+      <td>expt
+      <td>74
+      <td>needed
+     <tr>
+      <td>falt
+      <td>75
+      <td>needed
+     <tr>
+      <td>fwid
+      <td>76
+      <td>needed
+     <tr>
+      <td>halt
+      <td>77
+      <td>needed
+     <tr>
+      <td>hist
+      <td>78
+      <td>needed
+     <tr>
+      <td>hkna
+      <td>79
+      <td>needed
+     <tr>
+      <td>hlig
+      <td>80
+      <td>needed
+     <tr>
+      <td>hngl
+      <td>81
+      <td>needed
+     <tr>
+      <td>hojo
+      <td>82
+      <td>needed
+     <tr>
+      <td>hwid
+      <td>83
+      <td>needed
+     <tr>
+      <td>ital
+      <td>84
+      <td>needed
+     <tr>
+      <td>jp78
+      <td>85
+      <td>needed
+     <tr>
+      <td>jp83
+      <td>86
+      <td>needed
+     <tr>
+      <td>jp90
+      <td>87
+      <td>needed
+     <tr>
+      <td>jp04
+      <td>88
+      <td>needed
+     <tr>
+      <td>lfbd
+      <td>89
+      <td>needed
+     <tr>
+      <td>lnum
+      <td>90
+      <td>needed
+     <tr>
+      <td>mgrk
+      <td>91
+      <td>needed
+     <tr>
+      <td>nalt
+      <td>92
+      <td>needed
+     <tr>
+      <td>nlck
+      <td>93
+      <td>needed
+     <tr>
+      <td>onum
+      <td>94
+      <td>needed
+     <tr>
+      <td>opbd
+      <td>95
+      <td>needed
+     <tr>
+      <td>ordn
+      <td>96
+      <td>needed
+     <tr>
+      <td>ornm
+      <td>97
+      <td>needed
+     <tr>
+      <td>palt
+      <td>98
+      <td>needed
+     <tr>
+      <td>pcap
+      <td>99
+      <td>needed
+     <tr>
+      <td>pkna
+      <td>100
+      <td>needed
+     <tr>
+      <td>pnum
+      <td>101
+      <td>needed
+     <tr>
+      <td>pwid
+      <td>102
+      <td>needed
+     <tr>
+      <td>qwid
+      <td>103
+      <td>needed
+     <tr>
+      <td>rtbd
+      <td>104
+      <td>needed
+     <tr>
+      <td>ruby
+      <td>105
+      <td>needed
+     <tr>
+      <td>salt
+      <td>106
+      <td>needed
+     <tr>
+      <td>sinf
+      <td>107
+      <td>needed
+     <tr>
+      <td>size
+      <td>108
+      <td>needed
+     <tr>
+      <td>smcp
+      <td>109
+      <td>needed
+     <tr>
+      <td>smpl
+      <td>110
+      <td>needed
+     <tr>
+      <td>subs
+      <td>111
+      <td>needed
+     <tr>
+      <td>sups
+      <td>112
+      <td>needed
+     <tr>
+      <td>swsh
+      <td>113
+      <td>needed
+     <tr>
+      <td>titl
+      <td>114
+      <td>needed
+     <tr>
+      <td>tnam
+      <td>115
+      <td>needed
+     <tr>
+      <td>tnum
+      <td>116
+      <td>needed
+     <tr>
+      <td>trad
+      <td>117
+      <td>needed
+     <tr>
+      <td>twid
+      <td>118
+      <td>needed
+     <tr>
+      <td>unic
+      <td>119
+      <td>needed
+     <tr>
+      <td>vhal
+      <td>120
+      <td>needed
+     <tr>
+      <td>vkna
+      <td>121
+      <td>needed
+     <tr>
       <td>zero
-      <td>241
+      <td>122
+      <td>needed
+     <tr>
+      <td>ss01-ss20
+      <td>123-142
+      <td>needed
+     <tr>
+      <td>cv01-cv99
+      <td>143-241
       <td>needed
    </table>
    <h2 class="heading settled" id="obfuscation-codepoints"><span class="content"> Appendix B: Codepoints Requiring Obfuscation</span><a class="self-link" href="#obfuscation-codepoints"></a></h2>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="ab73e824b04b28286f80a7006ef7d4e3991b1813" name="document-revision">
+  <meta content="ab7c2d0406bfeea5c8c714e0c89933123586be94" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -2229,508 +2229,636 @@ was assembled from several sources:</p>
 default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz
 subsetter</a>.</p>
    </ul>
+   <p>The entries in this table are versioned (by the Encoding Version column) since the client and server need to agree on
+the encoding. Currently there is only one version, 1, which is used by default. Future specification updates may
+introduce additional versions and a mechanism for the server to inform the client up to which version it supports.</p>
    <table>
     <tbody>
      <tr>
       <th>Tag
       <th>Encoded As
       <th>Encode If
+      <th>Encoding Version
      <tr>
       <td>abvf
       <td>1
       <td>not needed
+      <td>1
      <tr>
       <td>abvm
       <td>2
       <td>not needed
+      <td>1
      <tr>
       <td>abvs
       <td>3
       <td>not needed
+      <td>1
      <tr>
       <td>akhn
       <td>4
       <td>not needed
+      <td>1
      <tr>
       <td>blwf
       <td>5
       <td>not needed
+      <td>1
      <tr>
       <td>blwm
       <td>6
       <td>not needed
+      <td>1
      <tr>
       <td>blws
       <td>7
       <td>not needed
+      <td>1
      <tr>
       <td>calt
       <td>8
       <td>not needed
+      <td>1
      <tr>
       <td>ccmp
       <td>9
       <td>not needed
+      <td>1
      <tr>
       <td>cfar
       <td>10
       <td>not needed
+      <td>1
      <tr>
       <td>chws
       <td>11
       <td>not needed
+      <td>1
      <tr>
       <td>cjct
       <td>12
       <td>not needed
+      <td>1
      <tr>
       <td>clig
       <td>13
       <td>not needed
+      <td>1
      <tr>
       <td>cswh
       <td>14
       <td>not needed
+      <td>1
      <tr>
       <td>curs
       <td>15
       <td>not needed
+      <td>1
      <tr>
       <td>dist
       <td>16
       <td>not needed
+      <td>1
      <tr>
       <td>dnom
       <td>17
       <td>not needed
+      <td>1
      <tr>
       <td>dtls
       <td>18
       <td>not needed
+      <td>1
      <tr>
       <td>fin2
       <td>19
       <td>not needed
+      <td>1
      <tr>
       <td>fin3
       <td>20
       <td>not needed
+      <td>1
      <tr>
       <td>fina
       <td>21
       <td>not needed
+      <td>1
      <tr>
       <td>flac
       <td>22
       <td>not needed
+      <td>1
      <tr>
       <td>frac
       <td>23
       <td>not needed
+      <td>1
      <tr>
       <td>half
       <td>24
       <td>not needed
+      <td>1
      <tr>
       <td>haln
       <td>25
       <td>not needed
+      <td>1
      <tr>
       <td>init
       <td>26
       <td>not needed
+      <td>1
      <tr>
       <td>isol
       <td>27
       <td>not needed
+      <td>1
      <tr>
       <td>jalt
       <td>28
       <td>not needed
+      <td>1
      <tr>
       <td>kern
       <td>29
       <td>not needed
+      <td>1
      <tr>
       <td>liga
       <td>30
       <td>not needed
+      <td>1
      <tr>
       <td>ljmo
       <td>31
       <td>not needed
+      <td>1
      <tr>
       <td>locl
       <td>32
       <td>not needed
+      <td>1
      <tr>
       <td>ltra
       <td>33
       <td>not needed
+      <td>1
      <tr>
       <td>ltrm
       <td>34
       <td>not needed
+      <td>1
      <tr>
       <td>mark
       <td>35
       <td>not needed
+      <td>1
      <tr>
       <td>med2
       <td>36
       <td>not needed
+      <td>1
      <tr>
       <td>medi
       <td>37
       <td>not needed
+      <td>1
      <tr>
       <td>mkmk
       <td>38
       <td>not needed
+      <td>1
      <tr>
       <td>mset
       <td>39
       <td>not needed
+      <td>1
      <tr>
       <td>nukt
       <td>40
       <td>not needed
+      <td>1
      <tr>
       <td>numr
       <td>41
       <td>not needed
+      <td>1
      <tr>
       <td>pref
       <td>42
       <td>not needed
+      <td>1
      <tr>
       <td>pres
       <td>43
       <td>not needed
+      <td>1
      <tr>
       <td>pstf
       <td>44
       <td>not needed
+      <td>1
      <tr>
       <td>psts
       <td>45
       <td>not needed
+      <td>1
      <tr>
       <td>rand
       <td>46
       <td>not needed
+      <td>1
      <tr>
       <td>rclt
       <td>47
       <td>not needed
+      <td>1
      <tr>
       <td>rkrf
       <td>48
       <td>not needed
+      <td>1
      <tr>
       <td>rlig
       <td>49
       <td>not needed
+      <td>1
      <tr>
       <td>rphf
       <td>50
       <td>not needed
+      <td>1
      <tr>
       <td>rtla
       <td>51
       <td>not needed
+      <td>1
      <tr>
       <td>rtlm
       <td>52
       <td>not needed
+      <td>1
      <tr>
       <td>rvrn
       <td>53
       <td>not needed
+      <td>1
      <tr>
       <td>ssty
       <td>54
       <td>not needed
+      <td>1
      <tr>
       <td>stch
       <td>55
       <td>not needed
+      <td>1
      <tr>
       <td>tjmo
       <td>56
       <td>not needed
+      <td>1
      <tr>
       <td>valt
       <td>57
       <td>not needed
+      <td>1
      <tr>
       <td>vatu
       <td>58
       <td>not needed
+      <td>1
      <tr>
       <td>vchw
       <td>59
       <td>not needed
+      <td>1
      <tr>
       <td>vert
       <td>60
       <td>not needed
+      <td>1
      <tr>
       <td>vjmo
       <td>61
       <td>not needed
+      <td>1
      <tr>
       <td>vkrn
       <td>62
       <td>not needed
+      <td>1
      <tr>
       <td>vpal
       <td>63
       <td>not needed
+      <td>1
      <tr>
       <td>vrt2
       <td>64
       <td>not needed
+      <td>1
      <tr>
       <td>vrtr
       <td>65
       <td>not needed
+      <td>1
      <tr>
       <td>aalt
       <td>66
       <td>needed
+      <td>1
      <tr>
       <td>afrc
       <td>67
       <td>needed
+      <td>1
      <tr>
       <td>case
       <td>68
       <td>needed
+      <td>1
      <tr>
       <td>cpct
       <td>69
       <td>needed
+      <td>1
      <tr>
       <td>cpsp
       <td>70
       <td>needed
+      <td>1
      <tr>
       <td>c2pc
       <td>71
       <td>needed
+      <td>1
      <tr>
       <td>c2sc
       <td>72
       <td>needed
+      <td>1
      <tr>
       <td>dlig
       <td>73
       <td>needed
+      <td>1
      <tr>
       <td>expt
       <td>74
       <td>needed
+      <td>1
      <tr>
       <td>falt
       <td>75
       <td>needed
+      <td>1
      <tr>
       <td>fwid
       <td>76
       <td>needed
+      <td>1
      <tr>
       <td>halt
       <td>77
       <td>needed
+      <td>1
      <tr>
       <td>hist
       <td>78
       <td>needed
+      <td>1
      <tr>
       <td>hkna
       <td>79
       <td>needed
+      <td>1
      <tr>
       <td>hlig
       <td>80
       <td>needed
+      <td>1
      <tr>
       <td>hngl
       <td>81
       <td>needed
+      <td>1
      <tr>
       <td>hojo
       <td>82
       <td>needed
+      <td>1
      <tr>
       <td>hwid
       <td>83
       <td>needed
+      <td>1
      <tr>
       <td>ital
       <td>84
       <td>needed
+      <td>1
      <tr>
       <td>jp78
       <td>85
       <td>needed
+      <td>1
      <tr>
       <td>jp83
       <td>86
       <td>needed
+      <td>1
      <tr>
       <td>jp90
       <td>87
       <td>needed
+      <td>1
      <tr>
       <td>jp04
       <td>88
       <td>needed
+      <td>1
      <tr>
       <td>lfbd
       <td>89
       <td>needed
+      <td>1
      <tr>
       <td>lnum
       <td>90
       <td>needed
+      <td>1
      <tr>
       <td>mgrk
       <td>91
       <td>needed
+      <td>1
      <tr>
       <td>nalt
       <td>92
       <td>needed
+      <td>1
      <tr>
       <td>nlck
       <td>93
       <td>needed
+      <td>1
      <tr>
       <td>onum
       <td>94
       <td>needed
+      <td>1
      <tr>
       <td>opbd
       <td>95
       <td>needed
+      <td>1
      <tr>
       <td>ordn
       <td>96
       <td>needed
+      <td>1
      <tr>
       <td>ornm
       <td>97
       <td>needed
+      <td>1
      <tr>
       <td>palt
       <td>98
       <td>needed
+      <td>1
      <tr>
       <td>pcap
       <td>99
       <td>needed
+      <td>1
      <tr>
       <td>pkna
       <td>100
       <td>needed
+      <td>1
      <tr>
       <td>pnum
       <td>101
       <td>needed
+      <td>1
      <tr>
       <td>pwid
       <td>102
       <td>needed
+      <td>1
      <tr>
       <td>qwid
       <td>103
       <td>needed
+      <td>1
      <tr>
       <td>rtbd
       <td>104
       <td>needed
+      <td>1
      <tr>
       <td>ruby
       <td>105
       <td>needed
+      <td>1
      <tr>
       <td>salt
       <td>106
       <td>needed
+      <td>1
      <tr>
       <td>sinf
       <td>107
       <td>needed
+      <td>1
      <tr>
       <td>size
       <td>108
       <td>needed
+      <td>1
      <tr>
       <td>smcp
       <td>109
       <td>needed
+      <td>1
      <tr>
       <td>smpl
       <td>110
       <td>needed
+      <td>1
      <tr>
       <td>subs
       <td>111
       <td>needed
+      <td>1
      <tr>
       <td>sups
       <td>112
       <td>needed
+      <td>1
      <tr>
       <td>swsh
       <td>113
       <td>needed
+      <td>1
      <tr>
       <td>titl
       <td>114
       <td>needed
+      <td>1
      <tr>
       <td>tnam
       <td>115
       <td>needed
+      <td>1
      <tr>
       <td>tnum
       <td>116
       <td>needed
+      <td>1
      <tr>
       <td>trad
       <td>117
       <td>needed
+      <td>1
      <tr>
       <td>twid
       <td>118
       <td>needed
+      <td>1
      <tr>
       <td>unic
       <td>119
       <td>needed
+      <td>1
      <tr>
       <td>vhal
       <td>120
       <td>needed
+      <td>1
      <tr>
       <td>vkna
       <td>121
       <td>needed
+      <td>1
      <tr>
       <td>zero
       <td>122
       <td>needed
+      <td>1
      <tr>
       <td>ss01-ss20
       <td>123-142
       <td>needed
+      <td>1
      <tr>
       <td>cv01-cv99
       <td>143-241
       <td>needed
+      <td>1
    </table>
    <h2 class="heading settled" id="obfuscation-codepoints"><span class="content"> Appendix B: Codepoints Requiring Obfuscation</span><a class="self-link" href="#obfuscation-codepoints"></a></h2>
    <p><em>This appendix is normative.</em> The following codepoints are considered to need obfuscation:</p>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="24692921e74dda1049091d25cfa9c35700fd85b3" name="document-revision">
+  <meta content="ab73e824b04b28286f80a7006ef7d4e3991b1813" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -2219,7 +2219,7 @@ them from being used for tracking.</p>
     <li>Made HTTP RFC references more specific
    </ul>
    <h2 class="heading settled" id="feature-tag-list"><span class="content"> Appendix A: Default Feature Tags and Encoding IDs</span><a class="self-link" href="#feature-tag-list"></a></h2>
-   <p>This appendix is normative. It lists the IDs used to encode feature tags into a <a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset③">FeatureTagSet</a>. This table
+   <p><em>This appendix is normative.</em> It lists the IDs used to encode feature tags into a <a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset③">FeatureTagSet</a>. This table
 was assembled from several sources:</p>
    <ul>
     <li data-md>
@@ -2733,7 +2733,7 @@ subsetter</a>.</p>
       <td>needed
    </table>
    <h2 class="heading settled" id="obfuscation-codepoints"><span class="content"> Appendix B: Codepoints Requiring Obfuscation</span><a class="self-link" href="#obfuscation-codepoints"></a></h2>
-   <p>This appendix is normative.The following codepoints are considered to need obfuscation:</p>
+   <p><em>This appendix is normative.</em> The following codepoints are considered to need obfuscation:</p>
    <ul>
     <li data-md>
      <p>All unicode codepoints with the <a href="https://www.unicode.org/reports/tr44/tr44-30.html#Unified_Ideograph">Unified_Ideograph</a> property.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="ab7c2d0406bfeea5c8c714e0c89933123586be94" name="document-revision">
+  <meta content="81a63e1ebfb53c453292ec6db64a743992c07c48" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -717,7 +717,7 @@ slow networks, very large fonts, or complex subsetting requirements currently pr
 example, even using WOFF 2 <a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a>, fonts for CJK languages are too large to be practical.</p>
    <p>There are two different methods which can be used to incrementally transfer fonts.</p>
    <h3 class="heading settled" data-level="1.1" id="patch-subset"><span class="secno">1.1. </span><span class="content">Patch Subset</span><a class="self-link" href="#patch-subset"></a></h3>
-   <p>In the the first method, <a href="#patch-subset">Patch Subset</a> a server generates binary patches which a
+   <p>In the the first method, <a href="#patch-incxfer">Patch Subset</a>, a server generates binary patches which a
 client applies to a subset of the font in order to extend the coverage of that subset. The server
 is stateless, it does not maintain any session data for clients between requests. Thus when a client
 requests the generation of a patch from the server it has to fully describe the current subset of the
@@ -886,9 +886,9 @@ servers may support different IFT methods, so a negotiation occurs as such:</p>
  header.</p>
     <li data-md>
      <p>If the server receives the patch request header and wishes to honor it, the server must reply
- according to <a href="#handling-patch-request">§ 4.5 Server: Responding to a PatchRequest</a>. Otherwise, the server must reply with the <a href="https://www.rfc-editor.org/rfc/rfc9110#section-14"><cite>HTTP Semantics</cite> §  14. Range Requests</a> <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-ranges"><code>Accept-Ranges</code></a> header, if it supports HTTP Range Requests.</p>
+ according to <a href="#handling-patch-request">§ 4.5 Server: Responding to a PatchRequest</a>. Otherwise, the server must reply with the <a href="https://www.rfc-editor.org/rfc/rfc9110#section-14.3">Accept-Ranges</a> header, if it supports HTTP Range Requests.</p>
     <li data-md>
-     <p>If the client receives a font with a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag "IFTP", it commences using the patch-subset method.
+     <p>If the client receives a font with a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag "IFTP", it commences using the patch-subset method.
  Otherwise, if the client receives the <code>Accept-Ranges: bytes</code> header, it commences
  using the range-request method. Otherwise, the whole font file is downloaded, and the current
  non-incremental loading behavior is used.</p>
@@ -963,23 +963,22 @@ when URLs are rewritten to point to the saved full font any of the incremental t
 be removed.</p>
    <h2 class="heading settled" data-level="4" id="patch-incxfer"><span class="secno">4. </span><span class="content">Patch Based Incremental Transfer</span><a class="self-link" href="#patch-incxfer"></a></h2>
    <h3 class="heading settled" data-level="4.1" id="font-subset-info"><span class="secno">4.1. </span><span class="content">Font Subset</span><a class="self-link" href="#font-subset-info"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-subset">font subset</dfn> is a modified version of a font file that contains only the data needed to
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-subset">font subset</dfn> is a modified version of a font file <a data-link-type="biblio" href="#biblio-iso14496-22" title="Information technology — Coding of audio-visual objects — Part 22: Open Font Format">[iso14496-22]</a>that contains only the data needed to
 render a subset of:</p>
    <ul>
     <li data-md>
      <p>the codepoints,</p>
     <li data-md>
-     <p><a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout
-features</a>,</p>
+     <p><a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout features</a>,</p>
     <li data-md>
      <p>and <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a>.</p>
    </ul>
-   <p>supported by the original font. <span class="conform client server" id="conform-font-subset"> When a subsetted font is used to render text using any combination of the subset codepoints, <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">layout features</a>,
-or <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a> it must render identically to the original font. This includes rendering with
+   <p>supported by the original font. <span class="conform client server" id="conform-font-subset"> When a subsetted font is used to render text using any combination of the subset codepoints, <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout features</a>, or <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a> it must render identically to the original font. This includes rendering with
 the use of any optional typographic features that a renderer may choose to use from the original font,
 such as hinting instructions. </span></p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-subset-definition">font subset definition</dfn> describes the minimum data (codepoints, layout features,
 variation axis space) that a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①">font subset</a> must possess.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> For convenience the remainder of this document links to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">[open-type]</a> specification which is a copy of <a data-link-type="biblio" href="#biblio-iso14496-22" title="Information technology — Coding of audio-visual objects — Part 22: Open Font Format">[iso14496-22]</a>.</p>
    <h3 class="heading settled" data-level="4.2" id="data-types"><span class="secno">4.2. </span><span class="content">Data Types</span><a class="self-link" href="#data-types"></a></h3>
    <p>This section lists all of the data types that are used to form the request and response messages
 sent between the client and server.</p>
@@ -1391,7 +1390,7 @@ bytes = [03 07 03 81 7F]
 </pre>
    </div>
    <h4 class="heading settled" data-level="4.2.7" id="featuretagset-object"><span class="secno">4.2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="featuretagset">FeatureTagSet</dfn></span><a class="self-link" href="#featuretagset-object"></a></h4>
-   <p>A FeatureTagSet encodes a set of zero or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>. To encode
+   <p>A FeatureTagSet encodes a set of zero or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">OpenType layout feature tags</a>. To encode
 a set of feature tags:</p>
    <ol>
     <li data-md>
@@ -1420,8 +1419,9 @@ the sorted list as a <a data-link-type="dfn" href="#sortedintegerlist" id="ref-f
    <p>When decoding a FeatureTagSet the integer values are mapped back to the original tags by reversing
 the above encoding rules.</p>
    <h4 class="heading settled" data-level="4.2.8" id="AxisSpace"><span class="secno">4.2.8. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="axisspace">AxisSpace</dfn></span><a class="self-link" href="#AxisSpace"></a></h4>
-   <p>Stores a set of intervals on one or more open type variation axes <a data-link-type="biblio" href="#biblio-opentype-variations" title="OpenType Font Variations Overview">[opentype-variations]</a>.
-Encoded as a CBOR map (major type 5). The key in each pair is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord"> axis tag</a>. It is encoded as a <a data-link-type="dfn" href="#bytestring" id="ref-for-bytestring⑤">ByteString</a> containing exactly 4 ASCII characters. The value in each
+   <p>Stores a set of intervals on one or more open type variation axes <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#">OpenType Specification § otvaroverview#</a>.
+Encoded as a CBOR map (major type 5). The key in each pair is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord">axis tag</a>. It is
+encoded as a <a data-link-type="dfn" href="#bytestring" id="ref-for-bytestring⑤">ByteString</a> containing exactly 4 ASCII characters. The value in each
 pair is an <a data-link-type="dfn" href="#arrayof" id="ref-for-arrayof">ArrayOf</a>&lt;<a data-link-type="dfn" href="#axisinterval" id="ref-for-axisinterval">AxisInterval</a>>. <span class="conform client server" id="conform-axis-space-disjoint">The list of intervals for a
 each axis tag must be disjoint.</span></p>
    <h4 class="heading settled" data-level="4.2.9" id="objects"><span class="secno">4.2.9. </span><span class="content">Objects</span><a class="self-link" href="#objects"></a></h4>
@@ -1619,8 +1619,8 @@ can be cached, or null.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>If <var>font subset</var> is set then load the <var>client state</var> from the <var>font subset</var>. Client state is stored in the <var>font subset</var> as a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag 'IFTP'. The contents of the table are a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate">ClientState</a> object
-encoded via CBOR.</p>
+     <p>If <var>font subset</var> is set then load the <var>client state</var> from the <var>font subset</var>. Client state is stored in the <var>font subset</var> as a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag 'IFTP'. The contents of the table are a
+single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate">ClientState</a> object encoded via CBOR.</p>
      <ul>
       <li data-md>
        <p>If <var>font subset</var> does not have an "IFTP" table, then this is not an incrementally
@@ -1662,7 +1662,7 @@ encoded via CBOR.</p>
       <li data-md>
        <p>Otherwise if <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method②">method</a> is "GET" then, a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header①">header</a> with name <code>Font-Patch-Request</code> (the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="patch-request-header">patch request header</dfn>)
  and whose value is a single <a data-link-type="dfn" href="#patchrequest" id="ref-for-patchrequest②">PatchRequest</a> object encoded via CBOR and then
- base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648" title="The Base16, Base32, and Base64 Data Encodings">[rfc4648]</a> must be added to the request’s header list.</p>
+base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648" title="The Base16, Base32, and Base64 Data Encodings">[rfc4648]</a> must be added to the request’s header list.</p>
      </ul>
      <p>Any request and/or url parameters which are not specified here should be set based on
  the user agent’s normal handling for font requests. For example if this font load is
@@ -1689,7 +1689,7 @@ encoded via CBOR.</p>
  The codepoint values are transformed to indices by applying the <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> specified by <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑤">codepoint_ordering</a> to each codepoint value. If
  the <var>client state</var> is not available or it does not have a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑥">codepoint_ordering</a> then this field should not be set.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags"> OpenType layout feature tags</a> that the current <var>font subset</var> has data
+       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">OpenType layout feature tags</a> that the current <var>font subset</var> has data
  for. If the current <var>font subset</var> is not set then this
  field is left unset. Additionally, if the current <var>font subset</var> has all
  data for features present in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font">original font</a> then this field can be unset.</p>
@@ -1764,7 +1764,7 @@ can be cached, or null.</p>
  the input <var>font subset</var> will be used as the source file for the decoding operation. The
  decoded response is the new <var>extended font subset</var>.</p>
     <li data-md>
-     <p>Load the <var>client state</var> from the <var>extended font subset</var>. Client state is stored in the <var>extended font subset</var> as a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag 'IFTP'. The contents of the table are a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate①">ClientState</a> object
+     <p>Load the <var>client state</var> from the <var>extended font subset</var>. Client state is stored in the <var>extended font subset</var> as a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag 'IFTP'. The contents of the table are a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate①">ClientState</a> object
 encoded via CBOR.</p>
     <li data-md>
      <p>If a <var>client state</var> table is not present then this is the full font and no further augmentation
@@ -1930,7 +1930,7 @@ that collection that a patch is desired for. The identified font is referred to 
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> the request may optionally set <a data-link-type="dfn" href="#patchrequest-codepoint_ordering" id="ref-for-patchrequest-codepoint_ordering①">codepoint_ordering</a> which is used by the client to
 provide the exact codepoint ordering that was used to encode <a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have⑥">indices_have</a> and <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed⑤">indices_needed</a>.</p>
-   <p>Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>:</p>
+   <p>Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">OpenType layout feature tags</a>:</p>
    <ol>
     <li data-md>
      <p>Feature tags the client’s subset has: specified by <a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have①">features_have</a>. If the field is
@@ -1967,8 +1967,7 @@ the union of the set of features needed and the sets of features the client alre
 space that covers at least the union of the axis space the client has and the axis space the
 client needs.</span></p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-client-state">That has a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> which is identified by the tag 'IFTP' whose content is a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate③">ClientState</a> object encoded via
-CBOR:</span></p>
+     <p><span class="conform server" id="conform-response-client-state">That has a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> which is identified by the tag 'IFTP' whose content is a single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate③">ClientState</a> object encoded via CBOR:</span></p>
      <ul>
       <li data-md>
        <p><span class="conform server" id="conform-response-client-state-original-checksum">The <a data-link-type="dfn" href="#clientstate-original_font_checksum" id="ref-for-clientstate-original_font_checksum①">original_font_checksum</a> field must be set to the checksum of the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font⑨">original font</a> computed by the procedure in <a href="#computing-checksums">§ 4.6 Computing Checksums</a>.</span></p>
@@ -1980,8 +1979,7 @@ CBOR:</span></p>
        <p><span class="conform server" id="conform-response-client-state-original-axis-space"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①①">original font</a> has variation axes, the <a data-link-type="dfn" href="#clientstate-original_axis_space" id="ref-for-clientstate-original_axis_space">original_axis_space</a> field must be set to the axis space covered by
  the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①②">original font</a>.</span></p>
       <li data-md>
-       <p><span class="conform server" id="conform-response-client-state-original-features"> The <a data-link-type="dfn" href="#clientstate-original_features" id="ref-for-clientstate-original_features">original_features</a> field must be set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout
-feature tags</a> that the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①③">original font</a> has data for.</span></p>
+       <p><span class="conform server" id="conform-response-client-state-original-features"> The <a data-link-type="dfn" href="#clientstate-original_features" id="ref-for-clientstate-original_features">original_features</a> field must be set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">OpenType layout feature tags</a> that the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①③">original font</a> has data for.</span></p>
       <li data-md>
        <p><span class="conform server" id="conform-response-client-state-missing-codepoints"> The <a data-link-type="dfn" href="#clientstate-missing_codepoints" id="ref-for-clientstate-missing_codepoints③">missing_codepoints</a> field must be set to the list of codepoints
 in that are in the set of codepoints needed or the set of codepoints the client has,
@@ -2170,11 +2168,12 @@ cache resources keyed by the site domain, this will limit checksum availability 
 them from being used for tracking.</p>
    <h3 class="heading settled" id="per-origin"><span class="content">Per-origin restriction avoids fingerprinting</span><a class="self-link" href="#per-origin"></a></h3>
    <p>As required by <a data-link-type="biblio" href="#biblio-css-fonts-4" title="CSS Fonts Module Level 4">[css-fonts-4]</a>,
-  Web Fonts <a href="https://drafts.csswg.org/css-fonts-4/#web-fonts">must not be accessible
+  Web Fonts <a href="https://www.w3.org/TR/css-fonts-4/#web-fonts">must not be accessible
   in any other Document from the one which either is associated with the @font-face rule
-  or owns the FontFaceSet.
-  Other applications on the device must not be able to access Web Fonts.</a> This avoids information leaking across origins.</p>
-   <p>Similarly, font palette values <a href="https://drafts.csswg.org/css-fonts-4/#font-palette-values">must only be available to the documents that
+  or owns the FontFaceSet</a>.
+  Other applications on the device must not be able to access Web Fonts.
+  This avoids information leaking across origins.</p>
+   <p>Similarly, font palette values <a href="https://www.w3.org/TR/css-fonts-4/#font-palette-values">must only be available to the documents that
   reference it</a>. Using an author-defined color palette outside of the documents that reference it
   would constitute a security leak since the contents of one page
   would be able to affect other pages,
@@ -2223,9 +2222,9 @@ them from being used for tracking.</p>
 was assembled from several sources:</p>
    <ul>
     <li data-md>
-     <p>Includes all features listed in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist">OpenType layout feature registry</a>.</p>
+     <p>Includes all features listed in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist#">OpenType layout feature registry</a>.</p>
     <li data-md>
-     <p>The value of "Encode If" is set to "not needed" for all features which are listed as "default on" in <a href="https://tiro.com/John/Enabling_Typography_(OTL).pdf">Enabling Typography</a> or are in the
+     <p>The value of "Encode If" is set to "not needed" for all features which are listed as "default on" in <a data-link-type="biblio" href="#biblio-enabling-typography" title="Enabling Typography: towards a general model of OpenType Layout">[enabling-typography]</a> or are in the
 default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz
 subsetter</a>.</p>
    </ul>
@@ -3002,12 +3001,20 @@ introduce additional versions and a mechanism for the server to inform the clien
    <dd>ztanml. <a href="https://github.com/ztanml/fast-hash"><cite>fast-hash</cite></a>. 22 October 2018. Note. URL: <a href="https://github.com/ztanml/fast-hash">https://github.com/ztanml/fast-hash</a>
    <dt id="biblio-fetch">[FETCH]
    <dd><a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. 22 May 2023. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-iso14496-22">[ISO14496-22]
+   <dd><a href="https://www.iso.org/standard/74461.html"><cite>Information technology — Coding of audio-visual objects — Part 22: Open Font Format</cite></a>. January 2019. Published. URL: <a href="https://www.iso.org/standard/74461.html">https://www.iso.org/standard/74461.html</a>
+   <dt id="biblio-open-type">[OPEN-TYPE]
+   <dd><a href="https://docs.microsoft.com/en-us/typography/opentype/spec"><cite>OpenType Specification</cite></a>. December 2021. Note. URL: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec">https://docs.microsoft.com/en-us/typography/opentype/spec</a>
    <dt id="biblio-pfe-report">[PFE-report]
    <dd>Chris Lilley. <a href="https://www.w3.org/TR/PFE-evaluation/"><cite>Progressive Font Enrichment: Evaluation Report</cite></a>. 15 October 2020. Note. URL: <a href="https://www.w3.org/TR/PFE-evaluation/">https://www.w3.org/TR/PFE-evaluation/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-rfc3284">[RFC3284]
    <dd>D. Korn; et al. <a href="https://www.rfc-editor.org/rfc/rfc3284"><cite>The VCDIFF Generic Differencing and Compression Data Format</cite></a>. June 2002. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3284">https://www.rfc-editor.org/rfc/rfc3284</a>
+   <dt id="biblio-rfc3629">[RFC3629]
+   <dd>F. Yergeau. <a href="https://www.rfc-editor.org/rfc/rfc3629"><cite>UTF-8, a transformation format of ISO 10646</cite></a>. November 2003. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3629">https://www.rfc-editor.org/rfc/rfc3629</a>
+   <dt id="biblio-rfc4648">[RFC4648]
+   <dd>S. Josefsson. <a href="https://www.rfc-editor.org/rfc/rfc4648"><cite>The Base16, Base32, and Base64 Data Encodings</cite></a>. October 2006. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc4648">https://www.rfc-editor.org/rfc/rfc4648</a>
    <dt id="biblio-rfc7932">[RFC7932]
    <dd>J. Alakuijala; Z. Szabadka. <a href="https://www.rfc-editor.org/rfc/rfc7932"><cite>Brotli Compressed Data Format</cite></a>. July 2016. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc7932">https://www.rfc-editor.org/rfc/rfc7932</a>
    <dt id="biblio-rfc8081">[RFC8081]
@@ -3027,16 +3034,12 @@ introduce additional versions and a mechanism for the server to inform the clien
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
+   <dt id="biblio-enabling-typography">[ENABLING-TYPOGRAPHY]
+   <dd>John Hudson. <a href="https://tiro.com/John/Enabling_Typography_(OTL).pdf"><cite>Enabling Typography: towards a general model of OpenType Layout</cite></a>. April 15th, 2014. Note. URL: <a href="https://tiro.com/John/Enabling_Typography_(OTL).pdf">https://tiro.com/John/Enabling_Typography_(OTL).pdf</a>
    <dt id="biblio-fips-180-4">[FIPS-180-4]
    <dd><a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf"><cite>FIPS PUB 180-4: Secure Hash Standard (SHS)</cite></a>. August 2015. National Standard. URL: <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf</a>
-   <dt id="biblio-opentype-variations">[OPENTYPE-VARIATIONS]
-   <dd><a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview"><cite>OpenType Font Variations Overview</cite></a>. 23 October 2020. Note. URL: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview">https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview</a>
    <dt id="biblio-rangerequest">[RangeRequest]
    <dd>Chris Lilley; Garret Rieger; Myles Maxfield. <a href="https://www.w3.org/TR/RangeRequest/"><cite>Range Request Incremental Font Transfer</cite></a>. 30 May 2023. WD. URL: <a href="https://www.w3.org/TR/RangeRequest/">https://www.w3.org/TR/RangeRequest/</a>
-   <dt id="biblio-rfc3629">[RFC3629]
-   <dd>F. Yergeau. <a href="https://www.rfc-editor.org/rfc/rfc3629"><cite>UTF-8, a transformation format of ISO 10646</cite></a>. November 2003. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3629">https://www.rfc-editor.org/rfc/rfc3629</a>
-   <dt id="biblio-rfc4648">[RFC4648]
-   <dd>S. Josefsson. <a href="https://www.rfc-editor.org/rfc/rfc4648"><cite>The Base16, Base32, and Base64 Data Encodings</cite></a>. October 2006. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc4648">https://www.rfc-editor.org/rfc/rfc4648</a>
    <dt id="biblio-woff2">[WOFF2]
    <dd>Vladimir Levantovsky; Raph Levien. <a href="https://www.w3.org/TR/WOFF2/"><cite>WOFF File Format 2.0</cite></a>. 10 March 2022. REC. URL: <a href="https://www.w3.org/TR/WOFF2/">https://www.w3.org/TR/WOFF2/</a>
   </dl>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="81a63e1ebfb53c453292ec6db64a743992c07c48" name="document-revision">
+  <meta content="bbe3035cfb59b95c8650af0984926a07d11f1f14" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -2228,9 +2228,25 @@ was assembled from several sources:</p>
 default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz
 subsetter</a>.</p>
    </ul>
-   <p>The entries in this table are versioned (by the Encoding Version column) since the client and server need to agree on
-the encoding. Currently there is only one version, 1, which is used by default. Future specification updates may
-introduce additional versions and a mechanism for the server to inform the client up to which version it supports.</p>
+   <p>The columns should be interpreted as follows:</p>
+   <ul>
+    <li data-md>
+     <p>Tag: the 4 byte tag for this feature from <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist#">OpenType Specification § featurelist#</a>.</p>
+    <li data-md>
+     <p>Encoded As: the integer ID used to represent this feature in a <a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset④">FeatureTagSet</a>.</p>
+    <li data-md>
+     <p>Encode If: entries marked as "not needed" are assumed to be in a <a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset⑤">FeatureTagSet</a> by default. Including their
+encoding ID in a <a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset⑥">FeatureTagSet</a> removes the feature from the set. Entries marked as "needed" are not included
+by default.</p>
+    <li data-md>
+     <p>Encoding Version: the entries in this table are versioned (by the Encoding Version column) since the client and
+server need to agree on the encoding. Currently there is only one version, 1, which is used by default. Future
+specification updates may introduce additional versions and a mechanism for the server to inform the client up to
+which version it supports.</p>
+   </ul>
+   <p class="note" role="note"><span class="marker">Note:</span> the set of features selected to be included by default is purely an optimization mechanism and should not be
+used by clients as a guide for which features they should be asking for in requests. To minimize the number of bytes
+loaded clients should only request features that are needed for the rendering of the content used by the font.</p>
    <table>
     <tbody>
      <tr>
@@ -3375,7 +3391,7 @@ window.dfnpanelData['sparsebitset'] = {"dfnID": "sparsebitset", "url": "#sparseb
 window.dfnpanelData['integerlist'] = {"dfnID": "integerlist", "url": "#integerlist", "dfnText": "IntegerList", "refSections": [{"refs": [{"id": "ref-for-integerlist"}], "title": "4.2.4. IntegerList"}, {"refs": [{"id": "ref-for-integerlist\u2460"}, {"id": "ref-for-integerlist\u2461"}], "title": "4.2.5. SortedIntegerList"}, {"refs": [{"id": "ref-for-integerlist\u2462"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-integerlist\u2463"}], "title": "4.3.4. ClientState"}, {"refs": [{"id": "ref-for-integerlist\u2464"}], "title": "4.7. Codepoint Reordering"}], "external": false};
 window.dfnpanelData['sortedintegerlist'] = {"dfnID": "sortedintegerlist", "url": "#sortedintegerlist", "dfnText": "SortedIntegerList", "refSections": [{"refs": [{"id": "ref-for-sortedintegerlist"}], "title": "4.2.5. SortedIntegerList"}, {"refs": [{"id": "ref-for-sortedintegerlist\u2460"}], "title": "4.2.6. RangeList"}, {"refs": [{"id": "ref-for-sortedintegerlist\u2461"}], "title": "4.2.7. FeatureTagSet"}], "external": false};
 window.dfnpanelData['rangelist'] = {"dfnID": "rangelist", "url": "#rangelist", "dfnText": "RangeList", "refSections": [{"refs": [{"id": "ref-for-rangelist"}, {"id": "ref-for-rangelist\u2460"}], "title": "4.3.1. CompressedSet"}], "external": false};
-window.dfnpanelData['featuretagset'] = {"dfnID": "featuretagset", "url": "#featuretagset", "dfnText": "FeatureTagSet", "refSections": [{"refs": [{"id": "ref-for-featuretagset"}, {"id": "ref-for-featuretagset\u2460"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-featuretagset\u2461"}], "title": "4.3.4. ClientState"}, {"refs": [{"id": "ref-for-featuretagset\u2462"}], "title": "\nAppendix A: Default Feature Tags and Encoding IDs"}], "external": false};
+window.dfnpanelData['featuretagset'] = {"dfnID": "featuretagset", "url": "#featuretagset", "dfnText": "FeatureTagSet", "refSections": [{"refs": [{"id": "ref-for-featuretagset"}, {"id": "ref-for-featuretagset\u2460"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-featuretagset\u2461"}], "title": "4.3.4. ClientState"}, {"refs": [{"id": "ref-for-featuretagset\u2462"}, {"id": "ref-for-featuretagset\u2463"}, {"id": "ref-for-featuretagset\u2464"}, {"id": "ref-for-featuretagset\u2465"}], "title": "\nAppendix A: Default Feature Tags and Encoding IDs"}], "external": false};
 window.dfnpanelData['axisspace'] = {"dfnID": "axisspace", "url": "#axisspace", "dfnText": "AxisSpace", "refSections": [{"refs": [{"id": "ref-for-axisspace"}, {"id": "ref-for-axisspace\u2460"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-axisspace\u2461"}, {"id": "ref-for-axisspace\u2462"}], "title": "4.3.4. ClientState"}], "external": false};
 window.dfnpanelData['compressedset'] = {"dfnID": "compressedset", "url": "#compressedset", "dfnText": "CompressedSet", "refSections": [{"refs": [{"id": "ref-for-compressedset"}, {"id": "ref-for-compressedset\u2460"}, {"id": "ref-for-compressedset\u2461"}, {"id": "ref-for-compressedset\u2462"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-compressedset\u2463"}], "title": "4.3.4. ClientState"}], "external": false};
 window.dfnpanelData['compressedset-sparse_bit_set'] = {"dfnID": "compressedset-sparse_bit_set", "url": "#compressedset-sparse_bit_set", "dfnText": "sparse_bit_set", "refSections": [{"refs": [{"id": "ref-for-compressedset-sparse_bit_set"}], "title": "4.3.1. CompressedSet"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="6955076d76752714eebb2297404f0857c9f10235" name="document-revision">
+  <meta content="035d0d8cc55bf4c9ac771afb7605c1e1ad1a7243" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -1390,7 +1390,7 @@ bytes = [03 07 03 81 7F]
 </pre>
    </div>
    <h4 class="heading settled" data-level="4.2.7" id="featuretagset-object"><span class="secno">4.2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="featuretagset">FeatureTagSet</dfn></span><a class="self-link" href="#featuretagset-object"></a></h4>
-   <p>A FeatureTagSet encodes a set of zero or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">OpenType layout feature tags</a>. To encode
+   <p>A FeatureTagSet encodes a set of zero or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout feature tags</a>. To encode
 a set of feature tags:</p>
    <ol>
     <li data-md>
@@ -1419,7 +1419,7 @@ the sorted list as a <a data-link-type="dfn" href="#sortedintegerlist" id="ref-f
    <p>When decoding a FeatureTagSet the integer values are mapped back to the original tags by reversing
 the above encoding rules.</p>
    <h4 class="heading settled" data-level="4.2.8" id="AxisSpace"><span class="secno">4.2.8. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="axisspace">AxisSpace</dfn></span><a class="self-link" href="#AxisSpace"></a></h4>
-   <p>Stores a set of intervals on one or more open type variation axes <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#">OpenType Specification § otvaroverview#</a>.
+   <p>Stores a set of intervals on one or more variation axes <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#">OpenType Specification § otvaroverview#</a>.
 Encoded as a CBOR map (major type 5). The key in each pair is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord">axis tag</a>. It is
 encoded as a <a data-link-type="dfn" href="#bytestring" id="ref-for-bytestring⑤">ByteString</a> containing exactly 4 ASCII characters. The value in each
 pair is an <a data-link-type="dfn" href="#arrayof" id="ref-for-arrayof">ArrayOf</a>&lt;<a data-link-type="dfn" href="#axisinterval" id="ref-for-axisinterval">AxisInterval</a>>. <span class="conform client server" id="conform-axis-space-disjoint">The list of intervals for a
@@ -1689,7 +1689,7 @@ base64url encoding <a data-link-type="biblio" href="#biblio-rfc4648" title="The 
  The codepoint values are transformed to indices by applying the <a href="#codepoint-reordering">§ 4.7 Codepoint Reordering</a> specified by <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑤">codepoint_ordering</a> to each codepoint value. If
  the <var>client state</var> is not available or it does not have a <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑥">codepoint_ordering</a> then this field should not be set.</p>
       <li data-md>
-       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">OpenType layout feature tags</a> that the current <var>font subset</var> has data
+       <p><a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have">features_have</a>: set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout feature tags</a> that the current <var>font subset</var> has data
  for. If the current <var>font subset</var> is not set then this
  field is left unset. Additionally, if the current <var>font subset</var> has all
  data for features present in the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font">original font</a> then this field can be unset.</p>
@@ -1930,7 +1930,7 @@ that collection that a patch is desired for. The identified font is referred to 
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> the request may optionally set <a data-link-type="dfn" href="#patchrequest-codepoint_ordering" id="ref-for-patchrequest-codepoint_ordering①">codepoint_ordering</a> which is used by the client to
 provide the exact codepoint ordering that was used to encode <a data-link-type="dfn" href="#patchrequest-indices_have" id="ref-for-patchrequest-indices_have⑥">indices_have</a> and <a data-link-type="dfn" href="#patchrequest-indices_needed" id="ref-for-patchrequest-indices_needed⑤">indices_needed</a>.</p>
-   <p>Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">OpenType layout feature tags</a>:</p>
+   <p>Likewise, the server can produce two sets of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout feature tags</a>:</p>
    <ol>
     <li data-md>
      <p>Feature tags the client’s subset has: specified by <a data-link-type="dfn" href="#patchrequest-features_have" id="ref-for-patchrequest-features_have①">features_have</a>. If the field is
@@ -1979,7 +1979,7 @@ client needs.</span></p>
        <p><span class="conform server" id="conform-response-client-state-original-axis-space"> If the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①①">original font</a> has variation axes, the <a data-link-type="dfn" href="#clientstate-original_axis_space" id="ref-for-clientstate-original_axis_space">original_axis_space</a> field must be set to the axis space covered by
  the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①②">original font</a>.</span></p>
       <li data-md>
-       <p><span class="conform server" id="conform-response-client-state-original-features"> The <a data-link-type="dfn" href="#clientstate-original_features" id="ref-for-clientstate-original_features">original_features</a> field must be set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">OpenType layout feature tags</a> that the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①③">original font</a> has data for.</span></p>
+       <p><span class="conform server" id="conform-response-client-state-original-features"> The <a data-link-type="dfn" href="#clientstate-original_features" id="ref-for-clientstate-original_features">original_features</a> field must be set to the list of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout feature tags</a> that the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font①③">original font</a> has data for.</span></p>
       <li data-md>
        <p><span class="conform server" id="conform-response-client-state-missing-codepoints"> The <a data-link-type="dfn" href="#clientstate-missing_codepoints" id="ref-for-clientstate-missing_codepoints③">missing_codepoints</a> field must be set to the list of codepoints
 in that are in the set of codepoints needed or the set of codepoints the client has,
@@ -2222,7 +2222,7 @@ them from being used for tracking.</p>
 was assembled from several sources:</p>
    <ul>
     <li data-md>
-     <p>Includes all features listed in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist#">OpenType layout feature registry</a>.</p>
+     <p>Includes all features listed in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist#">layout feature registry</a>.</p>
     <li data-md>
      <p>The value of "Encode If" is set to "not needed" for all features which are listed as "default on" in <a data-link-type="biblio" href="#biblio-enabling-typography" title="Enabling Typography: towards a general model of OpenType Layout">[enabling-typography]</a> or are in the
 default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="8cf088637d0997eb8c69a74cde8a01abf2ac39f9" name="document-revision">
+  <meta content="9568adc7983b057a92b724395456b2d06fd15cfd" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -1391,27 +1391,34 @@ bytes = [03 07 03 81 7F]
 </pre>
    </div>
    <h4 class="heading settled" data-level="4.2.7" id="featuretagset-object"><span class="secno">4.2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="featuretagset">FeatureTagSet</dfn></span><a class="self-link" href="#featuretagset-object"></a></h4>
-   <p>A FeatureTagSet encodes a set of zero or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>.
-Each feature tag is mapped to an integer value and then the set of mapped integers are encoded in a <a data-link-type="dfn" href="#sortedintegerlist" id="ref-for-sortedintegerlist②">SortedIntegerList</a>. Feature tags are mapped to integers as follows:</p>
-   <ul>
+   <p>A FeatureTagSet encodes a set of zero or more <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags">OpenType layout feature tags</a>. To encode
+a set of feature tags:</p>
+   <ol>
     <li data-md>
-     <p>If the tag is found in <a href="#feature-tag-list">Appendix A: Default Feature Tags and Encoding IDs</a>:</p>
+     <p>Union the set of feature tags to be encoded and the list of feature tags in <a href="#feature-tag-list">Appendix A: Default Feature Tags and Encoding IDs</a>. For each tag in the
+union:</p>
      <ul>
       <li data-md>
-       <p>If the "Encoded As" column corresponding to the tag is "default" then the tag is skipped and
-not encoded.</p>
+       <p>If the tag is present in the list of feature tags to be encoded, is present in <a href="#feature-tag-list">Appendix A: Default Feature Tags and Encoding IDs</a>, and
+has a value of "needed" in the "Encode If" column of <a href="#feature-tag-list">Appendix A: Default Feature Tags and Encoding IDs</a>; then add the value of "Encoded As"
+to the encoded ID list.</p>
       <li data-md>
-       <p>Else, the tag is mapped to the integer value in the "Encoded As" column.</p>
+       <p>If the tag is not present in the list of feature tags to be encoded, is present in <a href="#feature-tag-list">Appendix A: Default Feature Tags and Encoding IDs</a>, and
+has a value of "not needed" in the "Encode If" column of <a href="#feature-tag-list">Appendix A: Default Feature Tags and Encoding IDs</a>; then add the value of "Encoded As"
+to the encoded ID list.</p>
+      <li data-md>
+       <p>If the tag is present in the list of feature tags to be encoded and is not present in <a href="#feature-tag-list">Appendix A: Default Feature Tags and Encoding IDs</a>, then
+convert the tag to  an integer by treating the tag’s 4 byte string as a 4 byte little endian integer and add that
+value to the encoded ID list.</p>
+      <li data-md>
+       <p>Otherwise, do nothing for this tag.</p>
      </ul>
     <li data-md>
-     <p>Otherwise: the tag is converted to an integer by treating the tag’s 4 byte string as a 4 byte
-little endian integer.</p>
-   </ul>
-   <p>The final encoding is produced by sorting the mapped integers (excluding tags which are skipped)
-into ascending order and then encoding the sorted list as a <a data-link-type="dfn" href="#sortedintegerlist" id="ref-for-sortedintegerlist③">SortedIntegerList</a>.</p>
+     <p>The final encoding is produced by sorting the encoded ID list produced in step 1 into ascending order and then encoding
+the sorted list as a <a data-link-type="dfn" href="#sortedintegerlist" id="ref-for-sortedintegerlist②">SortedIntegerList</a>.</p>
+   </ol>
    <p>When decoding a FeatureTagSet the integer values are mapped back to the original tags by reversing
-the above mapping rules. <span class="conform server client" id="conform-feature-tag-set-defaults">Additionally all
-default features in <a href="#feature-tag-list">Appendix A: Default Feature Tags and Encoding IDs</a> must be added to the decoded set.</span></p>
+the above encoding rules.</p>
    <h4 class="heading settled" data-level="4.2.8" id="AxisSpace"><span class="secno">4.2.8. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="axisspace">AxisSpace</dfn></span><a class="self-link" href="#AxisSpace"></a></h4>
    <p>Stores a set of intervals on one or more open type variation axes <a data-link-type="biblio" href="#biblio-opentype-variations" title="OpenType Font Variations Overview">[opentype-variations]</a>.
 Encoded as a CBOR map (major type 5). The key in each pair is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/fvar#variationaxisrecord"> axis tag</a>. It is encoded as a <a data-link-type="dfn" href="#bytestring" id="ref-for-bytestring⑤">ByteString</a> containing exactly 4 ASCII characters. The value in each
@@ -2212,386 +2219,521 @@ them from being used for tracking.</p>
     <li>Made HTTP RFC references more specific
    </ul>
    <h2 class="heading settled" id="feature-tag-list"><span class="content"> Appendix A: Default Feature Tags and Encoding IDs</span><a class="self-link" href="#feature-tag-list"></a></h2>
+   <p>This appendix is normative. It lists the IDs used to encode feature tags into a <a data-link-type="dfn" href="#featuretagset" id="ref-for-featuretagset③">FeatureTagSet</a>. This table
+was assembled from several sources:</p>
+   <ul>
+    <li data-md>
+     <p>Includes all features listed in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist">OpenType layout feature registry</a>.</p>
+    <li data-md>
+     <p>The value of "Encode If" is set to "not needed" for all features which are listed as "default on" in <a href="https://tiro.com/John/Enabling_Typography_(OTL).pdf">Enabling Typography</a> or are in the
+default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz
+subsetter</a>.</p>
+   </ul>
    <table>
     <tbody>
      <tr>
       <th>Tag
       <th>Encoded As
+      <th>Encode If
      <tr>
       <td>aalt
       <td>1
+      <td>needed
      <tr>
       <td>abvf
-      <td>default
+      <td>2
+      <td>not needed
      <tr>
       <td>abvm
-      <td>default
+      <td>3
+      <td>not needed
      <tr>
       <td>abvs
-      <td>default
+      <td>4
+      <td>not needed
      <tr>
       <td>afrc
-      <td>2
+      <td>5
+      <td>needed
      <tr>
       <td>akhn
-      <td>default
+      <td>6
+      <td>not needed
      <tr>
       <td>blwf
-      <td>default
+      <td>7
+      <td>not needed
      <tr>
       <td>blwm
-      <td>default
+      <td>8
+      <td>not needed
      <tr>
       <td>blws
-      <td>default
+      <td>9
+      <td>not needed
      <tr>
       <td>calt
-      <td>default
+      <td>10
+      <td>not needed
      <tr>
       <td>case
-      <td>3
+      <td>11
+      <td>needed
      <tr>
       <td>ccmp
-      <td>default
+      <td>12
+      <td>not needed
      <tr>
       <td>cfar
-      <td>default
+      <td>13
+      <td>not needed
      <tr>
       <td>chws
-      <td>default
+      <td>14
+      <td>not needed
      <tr>
       <td>cjct
-      <td>default
+      <td>15
+      <td>not needed
      <tr>
       <td>clig
-      <td>default
+      <td>16
+      <td>not needed
      <tr>
       <td>cpct
-      <td>4
+      <td>17
+      <td>needed
      <tr>
       <td>cpsp
-      <td>5
+      <td>18
+      <td>needed
      <tr>
       <td>cswh
-      <td>default
+      <td>19
+      <td>not needed
      <tr>
       <td>curs
-      <td>default
+      <td>20
+      <td>not needed
      <tr>
       <td>cv01-cv99
-      <td>6-104
+      <td>21-119
+      <td>needed
      <tr>
       <td>c2pc
-      <td>105
+      <td>120
+      <td>needed
      <tr>
       <td>c2sc
-      <td>106
+      <td>121
+      <td>needed
      <tr>
       <td>dist
-      <td>default
+      <td>122
+      <td>not needed
      <tr>
       <td>dlig
-      <td>107
+      <td>123
+      <td>needed
      <tr>
       <td>dnom
-      <td>default
+      <td>124
+      <td>not needed
      <tr>
       <td>dtls
-      <td>default
+      <td>125
+      <td>not needed
      <tr>
       <td>expt
-      <td>108
+      <td>126
+      <td>needed
      <tr>
       <td>falt
-      <td>109
+      <td>127
+      <td>needed
      <tr>
       <td>fin2
-      <td>default
+      <td>128
+      <td>not needed
      <tr>
       <td>fin3
-      <td>default
+      <td>129
+      <td>not needed
      <tr>
       <td>fina
-      <td>default
+      <td>130
+      <td>not needed
      <tr>
       <td>flac
-      <td>default
+      <td>131
+      <td>not needed
      <tr>
       <td>frac
-      <td>default
+      <td>132
+      <td>not needed
      <tr>
       <td>fwid
-      <td>110
+      <td>133
+      <td>needed
      <tr>
       <td>half
-      <td>default
+      <td>134
+      <td>not needed
      <tr>
       <td>haln
-      <td>default
+      <td>135
+      <td>not needed
      <tr>
       <td>halt
-      <td>111
+      <td>136
+      <td>needed
      <tr>
       <td>hist
-      <td>112
+      <td>137
+      <td>needed
      <tr>
       <td>hkna
-      <td>113
+      <td>138
+      <td>needed
      <tr>
       <td>hlig
-      <td>114
+      <td>139
+      <td>needed
      <tr>
       <td>hngl
-      <td>115
+      <td>140
+      <td>needed
      <tr>
       <td>hojo
-      <td>116
+      <td>141
+      <td>needed
      <tr>
       <td>hwid
-      <td>117
+      <td>142
+      <td>needed
      <tr>
       <td>init
-      <td>default
+      <td>143
+      <td>not needed
      <tr>
       <td>isol
-      <td>default
+      <td>144
+      <td>not needed
      <tr>
       <td>ital
-      <td>118
+      <td>145
+      <td>needed
      <tr>
       <td>jalt
-      <td>default
+      <td>146
+      <td>not needed
      <tr>
       <td>jp78
-      <td>119
+      <td>147
+      <td>needed
      <tr>
       <td>jp83
-      <td>120
+      <td>148
+      <td>needed
      <tr>
       <td>jp90
-      <td>121
+      <td>149
+      <td>needed
      <tr>
       <td>jp04
-      <td>122
+      <td>150
+      <td>needed
      <tr>
       <td>kern
-      <td>default
+      <td>151
+      <td>not needed
      <tr>
       <td>lfbd
-      <td>123
+      <td>152
+      <td>needed
      <tr>
       <td>liga
-      <td>default
+      <td>153
+      <td>not needed
      <tr>
       <td>ljmo
-      <td>default
+      <td>154
+      <td>not needed
      <tr>
       <td>lnum
-      <td>124
+      <td>155
+      <td>needed
      <tr>
       <td>locl
-      <td>default
+      <td>156
+      <td>not needed
      <tr>
       <td>ltra
-      <td>default
+      <td>157
+      <td>not needed
      <tr>
       <td>ltrm
-      <td>default
+      <td>158
+      <td>not needed
      <tr>
       <td>mark
-      <td>default
+      <td>159
+      <td>not needed
      <tr>
       <td>med2
-      <td>default
+      <td>160
+      <td>not needed
      <tr>
       <td>medi
-      <td>default
+      <td>161
+      <td>not needed
      <tr>
       <td>mgrk
-      <td>125
+      <td>162
+      <td>needed
      <tr>
       <td>mkmk
-      <td>default
+      <td>163
+      <td>not needed
      <tr>
       <td>mset
-      <td>default
+      <td>164
+      <td>not needed
      <tr>
       <td>nalt
-      <td>126
+      <td>165
+      <td>needed
      <tr>
       <td>nlck
-      <td>127
+      <td>166
+      <td>needed
      <tr>
       <td>nukt
-      <td>default
+      <td>167
+      <td>not needed
      <tr>
       <td>numr
-      <td>default
+      <td>168
+      <td>not needed
      <tr>
       <td>onum
-      <td>128
+      <td>169
+      <td>needed
      <tr>
       <td>opbd
-      <td>129
+      <td>170
+      <td>needed
      <tr>
       <td>ordn
-      <td>130
+      <td>171
+      <td>needed
      <tr>
       <td>ornm
-      <td>131
+      <td>172
+      <td>needed
      <tr>
       <td>palt
-      <td>132
+      <td>173
+      <td>needed
      <tr>
       <td>pcap
-      <td>133
+      <td>174
+      <td>needed
      <tr>
       <td>pkna
-      <td>134
+      <td>175
+      <td>needed
      <tr>
       <td>pnum
-      <td>135
+      <td>176
+      <td>needed
      <tr>
       <td>pref
-      <td>default
+      <td>177
+      <td>not needed
      <tr>
       <td>pres
-      <td>default
+      <td>178
+      <td>not needed
      <tr>
       <td>pstf
-      <td>default
+      <td>179
+      <td>not needed
      <tr>
       <td>psts
-      <td>default
+      <td>180
+      <td>not needed
      <tr>
       <td>pwid
-      <td>136
+      <td>181
+      <td>needed
      <tr>
       <td>qwid
-      <td>137
+      <td>182
+      <td>needed
      <tr>
       <td>rand
-      <td>default
+      <td>183
+      <td>not needed
      <tr>
       <td>rclt
-      <td>default
+      <td>184
+      <td>not needed
      <tr>
       <td>rkrf
-      <td>default
+      <td>185
+      <td>not needed
      <tr>
       <td>rlig
-      <td>default
+      <td>186
+      <td>not needed
      <tr>
       <td>rphf
-      <td>default
+      <td>187
+      <td>not needed
      <tr>
       <td>rtbd
-      <td>138
+      <td>188
+      <td>needed
      <tr>
       <td>rtla
-      <td>default
+      <td>189
+      <td>not needed
      <tr>
       <td>rtlm
-      <td>default
+      <td>190
+      <td>not needed
      <tr>
       <td>ruby
-      <td>139
+      <td>191
+      <td>needed
      <tr>
       <td>rvrn
-      <td>default
+      <td>192
+      <td>not needed
      <tr>
       <td>salt
-      <td>140
+      <td>193
+      <td>needed
      <tr>
       <td>sinf
-      <td>141
+      <td>194
+      <td>needed
      <tr>
       <td>size
-      <td>142
+      <td>195
+      <td>needed
      <tr>
       <td>smcp
-      <td>143
+      <td>196
+      <td>needed
      <tr>
       <td>smpl
-      <td>144
+      <td>197
+      <td>needed
      <tr>
       <td>ss01-ss20
-      <td>145-164
+      <td>198-217
+      <td>needed
      <tr>
       <td>ssty
-      <td>default
+      <td>218
+      <td>not needed
      <tr>
       <td>stch
-      <td>default
+      <td>219
+      <td>not needed
      <tr>
       <td>subs
-      <td>165
+      <td>220
+      <td>needed
      <tr>
       <td>sups
-      <td>166
+      <td>221
+      <td>needed
      <tr>
       <td>swsh
-      <td>167
+      <td>222
+      <td>needed
      <tr>
       <td>titl
-      <td>168
+      <td>223
+      <td>needed
      <tr>
       <td>tjmo
-      <td>default
+      <td>224
+      <td>not needed
      <tr>
       <td>tnam
-      <td>169
+      <td>225
+      <td>needed
      <tr>
       <td>tnum
-      <td>170
+      <td>226
+      <td>needed
      <tr>
       <td>trad
-      <td>171
+      <td>227
+      <td>needed
      <tr>
       <td>twid
-      <td>172
+      <td>228
+      <td>needed
      <tr>
       <td>unic
-      <td>173
+      <td>229
+      <td>needed
      <tr>
       <td>valt
-      <td>default
+      <td>230
+      <td>not needed
      <tr>
       <td>vatu
-      <td>default
+      <td>231
+      <td>not needed
      <tr>
       <td>vchw
-      <td>default
+      <td>232
+      <td>not needed
      <tr>
       <td>vert
-      <td>default
+      <td>233
+      <td>not needed
      <tr>
       <td>vhal
-      <td>174
+      <td>234
+      <td>needed
      <tr>
       <td>vjmo
-      <td>default
+      <td>235
+      <td>not needed
      <tr>
       <td>vkna
-      <td>175
+      <td>236
+      <td>needed
      <tr>
       <td>vkrn
-      <td>default
+      <td>237
+      <td>not needed
      <tr>
       <td>vpal
-      <td>default
+      <td>238
+      <td>not needed
      <tr>
       <td>vrt2
-      <td>default
+      <td>239
+      <td>not needed
      <tr>
       <td>vrtr
-      <td>default
+      <td>240
+      <td>not needed
      <tr>
       <td>zero
-      <td>176
+      <td>241
+      <td>needed
    </table>
    <h2 class="heading settled" id="obfuscation-codepoints"><span class="content"> Appendix B: Codepoints Requiring Obfuscation</span><a class="self-link" href="#obfuscation-codepoints"></a></h2>
-   <p>The following codepoints are considered to need obfuscation:</p>
+   <p>This appendix is normative.The following codepoints are considered to need obfuscation:</p>
    <ul>
     <li data-md>
      <p>All unicode codepoints with the <a href="https://www.unicode.org/reports/tr44/tr44-30.html#Unified_Ideograph">Unified_Ideograph</a> property.</p>
@@ -3100,9 +3242,9 @@ window.dfnpanelData['string'] = {"dfnID": "string", "url": "#string", "dfnText":
 window.dfnpanelData['arrayof'] = {"dfnID": "arrayof", "url": "#arrayof", "dfnText": "ArrayOf", "refSections": [{"refs": [{"id": "ref-for-arrayof"}], "title": "4.2.8. AxisSpace"}], "external": false};
 window.dfnpanelData['sparsebitset'] = {"dfnID": "sparsebitset", "url": "#sparsebitset", "dfnText": "SparseBitSet", "refSections": [{"refs": [{"id": "ref-for-sparsebitset"}, {"id": "ref-for-sparsebitset\u2460"}], "title": "4.3.1. CompressedSet"}], "external": false};
 window.dfnpanelData['integerlist'] = {"dfnID": "integerlist", "url": "#integerlist", "dfnText": "IntegerList", "refSections": [{"refs": [{"id": "ref-for-integerlist"}], "title": "4.2.4. IntegerList"}, {"refs": [{"id": "ref-for-integerlist\u2460"}, {"id": "ref-for-integerlist\u2461"}], "title": "4.2.5. SortedIntegerList"}, {"refs": [{"id": "ref-for-integerlist\u2462"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-integerlist\u2463"}], "title": "4.3.4. ClientState"}, {"refs": [{"id": "ref-for-integerlist\u2464"}], "title": "4.7. Codepoint Reordering"}], "external": false};
-window.dfnpanelData['sortedintegerlist'] = {"dfnID": "sortedintegerlist", "url": "#sortedintegerlist", "dfnText": "SortedIntegerList", "refSections": [{"refs": [{"id": "ref-for-sortedintegerlist"}], "title": "4.2.5. SortedIntegerList"}, {"refs": [{"id": "ref-for-sortedintegerlist\u2460"}], "title": "4.2.6. RangeList"}, {"refs": [{"id": "ref-for-sortedintegerlist\u2461"}, {"id": "ref-for-sortedintegerlist\u2462"}], "title": "4.2.7. FeatureTagSet"}], "external": false};
+window.dfnpanelData['sortedintegerlist'] = {"dfnID": "sortedintegerlist", "url": "#sortedintegerlist", "dfnText": "SortedIntegerList", "refSections": [{"refs": [{"id": "ref-for-sortedintegerlist"}], "title": "4.2.5. SortedIntegerList"}, {"refs": [{"id": "ref-for-sortedintegerlist\u2460"}], "title": "4.2.6. RangeList"}, {"refs": [{"id": "ref-for-sortedintegerlist\u2461"}], "title": "4.2.7. FeatureTagSet"}], "external": false};
 window.dfnpanelData['rangelist'] = {"dfnID": "rangelist", "url": "#rangelist", "dfnText": "RangeList", "refSections": [{"refs": [{"id": "ref-for-rangelist"}, {"id": "ref-for-rangelist\u2460"}], "title": "4.3.1. CompressedSet"}], "external": false};
-window.dfnpanelData['featuretagset'] = {"dfnID": "featuretagset", "url": "#featuretagset", "dfnText": "FeatureTagSet", "refSections": [{"refs": [{"id": "ref-for-featuretagset"}, {"id": "ref-for-featuretagset\u2460"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-featuretagset\u2461"}], "title": "4.3.4. ClientState"}], "external": false};
+window.dfnpanelData['featuretagset'] = {"dfnID": "featuretagset", "url": "#featuretagset", "dfnText": "FeatureTagSet", "refSections": [{"refs": [{"id": "ref-for-featuretagset"}, {"id": "ref-for-featuretagset\u2460"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-featuretagset\u2461"}], "title": "4.3.4. ClientState"}, {"refs": [{"id": "ref-for-featuretagset\u2462"}], "title": "\nAppendix A: Default Feature Tags and Encoding IDs"}], "external": false};
 window.dfnpanelData['axisspace'] = {"dfnID": "axisspace", "url": "#axisspace", "dfnText": "AxisSpace", "refSections": [{"refs": [{"id": "ref-for-axisspace"}, {"id": "ref-for-axisspace\u2460"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-axisspace\u2461"}, {"id": "ref-for-axisspace\u2462"}], "title": "4.3.4. ClientState"}], "external": false};
 window.dfnpanelData['compressedset'] = {"dfnID": "compressedset", "url": "#compressedset", "dfnText": "CompressedSet", "refSections": [{"refs": [{"id": "ref-for-compressedset"}, {"id": "ref-for-compressedset\u2460"}, {"id": "ref-for-compressedset\u2461"}, {"id": "ref-for-compressedset\u2462"}], "title": "4.3.3. PatchRequest"}, {"refs": [{"id": "ref-for-compressedset\u2463"}], "title": "4.3.4. ClientState"}], "external": false};
 window.dfnpanelData['compressedset-sparse_bit_set'] = {"dfnID": "compressedset-sparse_bit_set", "url": "#compressedset-sparse_bit_set", "dfnText": "sparse_bit_set", "refSections": [{"refs": [{"id": "ref-for-compressedset-sparse_bit_set"}], "title": "4.3.1. CompressedSet"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="bbe3035cfb59b95c8650af0984926a07d11f1f14" name="document-revision">
+  <meta content="6955076d76752714eebb2297404f0857c9f10235" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -2247,6 +2247,8 @@ which version it supports.</p>
    <p class="note" role="note"><span class="marker">Note:</span> the set of features selected to be included by default is purely an optimization mechanism and should not be
 used by clients as a guide for which features they should be asking for in requests. To minimize the number of bytes
 loaded clients should only request features that are needed for the rendering of the content used by the font.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> If the client does not wish to customize the loaded features, then the set of default included features provides a good starting
+point as it is the set of features which are typically used by renderers by default.</p>
    <table>
     <tbody>
      <tr>

--- a/feature-registry.csv
+++ b/feature-registry.csv
@@ -21,9 +21,10 @@
 # ssty
 #
 # Are added as default due to being required for math layout.
-# 
-# New features should be added to the bottom to not disrupt existing numbering. Additionally any newly added features
-# after the specification is published cannot have "Is Default" set to 1 or risk breaking backwards compatibility.
+#
+# The encoding is versioned since the client and server must agree on the encoding scheme used. The initial version
+# of this table is version 1 which is used by default. Any new entries after the initial publication of
+# this specification should be added after the 'VERSION_2' line.
 Tag,Name,Is Default
 aalt,Access All Alternates,0
 abvf,Above-base Forms,1
@@ -150,5 +151,5 @@ zero,Slashed Zero,0
 # these features sets are at the end to keep all of the other tag IDs close together to improve delta encoding.
 ss01-ss20,Stylistic Set 1,0
 cv01-cv99,Character Variants,0
-# Add new features below this comment. Note: new features cannot have "Is Default" set to 1 or it will break
-# backwards compatibility.
+VERSION_2
+# === add new features below this comment. ===

--- a/feature-registry.csv
+++ b/feature-registry.csv
@@ -22,7 +22,8 @@
 #
 # Are added as default due to being required for math layout.
 # 
-# New features should be added to the bottom to not disrupt existing numbering.
+# New features should be added to the bottom to not disrupt existing numbering. Additionally any newly added features
+# after the specification is published cannot have "Is Default" set to 1 or risk breaking backwards compatibility.
 Tag,Name,Is Default
 aalt,Access All Alternates,0
 abvf,Above-base Forms,1
@@ -44,7 +45,6 @@ cpct,Centered CJK Punctuation,0
 cpsp,Capital Spacing,0
 cswh,Contextual Swash,1
 curs,Cursive Positioning,1
-cv01-cv99,Character Variants,0
 c2pc,Petite Capitals From Capitals,0
 c2sc,Small Capitals From Capitals,0
 dist,Distances,1
@@ -123,7 +123,6 @@ sinf,Scientific Inferiors,0
 size,Optical size,0
 smcp,Small Capitals,0
 smpl,Simplified Forms,0
-ss01-ss20,Stylistic Set 1,0
 ssty,Math script style alternates,1
 stch,Stretching Glyph Decomposition,1
 subs,Subscript,0
@@ -148,4 +147,8 @@ vpal,Proportional Alternate Vertical Metrics,1
 vrt2,Vertical Alternates and Rotation,1
 vrtr,Vertical Alternates for Rotation,1
 zero,Slashed Zero,0
-# ===== Add new features below this line =====
+# these features sets are at the end to keep all of the other tag IDs close together to improve delta encoding.
+ss01-ss20,Stylistic Set 1,0
+cv01-cv99,Character Variants,0
+# Add new features below this comment. Note: new features cannot have "Is Default" set to 1 or it will break
+# backwards compatibility.

--- a/registry_to_html.py
+++ b/registry_to_html.py
@@ -5,26 +5,27 @@ print("<table>")
 print("  <tr><th>Tag</th><th>Encoded As</th><th>Encode If</th></tr>")
 with open("feature-registry.csv") as r:
   reader = csv.reader(r, delimiter=",")
+  lines = [row for row in reader]
   i = 1
-  for row in reader:
-    if row[0] == "Tag" or row[0].startswith("#"):
+  for is_default in [True, False]:
+    for row in lines:
+      if row[0] == "Tag" or row[0].startswith("#"):
         continue
 
+      if is_default != (int(row[2]) == 1):
+        continue
 
-    presence = "needed"
-    if int(row[2]) == 1:
-      presence = "not needed"
+      presence = "not needed" if int(row[2]) == 1 else "needed"
+      m = re.search("[a-z]{2}([0-9]{2})-[a-z]{2}([0-9]{2})", row[0])
+      if m:
+        start = i
+        end = i + (int(m.group(2)) - int(m.group(1)))
+        i += end - start + 1
+        v = f"{start}-{end}"
+      else:
+        v = i
+        i += 1
 
-    m = re.search("[a-z]{2}([0-9]{2})-[a-z]{2}([0-9]{2})", row[0])
-    if m:
-      start = i
-      end = i + (int(m.group(2)) - int(m.group(1)))
-      i += end - start + 1
-      v = f"{start}-{end}"
-    else:
-      v = i
-      i += 1
-
-    print(f"  <tr><td>{row[0]}</td><td>{v}</td><td>{presence}</td></tr>")
+      print(f"  <tr><td>{row[0]}</td><td>{v}</td><td>{presence}</td></tr>")
 
 print("</table>")

--- a/registry_to_html.py
+++ b/registry_to_html.py
@@ -2,13 +2,19 @@ import csv
 import re
 
 print("<table>")
-print("  <tr><th>Tag</th><th>Encoded As</th><th>Encode If</th></tr>")
+print("  <tr><th>Tag</th><th>Encoded As</th><th>Encode If</th><th>Encoding Version</th></tr>")
 with open("feature-registry.csv") as r:
   reader = csv.reader(r, delimiter=",")
   lines = [row for row in reader]
+
   i = 1
   for is_default in [True, False]:
+    version = 1
     for row in lines:
+      if row[0].startswith("VERSION_2"):
+        version = 2
+        continue
+
       if row[0] == "Tag" or row[0].startswith("#"):
         continue
 
@@ -26,6 +32,6 @@ with open("feature-registry.csv") as r:
         v = i
         i += 1
 
-      print(f"  <tr><td>{row[0]}</td><td>{v}</td><td>{presence}</td></tr>")
+      print(f"  <tr><td>{row[0]}</td><td>{v}</td><td>{presence}</td><td>{version}</td></tr>")
 
 print("</table>")

--- a/registry_to_html.py
+++ b/registry_to_html.py
@@ -2,7 +2,7 @@ import csv
 import re
 
 print("<table>")
-print("  <tr><th>Tag</th><th>Encoded As</th></tr>")
+print("  <tr><th>Tag</th><th>Encoded As</th><th>Encode If</th></tr>")
 with open("feature-registry.csv") as r:
   reader = csv.reader(r, delimiter=",")
   i = 1
@@ -11,19 +11,20 @@ with open("feature-registry.csv") as r:
         continue
 
 
+    presence = "needed"
     if int(row[2]) == 1:
-      v = "default"
-    else:
-      m = re.search("[a-z]{2}([0-9]{2})-[a-z]{2}([0-9]{2})", row[0])
-      if m:
-        start = i
-        end = i + (int(m.group(2)) - int(m.group(1)))
-        i += end - start + 1
-        v = f"{start}-{end}"
-      else:
-        v = i
-        i += 1
+      presence = "not needed"
 
-    print(f"  <tr><td>{row[0]}</td><td>{v}</td></tr>")
+    m = re.search("[a-z]{2}([0-9]{2})-[a-z]{2}([0-9]{2})", row[0])
+    if m:
+      start = i
+      end = i + (int(m.group(2)) - int(m.group(1)))
+      i += end - start + 1
+      v = f"{start}-{end}"
+    else:
+      v = i
+      i += 1
+
+    print(f"  <tr><td>{row[0]}</td><td>{v}</td><td>{presence}</td></tr>")
 
 print("</table>")


### PR DESCRIPTION
'default included' features can now be omitted from the set by including the ID associated with that feature. This allows the client to fully customize the feature set if the list of default included features does not match what the client's shaper is expected to require for it's current content. For example the default included 'vert' feature could be omitted if no vertical layout is being done.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/149.html" title="Last updated on Sep 7, 2023, 5:17 PM UTC (77059cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/149/9568adc...77059cd.html" title="Last updated on Sep 7, 2023, 5:17 PM UTC (77059cd)">Diff</a>