### PR TITLE
Update references to RFC9110, RFC9111 and RFC9112

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -311,14 +311,14 @@ When the particular IFT method(s) that are supported by a server are not known, 
 determine which method to use. Different clients may support different IFT methods, and different
 servers may support different IFT methods, so a negotiation occurs as such:
 
-1.  The browser makes the first request to the server using the GET HTTP method ([[rfc9110#section-9.3.1]]).
+1.  The browser makes the first request to the server using the GET HTTP method ([[rfc9110#GET]]).
      If the client prefers the [[#patch-incxfer|patch-subset method]], it sends the relevant
      [=patch request header=]. If the client prefers the range-request method, it does not send the
      header.
 
 2.  If the server receives the patch request header and wishes to honor it, the server must reply
      according to [[#handling-patch-request]]. Otherwise, the server must reply with the
-     [[RFC9110#section-14.3|Accept-Ranges]] header, if it supports HTTP Range Requests.
+     [[RFC9110#field.accept-ranges|Accept-Ranges]] header, if it supports HTTP Range Requests.
      
 3.  If the client receives a font with a
      [[open-type/otff#table-directory|table]]
@@ -1109,7 +1109,7 @@ The algorithm outputs:
 * Extended Font Subset: [=font subset=] that has been updated to cover at least the requested subset
     definition.
 
-* Cache fields: HTTP cache fields [[rfc9111#section-5]] describing how client state
+* Cache fields: HTTP cache fields [[rfc9111#header.field.definitions]] describing how client state
     can be cached, or null.
 
 The algorithm:
@@ -1153,7 +1153,7 @@ The algorithm:
 
      * The request URL [=url/path=] is set to the input <var>font URL</var> path.
 
-     * The request must include an [[rfc9110#section-12.5.3|Accept-Encoding]] header which lists
+     * The request must include an [[rfc9110#field.accept-encoding|Accept-Encoding]] header which lists
          at minimum one of the encodings from [[#patch-encodings]].
 
      * The request must include a <code>sec-available-dictionary</code> [=header=] whose value is the
@@ -1269,7 +1269,7 @@ The algorithm outputs:
 * Extended Font Subset: [=font subset=] that has been updated to cover at least the requested subset
     definition.
 
-* Cache fields: HTTP cache fields [[rfc9111#section-5]] describing how client state
+* Cache fields: HTTP cache fields [[rfc9111#header.field.definitions]] describing how client state
     can be cached, or null.
 
 The algorithm:
@@ -1279,7 +1279,7 @@ The algorithm:
      *  If it is a redirect [=status=]: follow normal redirect handling, such as
          [[fetch#http-redirect-fetch]] and then go back to step 1.
 
-     *  If [=response/status=] is [[RFC9110#section-15.5.10|409]], then the server does not recognize the codepoint ordering
+     *  If [=response/status=] is [[RFC9110#status.409|409]], then the server does not recognize the codepoint ordering
          used by the client. The client should resend the request that triggered this response but also
          set the [=PatchRequest/codepoint_ordering=] field on the request to the
          [=ClientState/codepoint_ordering=] in the client state table within <var>font subset</var>.
@@ -1288,8 +1288,8 @@ The algorithm:
          [$Handle failed font load$] and return the result.
 
 2. Decode the <var>server response</var> [=response/body=] by applying the appropriate decoding as
-     specified by the [[rfc9110#section-8.4|Content-Encoding]] header. If the
-     [[rfc9110#section-8.4|Content-Encoding]] is one of those from [[#patch-encodings]] then
+     specified by the [[rfc9110#field.content-encoding|Content-Encoding]] header. If the
+     [[rfc9110#field.content-encoding|Content-Encoding]] is one of those from [[#patch-encodings]] then
      the input <var>font subset</var> will be used as the source file for the decoding operation. The
      decoded response is the new <var>extended font subset</var>.
 
@@ -1415,7 +1415,7 @@ The algorithm:
 
      * The request [=request/cache mode=] is "only-if-cached".
 
-2.  If the request is successful and the response is "fresh" ([[RFC9111#section-4.2]])
+2.  If the request is successful and the response is "fresh" ([[RFC9111#expiration.model]])
      then invoke [$Extend the font subset$] with:
 
      *  Font url set to the input <var>font URL</var>.
@@ -1502,7 +1502,7 @@ Lastly, the server can produce two variable axis spaces:
 
 <span class="conform server" id="conform-bad-reordering">
 If the server does not recognize the codepoint ordering used by the client, it must respond
-with [=response/status=] code  [[RFC9110#section-15.5.10|409]]. This will instruct the client to resend
+with [=response/status=] code  [[RFC9110#status.409|409]]. This will instruct the client to resend
 the request including the codepoint ordering it has.
 </span>
 
@@ -1558,16 +1558,16 @@ result in an extended [=font subset=]:
 Additionally:
 
    *  The response [=response/body=] should be encoded by one of the content encodings listed
-        in the [[rfc9110#section-12.5.3|Accept-Encoding]] header of the request. When possible
+        in the [[rfc9110#field.accept-encoding|Accept-Encoding]] header of the request. When possible
         the server should utilize one of the patch based encodings from [[#patch-encodings]]. Non-patch
         based encodings should only be used where the server is unable to recreate the client's state
         in order to generate a patch against it.
 
    *  <span class="conform server" id="conform-response-vary">
-        The response must include a [[rfc9110#section-12.5.5|Vary]] [=header=] which includes
+        The response must include a [[rfc9110#field.vary|Vary]] [=header=] which includes
         at minimum <code>Accept-Encoding</code> and <code>use-sec-available-dictionary</code>.
         Additionally, if a <code>Font-Patch-Request</code> header is present on the request then the
-        [[rfc9110#section-12.5.5|Vary]] header must also include <code>Font-Patch-Request</code>.
+        [[rfc9110#field.vary|Vary]] header must also include <code>Font-Patch-Request</code>.
         </span>
 
    *  The response should set a <code>use-as-dictionary</code> [=header=] whose value is:
@@ -1590,16 +1590,16 @@ Possible error responses:
 
 *  <span class="conform server" id="conform-reject-malformed-request">
      If the request is malformed the server must instead respond with http [=response/status=] code
-      [[RFC9110#section-15.5.1|400]] to indicate an error.</span>
+      [[RFC9110#status.400|400]] to indicate an error.</span>
 
 *  If the requested font is not recognized by the server it should respond with http
-    [=response/status=] code  [[RFC9110#section-15.5.5|404]] to indicate a not found error.
+    [=response/status=] code  [[RFC9110#status.404|404]] to indicate a not found error.
 
 ### Range Request Support ### {#range-request-support}
 
 A patch subset support server must also support incremental transfer via [[#range-request-incxfer]].
 To support range request incremental transfer the patch subset server must support HTTP range requests
-([[RFC9110#section-14]]) against the font files it provides via patch subset.
+([[RFC9110#range.requests]]) against the font files it provides via patch subset.
 
 
 Computing Checksums {#computing-checksums}
@@ -1712,7 +1712,7 @@ in little endian order.
 Patch Encodings {#patch-encodings}
 ----------------------------------
 
-The following [[rfc9110#section-8.4|content encodings]] can be used to encode a target
+The following [[rfc9110#field.content-encoding|content encodings]] can be used to encode a target
 file as a patch against a source file:
 
 <table>
@@ -1817,7 +1817,7 @@ Since the <a href="https://www.w3.org/TR/2022/WD-IFT-20220628/">Working
   <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):
 
 <ul>
-  <li>Updated citations of rfc9110 and rfc9111 to use section references</li>
+  <li>Updated citations of rfc9110 and rfc9111 to use new references</li>
   <li>Update privacy section to clarify purpose of checksums</li>
   <li>Split off the range request section back into a separate document</li>
   <li>Removed PatchResponse from the specification</li>

--- a/Overview.html
+++ b/Overview.html
@@ -4,9 +4,9 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Incremental Font Transfer</title>
   <meta content="WD" name="w3c-status">
-  <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
+  <meta content="Bikeshed version 82ce88815, updated Thu Sep 7 16:33:55 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="035d0d8cc55bf4c9ac771afb7605c1e1ad1a7243" name="document-revision">
+  <meta content="513d4d4971ad2afc1ce2f2f31c7ea80f0c0ddfbc" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -517,7 +517,7 @@ a.self-link::before            { content: "¶"; }
 .heading > a.self-link::before { content: "§"; }
 dfn > a.self-link::before      { content: "#"; }
 </style>
-<style>/* Boilerplate: style-style-var-click-highlighting */
+<style>/* Boilerplate: style-var-click-highlighting */
 /*
 Colors were chosen in Lab using https://nixsensor.com/free-color-converter/
 D50 2deg illuminant, L in [0,100], a and b in [-128, 128]
@@ -555,7 +555,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
       <dt>Editor's Draft:
       <dd><a href="https://w3c.github.io/IFT/Overview.html">https://w3c.github.io/IFT/Overview.html</a>
       <dt>History:
-      <dd><a class="u-url" href="https://www.w3.org/standards/history/IFT">https://www.w3.org/standards/history/IFT</a>
+      <dd><a class="u-url" href="https://www.w3.org/standards/history/IFT/">https://www.w3.org/standards/history/IFT/</a>
       <dt>Feedback:
       <dd><span><a href="mailto:public-webfonts-wg@w3.org?subject=%5BIFT%5D%20YOUR%20TOPIC%20HERE">public-webfonts-wg@w3.org</a> with subject line “<kbd>[IFT] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webfonts-wg/" rel="discussion">archives</a>)</span>
       <dd><a href="https://github.com/w3c/PFE/issues/">GitHub</a>
@@ -567,7 +567,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
     </div>
    </details>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software" rel="license" title="W3C Software and Document License">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/copyright/software-license/" rel="license" title="W3C Software and Document License">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -585,7 +585,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   current W3C publications and the latest revision of this technical report
   can be found in the <a href="https://www.w3.org/TR/">W3C technical reports
   index at https://www.w3.org/TR/.</a></em> </p>
-   <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Working Draft using the <a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Recommendation
+   <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Working Draft using the <a href="https://www.w3.org/2023/Process-20231103/#recs-and-notes">Recommendation
       track</a>. This document is intended to become a W3C Recommendation. </p>
    <p> If you wish to make comments regarding this document, please <a href="https://github.com/w3c/PFE/issues/new">file an issue on the specification repository</a>. </p>
    <p> Publication as a Working Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. This is a draft document and may be updated, replaced or
@@ -596,7 +596,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2021/Process-20211102/" id="w3c_process_revision">2 November 2021 W3C Process Document</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2023/Process-20231103/" id="w3c_process_revision">03 November 2023 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -881,12 +881,12 @@ determine which method to use. Different clients may support different IFT metho
 servers may support different IFT methods, so a negotiation occurs as such:</p>
    <ol>
     <li data-md>
-     <p>The browser makes the first request to the server using the GET HTTP method (<a href="https://www.rfc-editor.org/rfc/rfc9110#section-9.3.1"><cite>HTTP Semantics</cite> § 9.3.1 GET</a>).
+     <p>The browser makes the first request to the server using the GET HTTP method (<a href="https://httpwg.org/specs/rfc9110.html#GET"><cite>HTTP Semantics</cite> § 9.3.1 GET</a>).
  If the client prefers the <a href="#patch-incxfer">patch-subset method</a>, it sends the relevant <a data-link-type="dfn" href="#patch-request-header" id="ref-for-patch-request-header">patch request header</a>. If the client prefers the range-request method, it does not send the
  header.</p>
     <li data-md>
      <p>If the server receives the patch request header and wishes to honor it, the server must reply
- according to <a href="#handling-patch-request">§ 4.5 Server: Responding to a PatchRequest</a>. Otherwise, the server must reply with the <a href="https://www.rfc-editor.org/rfc/rfc9110#section-14.3">Accept-Ranges</a> header, if it supports HTTP Range Requests.</p>
+ according to <a href="#handling-patch-request">§ 4.5 Server: Responding to a PatchRequest</a>. Otherwise, the server must reply with the <a href="https://httpwg.org/specs/rfc9110.html#field.accept-ranges">Accept-Ranges</a> header, if it supports HTTP Range Requests.</p>
     <li data-md>
      <p>If the client receives a font with a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by the 4-byte tag "IFTP", it commences using the patch-subset method.
  Otherwise, if the client receives the <code>Accept-Ranges: bytes</code> header, it commences
@@ -1613,7 +1613,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
      <p>Extended Font Subset: <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> that has been updated to cover at least the requested subset
 definition.</p>
     <li data-md>
-     <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#section-5"><cite>HTTP Caching</cite> § 5 Field Definitions</a> describing how client state
+     <p>Cache fields: HTTP cache fields <a href="https://httpwg.org/specs/rfc9111.html#header.field.definitions"><cite>HTTP Caching</cite> § 5 Field Definitions</a> describing how client state
 can be cached, or null.</p>
    </ul>
    <p>The algorithm:</p>
@@ -1653,7 +1653,7 @@ single <a data-link-type="dfn" href="#clientstate" id="ref-for-clientstate">Clie
       <li data-md>
        <p>The request URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-path" id="ref-for-concept-url-path">path</a> is set to the input <var>font URL</var> path.</p>
       <li data-md>
-       <p>The request must include an <a href="https://www.rfc-editor.org/rfc/rfc9110#section-12.5.3">Accept-Encoding</a> header which lists
+       <p>The request must include an <a href="https://httpwg.org/specs/rfc9110.html#field.accept-encoding">Accept-Encoding</a> header which lists
  at minimum one of the encodings from <a href="#patch-encodings">§ 4.8 Patch Encodings</a>.</p>
       <li data-md>
        <p>The request must include a <code>sec-available-dictionary</code> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header">header</a> whose value is the <a data-link-type="biblio" href="#biblio-fips-180-4" title="FIPS PUB 180-4: Secure Hash Standard (SHS)">SHA-256</a> hash of the input <var>font subset</var>.</p>
@@ -1741,7 +1741,7 @@ patch against the current font subset.</p>
      <p>Extended Font Subset: <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a> that has been updated to cover at least the requested subset
 definition.</p>
     <li data-md>
-     <p>Cache fields: HTTP cache fields <a href="https://www.rfc-editor.org/rfc/rfc9111#section-5"><cite>HTTP Caching</cite> § 5 Field Definitions</a> describing how client state
+     <p>Cache fields: HTTP cache fields <a href="https://httpwg.org/specs/rfc9111.html#header.field.definitions"><cite>HTTP Caching</cite> § 5 Field Definitions</a> describing how client state
 can be cached, or null.</p>
    </ul>
    <p>The algorithm:</p>
@@ -1752,7 +1752,7 @@ can be cached, or null.</p>
       <li data-md>
        <p>If it is a redirect <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-status" id="ref-for-concept-status">status</a>: follow normal redirect handling, such as <a href="https://fetch.spec.whatwg.org/#http-redirect-fetch"><cite>Fetch</cite> § 4.4 HTTP-redirect fetch</a> and then go back to step 1.</p>
       <li data-md>
-       <p>If <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> is <a href="https://www.rfc-editor.org/rfc/rfc9110#section-15.5.10">409</a>, then the server does not recognize the codepoint ordering
+       <p>If <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status②">status</a> is <a href="https://httpwg.org/specs/rfc9110.html#status.409">409</a>, then the server does not recognize the codepoint ordering
  used by the client. The client should resend the request that triggered this response but also
  set the <a data-link-type="dfn" href="#patchrequest-codepoint_ordering" id="ref-for-patchrequest-codepoint_ordering">codepoint_ordering</a> field on the request to the <a data-link-type="dfn" href="#clientstate-codepoint_ordering" id="ref-for-clientstate-codepoint_ordering⑧">codepoint_ordering</a> in the client state table within <var>font subset</var>.</p>
       <li data-md>
@@ -1760,7 +1760,7 @@ can be cached, or null.</p>
      </ul>
     <li data-md>
      <p>Decode the <var>server response</var> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body①">body</a> by applying the appropriate decoding as
- specified by the <a href="https://www.rfc-editor.org/rfc/rfc9110#section-8.4">Content-Encoding</a> header. If the <a href="https://www.rfc-editor.org/rfc/rfc9110#section-8.4">Content-Encoding</a> is one of those from <a href="#patch-encodings">§ 4.8 Patch Encodings</a> then
+ specified by the <a href="https://httpwg.org/specs/rfc9110.html#field.content-encoding">Content-Encoding</a> header. If the <a href="https://httpwg.org/specs/rfc9110.html#field.content-encoding">Content-Encoding</a> is one of those from <a href="#patch-encodings">§ 4.8 Patch Encodings</a> then
  the input <var>font subset</var> will be used as the source file for the decoding operation. The
  decoded response is the new <var>extended font subset</var>.</p>
     <li data-md>
@@ -1877,7 +1877,7 @@ whatever HTTP fetching algorithm the user agent supports.</p>
        <p>The request <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode" id="ref-for-concept-request-cache-mode①">cache mode</a> is "only-if-cached".</p>
      </ul>
     <li data-md>
-     <p>If the request is successful and the response is "fresh" (<a href="https://www.rfc-editor.org/rfc/rfc9111#section-4.2"><cite>HTTP Caching</cite> § 4.2 Freshness</a>)
+     <p>If the request is successful and the response is "fresh" (<a href="https://httpwg.org/specs/rfc9111.html#expiration.model"><cite>HTTP Caching</cite> § 4.2 Freshness</a>)
  then invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-the-font-subset" id="ref-for-abstract-opdef-extend-the-font-subset">Extend the font subset</a> with:</p>
      <ul>
       <li data-md>
@@ -1951,7 +1951,7 @@ provide the exact codepoint ordering that was used to encode <a data-link-type="
  interval from the <a data-link-type="dfn" href="#original-font" id="ref-for-original-font⑧">original font</a>.</p>
    </ol>
    <p><span class="conform server" id="conform-bad-reordering"> If the server does not recognize the codepoint ordering used by the client, it must respond
-with <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status④">status</a> code <a href="https://www.rfc-editor.org/rfc/rfc9110#section-15.5.10">409</a>. This will instruct the client to resend
+with <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status④">status</a> code <a href="https://httpwg.org/specs/rfc9110.html#status.409">409</a>. This will instruct the client to resend
 the request including the codepoint ordering it has. </span></p>
    <p><span class="conform server" id="conform-response-valid-patch"> Otherwise when the response is decoded by the client following the process in <a href="#handling-patch-response">§ 4.4.2 Handling Server Response</a> with an input <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> whose <a data-link-type="biblio" href="#biblio-fips-180-4" title="FIPS PUB 180-4: Secure Hash Standard (SHS)">SHA-256</a> matches the value of the <code>sec-available-dictionary</code> header if it is present, it must
 result in an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a>: </span></p>
@@ -1990,14 +1990,14 @@ and are not present in the <a data-link-type="dfn" href="#original-font" id="ref
    <ul>
     <li data-md>
      <p>The response <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-body" id="ref-for-concept-response-body②">body</a> should be encoded by one of the content encodings listed
-    in the <a href="https://www.rfc-editor.org/rfc/rfc9110#section-12.5.3">Accept-Encoding</a> header of the request. When possible
+    in the <a href="https://httpwg.org/specs/rfc9110.html#field.accept-encoding">Accept-Encoding</a> header of the request. When possible
     the server should utilize one of the patch based encodings from <a href="#patch-encodings">§ 4.8 Patch Encodings</a>. Non-patch
     based encodings should only be used where the server is unable to recreate the client’s state
     in order to generate a patch against it.</p>
     <li data-md>
-     <p><span class="conform server" id="conform-response-vary"> The response must include a <a href="https://www.rfc-editor.org/rfc/rfc9110#section-12.5.5">Vary</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header②">header</a> which includes
+     <p><span class="conform server" id="conform-response-vary"> The response must include a <a href="https://httpwg.org/specs/rfc9110.html#field.vary">Vary</a> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header②">header</a> which includes
     at minimum <code>Accept-Encoding</code> and <code>use-sec-available-dictionary</code>.
-    Additionally, if a <code>Font-Patch-Request</code> header is present on the request then the <a href="https://www.rfc-editor.org/rfc/rfc9110#section-12.5.5">Vary</a> header must also include <code>Font-Patch-Request</code>. </span></p>
+    Additionally, if a <code>Font-Patch-Request</code> header is present on the request then the <a href="https://httpwg.org/specs/rfc9110.html#field.vary">Vary</a> header must also include <code>Font-Patch-Request</code>. </span></p>
     <li data-md>
      <p>The response should set a <code>use-as-dictionary</code> <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header" id="ref-for-concept-header③">header</a> whose value is:</p>
      <p><code>match=&lt;path></code></p>
@@ -2014,14 +2014,14 @@ same client to the same server task.</p>
    <p>Possible error responses:</p>
    <ul>
     <li data-md>
-     <p><span class="conform server" id="conform-reject-malformed-request"> If the request is malformed the server must instead respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status⑤">status</a> code <a href="https://www.rfc-editor.org/rfc/rfc9110#section-15.5.1">400</a> to indicate an error.</span></p>
+     <p><span class="conform server" id="conform-reject-malformed-request"> If the request is malformed the server must instead respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status⑤">status</a> code <a href="https://httpwg.org/specs/rfc9110.html#status.400">400</a> to indicate an error.</span></p>
     <li data-md>
-     <p>If the requested font is not recognized by the server it should respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status⑥">status</a> code <a href="https://www.rfc-editor.org/rfc/rfc9110#section-15.5.5">404</a> to indicate a not found error.</p>
+     <p>If the requested font is not recognized by the server it should respond with http <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status" id="ref-for-concept-response-status⑥">status</a> code <a href="https://httpwg.org/specs/rfc9110.html#status.404">404</a> to indicate a not found error.</p>
    </ul>
    <h4 class="heading settled" data-level="4.5.1" id="range-request-support"><span class="secno">4.5.1. </span><span class="content">Range Request Support</span><a class="self-link" href="#range-request-support"></a></h4>
    <p>A patch subset support server must also support incremental transfer via <a href="#range-request-incxfer">§ 5 Range Request Incremental Transfer</a>.
 To support range request incremental transfer the patch subset server must support HTTP range requests
-(<a href="https://www.rfc-editor.org/rfc/rfc9110#section-14"><cite>HTTP Semantics</cite> §  14. Range Requests</a>) against the font files it provides via patch subset.</p>
+(<a href="https://httpwg.org/specs/rfc9110.html#range.requests"><cite>HTTP Semantics</cite> §  14. Range Requests</a>) against the font files it provides via patch subset.</p>
    <h3 class="heading settled" data-level="4.6" id="computing-checksums"><span class="secno">4.6. </span><span class="content">Computing Checksums</span><a class="self-link" href="#computing-checksums"></a></h3>
    <p>64 bit checksums of byte strings are computed using the <a data-link-type="biblio" href="#biblio-fast-hash" title="fast-hash">[fast-hash]</a> algorithm. A python like pseudo
 code version of the algorithm is presented below:</p>
@@ -2110,7 +2110,7 @@ in little endian order.</p>
     </table>
    </div>
    <h3 class="heading settled" data-level="4.8" id="patch-encodings"><span class="secno">4.8. </span><span class="content">Patch Encodings</span><a class="self-link" href="#patch-encodings"></a></h3>
-   <p>The following <a href="https://www.rfc-editor.org/rfc/rfc9110#section-8.4">content encodings</a> can be used to encode a target
+   <p>The following <a href="https://httpwg.org/specs/rfc9110.html#field.content-encoding">content encodings</a> can be used to encode a target
 file as a patch against a source file:</p>
    <table>
     <tbody>
@@ -2184,7 +2184,7 @@ them from being used for tracking.</p>
    <p>Since the <a href="https://www.w3.org/TR/2022/WD-IFT-20220628/">Working
   Draft of 28 June 2022</a> (see <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
    <ul>
-    <li>Updated citations of rfc9110 and rfc9111 to use section references
+    <li>Updated citations of rfc9110 and rfc9111 to use new references
     <li>Update privacy section to clarify purpose of checksums
     <li>Split off the range request section back into a separate document
     <li>Removed PatchResponse from the specification
@@ -2881,49 +2881,74 @@ point as it is the set of features which are typically used by renderers by defa
    <p><em>This appendix is normative.</em> The following codepoints are considered to need obfuscation:</p>
    <ul>
     <li data-md>
-     <p>All unicode codepoints with the <a href="https://www.unicode.org/reports/tr44/tr44-30.html#Unified_Ideograph">Unified_Ideograph</a> property.</p>
+     <p>All unicode codepoints with the <a href="https://www.unicode.org/reports/tr44/tr44-32.html#Unified_Ideograph">Unified_Ideograph</a> property.</p>
    </ul>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="w3c-conformance"><span class="content">Conformance</span><a class="self-link" href="#w3c-conformance"></a></h2>
    <h3 class="no-ref no-num heading settled" id="w3c-conventions"><span class="content">Document conventions</span><a class="self-link" href="#w3c-conventions"></a></h3>
    <p>Conformance requirements are expressed
+
     with a combination of descriptive assertions
+
     and RFC 2119 terminology.
+
     The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+
     in the normative parts of this document
+
     are to be interpreted as described in RFC 2119.
+
     However, for readability,
+
     these words do not appear in all uppercase letters in this specification. </p>
    <p>All of the text of this specification is normative
+
     except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">[RFC2119]</a> </p>
    <p>Examples in this specification are introduced with the words “for example”
+
     or are set apart from the normative text
+
     with <code>class="example"</code>,
+
     like this: </p>
    <div class="example" id="w3c-example">
     <a class="self-link" href="#w3c-example"></a> 
     <p>This is an example of an informative example. </p>
    </div>
    <p>Informative notes begin with the word “Note”
+
     and are set apart from the normative text
+
     with <code>class="note"</code>,
+
     like this: </p>
    <p class="note" role="note">Note, this is an informative note.</p>
    <section>
     <h3 class="no-ref no-num heading settled" id="w3c-conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#w3c-conformant-algorithms"></a></h3>
     <p>Requirements phrased in the imperative as part of algorithms
+
     (such as "strip any leading space characters"
+
     or "return false and abort these steps")
+
     are to be interpreted with the meaning of the key word
+
     ("must", "should", "may", etc)
+
     used in introducing the algorithm. </p>
     <p>Conformance requirements phrased as algorithms or specific steps
+
     can be implemented in any manner,
+
     so long as the end result is equivalent.
+
     In particular, the algorithms defined in this specification
+
     are intended to be easy to understand
+
     and are not intended to be performant.
+
     Implementers are encouraged to optimize. </p>
    </section>
   </div>
@@ -3020,7 +3045,7 @@ point as it is the set of features which are typically used by renderers by defa
    <dt id="biblio-fetch">[FETCH]
    <dd><a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. 22 May 2023. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-iso14496-22">[ISO14496-22]
-   <dd><a href="https://www.iso.org/standard/74461.html"><cite>Information technology — Coding of audio-visual objects — Part 22: Open Font Format</cite></a>. January 2019. Published. URL: <a href="https://www.iso.org/standard/74461.html">https://www.iso.org/standard/74461.html</a>
+   <dd><a href="https://www.iso.org/standard/87621.html"><cite>Information technology — Coding of audio-visual objects — Part 22: Open Font Format</cite></a>. Under development. URL: <a href="https://www.iso.org/standard/87621.html">https://www.iso.org/standard/87621.html</a>
    <dt id="biblio-open-type">[OPEN-TYPE]
    <dd><a href="https://docs.microsoft.com/en-us/typography/opentype/spec"><cite>OpenType Specification</cite></a>. December 2021. Note. URL: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec">https://docs.microsoft.com/en-us/typography/opentype/spec</a>
    <dt id="biblio-pfe-report">[PFE-report]
@@ -3040,13 +3065,13 @@ point as it is the set of features which are typically used by renderers by defa
    <dt id="biblio-rfc8949">[RFC8949]
    <dd>C. Bormann; P. Hoffman. <a href="https://www.rfc-editor.org/rfc/rfc8949"><cite>Concise Binary Object Representation (CBOR)</cite></a>. December 2020. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc8949">https://www.rfc-editor.org/rfc/rfc8949</a>
    <dt id="biblio-rfc9110">[RFC9110]
-   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9110"><cite>HTTP Semantics</cite></a>. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a>
+   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://httpwg.org/specs/rfc9110.html"><cite>HTTP Semantics</cite></a>. June 2022. Internet Standard. URL: <a href="https://httpwg.org/specs/rfc9110.html">https://httpwg.org/specs/rfc9110.html</a>
    <dt id="biblio-rfc9111">[RFC9111]
-   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9111"><cite>HTTP Caching</cite></a>. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9111">https://www.rfc-editor.org/rfc/rfc9111</a>
+   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://httpwg.org/specs/rfc9111.html"><cite>HTTP Caching</cite></a>. June 2022. Internet Standard. URL: <a href="https://httpwg.org/specs/rfc9111.html">https://httpwg.org/specs/rfc9111.html</a>
    <dt id="biblio-shared-brotli">[Shared-Brotli]
    <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2"><cite>Shared Brotli Compressed Data Format</cite></a>. 27 Jul 2021. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2</a>
    <dt id="biblio-uax44">[UAX44]
-   <dd>Ken Whistler. <a href="https://www.unicode.org/reports/tr44/tr44-30.html"><cite>Unicode Character Database</cite></a>. 2 September 2022. Unicode Standard Annex #44. URL: <a href="https://www.unicode.org/reports/tr44/tr44-30.html">https://www.unicode.org/reports/tr44/tr44-30.html</a>
+   <dd>Ken Whistler. <a href="https://www.unicode.org/reports/tr44/tr44-32.html"><cite>Unicode Character Database</cite></a>. 6 September 2023. Unicode Standard Annex #44. URL: <a href="https://www.unicode.org/reports/tr44/tr44-32.html">https://www.unicode.org/reports/tr44/tr44-32.html</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
   </dl>

--- a/RangeRequest.bs
+++ b/RangeRequest.bs
@@ -77,7 +77,7 @@ Note: There are no <code>MUST</code>-level requirements on the organization of a
 
 ### Compression ### {#font-organization-compression}
 
-Servers supporting the range-request IFT method should support compression via the <code>Content-Encoding</code> header ([[RFC9110#section-8.4]]), rather than having the font file itself be statically compressed.
+Servers supporting the range-request IFT method should support compression via the <code>Content-Encoding</code> header ([[RFC9110#field.content-encoding]]), rather than having the font file itself be statically compressed.
 
 A [=range-request optimized font=] file (the file itself) should not use any kind of compression other than [[!RFC7932]] (commonly referred to as "Brotli") compression.
 
@@ -164,13 +164,13 @@ Note: The first request does not have to be a range request. If the browser expe
 
 Once all the data before the [=range-request threshold=] has been loaded by the browser, the browser may either close this connection to the server, or it may choose to leave the connection open and let the font data continue loading in the background.
 
-A browser may choose to add a <code>Range</code> header ([[RFC9110#section-14.2]]) to the initial request during the IFT method selection if it has reason to believe the range it requests will be large enough and it prefers to not close this connection to the server.
+A browser may choose to add a <code>Range</code> header ([[RFC9110#range.specifiers]]) to the initial request during the IFT method selection if it has reason to believe the range it requests will be large enough and it prefers to not close this connection to the server.
 
 Note: Different browsers may choose different [=range-request thresholds=]. Some browsers may treat this threshold as occuring at the end of the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">sfnt tableDirectory</a>. Other browsers may treat this threshold as occurring just before any outline data, provided the outline data appears at the end of the font. Other browsers may place this threshold at the very beginning of the file, thereby treating the whole file as able to be downloaded with range-requests.
 
 ### Subsequent Requests ### {#browser-behaviors-subsequent-requests}
 
-After all the data before the [=range-request threshold=] has been loaded by the browser, the browser will determine which additional byte ranges in the file are necessary to load. It will then issue HTTP Range Requests ([[RFC9110#section-14]]) for at least those ranges.
+After all the data before the [=range-request threshold=] has been loaded by the browser, the browser will determine which additional byte ranges in the file are necessary to load. It will then issue HTTP Range Requests ([[RFC9110#range.requests]]) for at least those ranges.
 
 Note: Browsers are encouraged to coalesce range requests for nearby areas of the file, to minimize the amount of range-request overhead required. Browsers are encouraged to inform these coalescing decisions from network configuration parameters and bandwidth / latency observations.
 
@@ -181,11 +181,11 @@ Note: Another valid alternative is to treat the entire font as residing on an as
 Server Behaviors {#server-behaviors}
 ------------------------------------
 
-Servers supporting the range-request IFT method must support range requests ([[RFC9110#section-14]]).
+Servers supporting the range-request IFT method must support range requests ([[RFC9110#range.requests]]).
 
 Servers supporting the range-request IFT method should support compression via the
-<code>Content-Encoding</code> ([[RFC9110#section-8.4]]) header or the
-<code>Transfer-Encoding</code> header ([[RFC9112#section-6.1]]), rather than having the font file
+<code>Content-Encoding</code> ([[RFC9110#field.content-encoding]]) header or the
+<code>Transfer-Encoding</code> header ([[RFC9112#field.transfer-encoding]]), rather than having the font file
 itself be statically compressed.
 
 <h2 class=no-num id=priv>Privacy Considerations</h2>
@@ -203,7 +203,7 @@ Since the <a href="https://www.w3.org/TR/2022/WD-IFT-20220628/">Working
   <a href="https://github.com/w3c/IFT/commits/main/RangeRequest.bs">commit history</a>):
 
 <ul>
-  <li>Updated citations of rfc9110 and rfc9111 to use section references</li>
+  <li>Updated citations of rfc9110 and rfc9112 to use new references</li>
   <li>Split off this range request section back into a separate document</li>
 </ul>
 

--- a/RangeRequest.html
+++ b/RangeRequest.html
@@ -4,9 +4,9 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Range Request Incremental Font Transfer</title>
   <meta content="WD" name="w3c-status">
-  <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
+  <meta content="Bikeshed version 82ce88815, updated Thu Sep 7 16:33:55 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/RangeRequest/" rel="canonical">
-  <meta content="5560392ce3f07cffc89d8f01f2fcc85edf5c825d" name="document-revision">
+  <meta content="513d4d4971ad2afc1ce2f2f31c7ea80f0c0ddfbc" name="document-revision">
 <style>
     .conform:hover {background: #31668f; color: white}
     .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -481,7 +481,7 @@ dfn > a.self-link::before      { content: "#"; }
       <dt>Editor's Draft:
       <dd><a href="https://w3c.github.io/IFT/RangeRequest.html">https://w3c.github.io/IFT/RangeRequest.html</a>
       <dt>History:
-      <dd><a class="u-url" href="https://www.w3.org/standards/history/RangeRequest">https://www.w3.org/standards/history/RangeRequest</a>
+      <dd><a class="u-url" href="https://www.w3.org/standards/history/RangeRequest/">https://www.w3.org/standards/history/RangeRequest/</a>
       <dt>Feedback:
       <dd><span><a href="mailto:public-webfonts-wg@w3.org?subject=%5BRangeRequest%5D%20YOUR%20TOPIC%20HERE">public-webfonts-wg@w3.org</a> with subject line “<kbd>[RangeRequest] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webfonts-wg/" rel="discussion">archives</a>)</span>
       <dd><a href="https://github.com/w3c/PFE/issues/">GitHub</a>
@@ -494,7 +494,7 @@ dfn > a.self-link::before      { content: "#"; }
     </div>
    </details>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-software" rel="license" title="W3C Software and Document License">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/copyright/software-license/" rel="license" title="W3C Software and Document License">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -512,7 +512,7 @@ dfn > a.self-link::before      { content: "#"; }
   current W3C publications and the latest revision of this technical report
   can be found in the <a href="https://www.w3.org/TR/">W3C technical reports
   index at https://www.w3.org/TR/.</a></em> </p>
-   <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Working Draft using the <a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Recommendation
+   <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Working Draft using the <a href="https://www.w3.org/2023/Process-20231103/#recs-and-notes">Recommendation
       track</a>. This document is intended to become a W3C Recommendation. </p>
    <p> If you wish to make comments regarding this document, please <a href="https://github.com/w3c/PFE/issues/new">file an issue on the specification repository</a>. </p>
    <p> Publication as a Working Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. This is a draft document and may be updated, replaced or
@@ -523,7 +523,7 @@ dfn > a.self-link::before      { content: "#"; }
   W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2021/Process-20211102/" id="w3c_process_revision">2 November 2021 W3C Process Document</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2023/Process-20231103/" id="w3c_process_revision">03 November 2023 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -596,7 +596,7 @@ bytes are necessary, the browser makes one initial special request for the begin
    <div class="example" id="example-85584618"><a class="self-link" href="#example-85584618"></a> The result of optimizing an OpenType font for the range-request IFT method is still a valid OpenType font. The resulting file may be larger (by byte count) than it was before optimizing it, but fewer of those bytes should be necessary for a client to download in order to render a target text. </div>
    <p class="note" role="note"><span class="marker">Note:</span> There are no <code>MUST</code>-level requirements on the organization of a <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font">range-request optimized font</a>. Any arbitrary font file may be considered to be a <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font①">range-request optimized font</a>. However, additional optimizations should increase the performance of loading in a browser via the range-request IFT method. Font creators are encouraged to enact as many of the optimizations listed in this section as are reasonable for the fonts they create.</p>
    <h4 class="heading settled" data-level="1.2.3" id="font-organization-compression"><span class="secno">1.2.3. </span><span class="content">Compression</span><a class="self-link" href="#font-organization-compression"></a></h4>
-   <p>Servers supporting the range-request IFT method should support compression via the <code>Content-Encoding</code> header (<a href="https://www.rfc-editor.org/rfc/rfc9110#section-8.4"><cite>HTTP Semantics</cite> § 8.4 Content-Encoding</a>), rather than having the font file itself be statically compressed.</p>
+   <p>Servers supporting the range-request IFT method should support compression via the <code>Content-Encoding</code> header (<a href="https://httpwg.org/specs/rfc9110.html#field.content-encoding"><cite>HTTP Semantics</cite> § 8.4 Content-Encoding</a>), rather than having the font file itself be statically compressed.</p>
    <p>A <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font②">range-request optimized font</a> file (the file itself) should not use any kind of compression other than <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">[RFC7932]</a> (commonly referred to as "Brotli") compression.</p>
    <p>If Brotli compression is used in a <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font③">range-request optimized font</a>, it should use only one <a href="https://datatracker.ietf.org/doc/html/rfc7932#section-9.2">meta-block</a>.</p>
    <p>If Brotli compression is used in a <a data-link-type="dfn" href="#range-request-optimized-font" id="ref-for-range-request-optimized-font④">range-request optimized font</a>, its one meta-block should have the <a href="https://datatracker.ietf.org/doc/html/rfc7932#section-9.2"><code>ISUNCOMPRESSED</code></a> bit set to 1.</p>
@@ -645,16 +645,16 @@ which carry different types of glyph outlines:</p>
    <p>There is a certain amount of data from the beginning of the font file which the browser should unconditionally download. The boundary at the end of this data is called the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="range-request-threshold">range-request threshold</dfn>.</p>
    <p class="note" role="note"><span class="marker">Note:</span> The first request does not have to be a range request. If the browser expects the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold">range-request threshold</a> to lie within the first <code>n</code> bytes of the font, the first request may be a range request for the first <code>n</code> bytes of the font. However, a browser may instead make a non-range request, parse the data as it is being streamed from the server, and discover that it has reached the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold①">range-request threshold</a> while data is still being streamed.</p>
    <p>Once all the data before the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold②">range-request threshold</a> has been loaded by the browser, the browser may either close this connection to the server, or it may choose to leave the connection open and let the font data continue loading in the background.</p>
-   <p>A browser may choose to add a <code>Range</code> header (<a href="https://www.rfc-editor.org/rfc/rfc9110#section-14.2"><cite>HTTP Semantics</cite> § 14.2 Range</a>) to the initial request during the IFT method selection if it has reason to believe the range it requests will be large enough and it prefers to not close this connection to the server.</p>
+   <p>A browser may choose to add a <code>Range</code> header (<a href="https://httpwg.org/specs/rfc9110.html#range.specifiers"><cite>HTTP Semantics</cite> § 14.1.1 Range Specifiers</a>) to the initial request during the IFT method selection if it has reason to believe the range it requests will be large enough and it prefers to not close this connection to the server.</p>
    <p class="note" role="note"><span class="marker">Note:</span> Different browsers may choose different <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold③">range-request thresholds</a>. Some browsers may treat this threshold as occuring at the end of the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">sfnt tableDirectory</a>. Other browsers may treat this threshold as occurring just before any outline data, provided the outline data appears at the end of the font. Other browsers may place this threshold at the very beginning of the file, thereby treating the whole file as able to be downloaded with range-requests.</p>
    <h4 class="heading settled" data-level="1.3.2" id="browser-behaviors-subsequent-requests"><span class="secno">1.3.2. </span><span class="content">Subsequent Requests</span><a class="self-link" href="#browser-behaviors-subsequent-requests"></a></h4>
-   <p>After all the data before the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold④">range-request threshold</a> has been loaded by the browser, the browser will determine which additional byte ranges in the file are necessary to load. It will then issue HTTP Range Requests (<a href="https://www.rfc-editor.org/rfc/rfc9110#section-14"><cite>HTTP Semantics</cite> §  14. Range Requests</a>) for at least those ranges.</p>
+   <p>After all the data before the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold④">range-request threshold</a> has been loaded by the browser, the browser will determine which additional byte ranges in the file are necessary to load. It will then issue HTTP Range Requests (<a href="https://httpwg.org/specs/rfc9110.html#range.requests"><cite>HTTP Semantics</cite> §  14. Range Requests</a>) for at least those ranges.</p>
    <p class="note" role="note"><span class="marker">Note:</span> Browsers are encouraged to coalesce range requests for nearby areas of the file, to minimize the amount of range-request overhead required. Browsers are encouraged to inform these coalescing decisions from network configuration parameters and bandwidth / latency observations.</p>
    <p class="note" role="note"><span class="marker">Note:</span> If the font file has followed all of the organization guidelines above, all information required for laying out content and performing shaping will lie before any of the outline data in the file, and every glyph’s outline will be independent from every other glyph. Therefore, the browser can treat the <a data-link-type="dfn" href="#range-request-threshold" id="ref-for-range-request-threshold⑤">range-request threshold</a> as being just before outline data begins, and once it has loaded up to that threshold, it can lay out page content. After laying out the page, downloading all the necessary outlines can be done with a collection of independent and parallel range requests. This works particularly well for Chinese, Japanese, and Korean fonts, where 90% or more of the font data is outline data.</p>
    <p class="note" role="note"><span class="marker">Note:</span> Another valid alternative is to treat the entire font as residing on an asynchronous virtual filesystem, and have the browser track which ranges of the font it ended up reading during its normal operation. The browser could then request those regions in range requests.</p>
    <h3 class="heading settled" data-level="1.4" id="server-behaviors"><span class="secno">1.4. </span><span class="content">Server Behaviors</span><a class="self-link" href="#server-behaviors"></a></h3>
-   <p>Servers supporting the range-request IFT method must support range requests (<a href="https://www.rfc-editor.org/rfc/rfc9110#section-14"><cite>HTTP Semantics</cite> §  14. Range Requests</a>).</p>
-   <p>Servers supporting the range-request IFT method should support compression via the <code>Content-Encoding</code> (<a href="https://www.rfc-editor.org/rfc/rfc9110#section-8.4"><cite>HTTP Semantics</cite> § 8.4 Content-Encoding</a>) header or the <code>Transfer-Encoding</code> header (<a href="https://www.rfc-editor.org/rfc/rfc9112#section-6.1"><cite>HTTP/1.1</cite> § 6.1 Transfer-Encoding</a>), rather than having the font file
+   <p>Servers supporting the range-request IFT method must support range requests (<a href="https://httpwg.org/specs/rfc9110.html#range.requests"><cite>HTTP Semantics</cite> §  14. Range Requests</a>).</p>
+   <p>Servers supporting the range-request IFT method should support compression via the <code>Content-Encoding</code> (<a href="https://httpwg.org/specs/rfc9110.html#field.content-encoding"><cite>HTTP Semantics</cite> § 8.4 Content-Encoding</a>) header or the <code>Transfer-Encoding</code> header (<a href="https://httpwg.org/specs/rfc9112.html#field.transfer-encoding"><cite>HTTP/1.1</cite> § 6.1 Transfer-Encoding</a>), rather than having the font file
 itself be statically compressed.</p>
    <h2 class="no-num heading settled" id="priv"><span class="content">Privacy Considerations</span><a class="self-link" href="#priv"></a></h2>
    <p>Please see <a href="https://www.w3.org/TR/IFT/#priv">Privacy Considerations</a> in the main IFT document.</p>
@@ -664,7 +664,7 @@ itself be statically compressed.</p>
    <p>Since the <a href="https://www.w3.org/TR/2022/WD-IFT-20220628/">Working
   Draft of 28 June 2022</a> (see <a href="https://github.com/w3c/IFT/commits/main/RangeRequest.bs">commit history</a>):</p>
    <ul>
-    <li>Updated citations of rfc9110 and rfc9111 to use section references
+    <li>Updated citations of rfc9110 and rfc9112 to use new references
     <li>Split off this range request section back into a separate document
    </ul>
    <h2 class="heading settled" id="suggested-glyph-character-ordering"><span class="content"> Appendix A: Suggested glyph/character ordering</span><a class="self-link" href="#suggested-glyph-character-ordering"></a></h2>
@@ -675,42 +675,67 @@ itself be statically compressed.</p>
    <h2 class="no-ref no-num heading settled" id="w3c-conformance"><span class="content">Conformance</span><a class="self-link" href="#w3c-conformance"></a></h2>
    <h3 class="no-ref no-num heading settled" id="w3c-conventions"><span class="content">Document conventions</span><a class="self-link" href="#w3c-conventions"></a></h3>
    <p>Conformance requirements are expressed
+
     with a combination of descriptive assertions
+
     and RFC 2119 terminology.
+
     The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+
     in the normative parts of this document
+
     are to be interpreted as described in RFC 2119.
+
     However, for readability,
+
     these words do not appear in all uppercase letters in this specification. </p>
    <p>All of the text of this specification is normative
+
     except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">[RFC2119]</a> </p>
    <p>Examples in this specification are introduced with the words “for example”
+
     or are set apart from the normative text
+
     with <code>class="example"</code>,
+
     like this: </p>
    <div class="example" id="w3c-example">
     <a class="self-link" href="#w3c-example"></a> 
     <p>This is an example of an informative example. </p>
    </div>
    <p>Informative notes begin with the word “Note”
+
     and are set apart from the normative text
+
     with <code>class="note"</code>,
+
     like this: </p>
    <p class="note" role="note">Note, this is an informative note.</p>
    <section>
     <h3 class="no-ref no-num heading settled" id="w3c-conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#w3c-conformant-algorithms"></a></h3>
     <p>Requirements phrased in the imperative as part of algorithms
+
     (such as "strip any leading space characters"
+
     or "return false and abort these steps")
+
     are to be interpreted with the meaning of the key word
+
     ("must", "should", "may", etc)
+
     used in introducing the algorithm. </p>
     <p>Conformance requirements phrased as algorithms or specific steps
+
     can be implemented in any manner,
+
     so long as the end result is equivalent.
+
     In particular, the algorithms defined in this specification
+
     are intended to be easy to understand
+
     and are not intended to be performant.
+
     Implementers are encouraged to optimize. </p>
    </section>
   </div>
@@ -736,9 +761,9 @@ itself be statically compressed.</p>
    <dt id="biblio-rfc7932">[RFC7932]
    <dd>J. Alakuijala; Z. Szabadka. <a href="https://www.rfc-editor.org/rfc/rfc7932"><cite>Brotli Compressed Data Format</cite></a>. July 2016. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc7932">https://www.rfc-editor.org/rfc/rfc7932</a>
    <dt id="biblio-rfc9110">[RFC9110]
-   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9110"><cite>HTTP Semantics</cite></a>. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a>
+   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://httpwg.org/specs/rfc9110.html"><cite>HTTP Semantics</cite></a>. June 2022. Internet Standard. URL: <a href="https://httpwg.org/specs/rfc9110.html">https://httpwg.org/specs/rfc9110.html</a>
    <dt id="biblio-rfc9112">[RFC9112]
-   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9112"><cite>HTTP/1.1</cite></a>. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9112">https://www.rfc-editor.org/rfc/rfc9112</a>
+   <dd>R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed.. <a href="https://httpwg.org/specs/rfc9112.html"><cite>HTTP/1.1</cite></a>. June 2022. Internet Standard. URL: <a href="https://httpwg.org/specs/rfc9112.html">https://httpwg.org/specs/rfc9112.html</a>
    <dt id="biblio-truetype">[TRUETYPE]
    <dd><a href="https://developer.apple.com/fonts/TrueType-Reference-Manual/"><cite>TrueType™ Reference Manual</cite></a>. URL: <a href="https://developer.apple.com/fonts/TrueType-Reference-Manual/">https://developer.apple.com/fonts/TrueType-Reference-Manual/</a>
    <dt id="biblio-woff">[WOFF]


### PR DESCRIPTION
We eventually switched to the `https://httpwg.org/specs/` versions for RFC9110, RFC9111 and RFC9112 in the cross-references database, because they are more readable.

Unfortunately, this means that references to sections in these specs need to be updated again, as was done in #144. This update uses the new (and in theory now stable) fragment identifiers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/IFT/pull/154.html" title="Last updated on Nov 24, 2023, 3:15 PM UTC (643d5ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/154/01037d2...tidoust:643d5ab.html" title="Last updated on Nov 24, 2023, 3:15 PM UTC (643d5ab)">Diff</a>