### PR TITLE
Add specification for the Format 2 Patch Map

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -655,7 +655,8 @@ The algorithm:
     <td>uint8</td> <!-- TODO: uint32 to match format 1? -->
     <td><dfn for="Format 2 Patch Map">defaultPatchEncoding</dfn></td>
     <td>
-      Specifies the format of the patches linked to by uriTemplate. Using the ID number from the [[#font-patch-formats-summary]] table.
+      Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry). Uses the ID numbers from the
+      [[#font-patch-formats-summary]] table.
     </td>
   </tr>
   <tr>
@@ -693,7 +694,7 @@ The algorithm:
   <tr>
     <td>[=Mapping Entry=]</td>
     <td><dfn for="Mapping Entries">entries</dfn>&lsqb;[=Format 2 Patch Map/entryCount=]&rsqb;</td>
-    <td>List of entries. Each entry has a variable length.</td>
+    <td>List of entries. Each entry has a variable length, which is determined following [$Interpret Format 2 Patch Map Entry$].</td>
   </tr>
 </table>
 
@@ -707,8 +708,8 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Mapping Entry">format</dfn></td>
     <td>
-      A bit field. Bit 0 (least significant bit) through bit 5 indicate presence of optional fields. If bit 6 is set this entry is ignored.
-      Bit 7 is reserved for future use and set to 0.
+      A bit field. Bit 0 (least significant bit) through bit 5 indicate the presence of optional fields. If bit 6 is set this entry is
+      ignored. Bit 7 is reserved for future use and set to 0.
     </td>
   </tr>
 
@@ -723,7 +724,8 @@ The algorithm:
     <td>Tag</td>
     <td><dfn for="Mapping Entry">featureTags</dfn>[featureCount]</td>
     <td>
-      Array of [[open-type/featuretags|feature tags]]. Only present if [=Mapping Entry/format=] bit 0 is set.
+      List of [[open-type/featuretags|feature tags]] in the entry's [=font subset definition=]. Only present if
+      [=Mapping Entry/format=] bit 0 is set.
     </td>
   </tr>
 
@@ -738,7 +740,7 @@ The algorithm:
     <td>[=Design Space Segment=]</td>
     <td><dfn for="Mapping Entry">designSpaceSegments</dfn>[designSpaceCount]</td>
     <td>
-      Array of [=Design Space Segment=]'s. Only present if [=Mapping Entry/format=] bit 0 is set.
+      List of design space segments in the entry's [=font subset definition=]. Only present if [=Mapping Entry/format=] bit 0 is set.
     </td>
   </tr>
 
@@ -753,8 +755,9 @@ The algorithm:
     <td>uint16</td>
     <td><dfn for="Mapping Entry">copyIndices</dfn>[copyCount]</td>
     <td>
-      Array of indices from the [=Mapping Entries/entries=] array which should be copied into this mapping. All values must be less than
-      the index of this [=Mapping Entry=]. Only present if [=Mapping Entry/format=] bit 1 is set.
+      List of indices from the [=Mapping Entries/entries=] array whose [=font subset definition=] should be copied into this entry. All
+      values must be less than the index of this [=Mapping Entry=] in [=Mapping Entries/entries=]. Only present if
+      [=Mapping Entry/format=] bit 1 is set.
     </td>
   </tr>
 
@@ -762,7 +765,7 @@ The algorithm:
     <td>int16</td>
     <td><dfn for="Mapping Entry">entryIdDelta</dfn></td>
     <td>
-      Delta which is added to the entry id of the previous [=Mapping Entry=] to produce the entry id for this entry.
+      Signed delta which is added to the entry id of the previous [=Mapping Entry=] to produce the id for this entry.
       Only present if [=Mapping Entry/format=] bit 2 is set.
     </td>
   </tr>
@@ -771,7 +774,7 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Mapping Entry">patchEncoding</dfn></td>
     <td>
-      Specifies the format of the patch linked to by this entry. Using the ID number from the [[#font-patch-formats-summary]] table.
+      Specifies the format of the patch linked to by this entry. Uses the ID numbers from the [[#font-patch-formats-summary]] table.
       Overrides [=Format 2 Patch Map/defaultPatchEncoding=].
       Only present if [=Mapping Entry/format=] bit 3 is set.
     </td>
@@ -782,7 +785,7 @@ The algorithm:
     <td>uint16/uint24</td>
     <td><dfn for="Mapping Entry">bias</dfn></td>
     <td>
-      Bias value which is added to all codepoint values encoded in the codepoints set.
+      Bias value which is added to all codepoint values in the codepoints set.
       If format bit 4 is 0 and bit 5 is 1, then this is present and a uint16.
       If format bit 4 is 1 and bit 5 is 1, then this is present and a uint24.
       Otherwise it is not present.
@@ -793,7 +796,8 @@ The algorithm:
     <td><dfn for="Mapping Entry">codepoints</dfn>[variable]</td>
     <td>
       Set of codepoints for this mapping. Encoded as a [[#sparse-bit-set-decoding]]. 
-      Only present if [=Mapping Entry/format=] bit 4 and/or 5 is set.
+      Only present if [=Mapping Entry/format=] bit 4 and/or 5 is set. The length is
+      determined by following the decoding procedures in [[#sparse-bit-set-decoding]].
     </td>
   </tr>
 </table>
@@ -858,12 +862,11 @@ The algorithm:
          [=Format 2 Patch Map/defaultPatchEncoding=], and
          [=Format 2 Patch Map/uriTemplate=].
 
-     *  Add the returned entry to <var>entry list</var>.
-
      *  Set <var>last entry id</var> to the returned entry id.
 
      *  Add the returned consumed byte count to <var>current byte</var>.
-     <!-- TODO handle the ignore bit -->
+
+     *  If the returned value of ignored is false, then add the returned entry to <var>entry list</var>.
 
 4.  Return <var>entry list</var>.
 
@@ -886,6 +889,8 @@ The algorithm outputs:
 * <var>entry</var>: a single [=patch map entries|entry=].
 
 * <var>consumed bytes</var>: the number of bytes used to encode the entry.
+
+* <var>ignored</var>: if true, then this entry should be ignored.
 
 The algorithm:
 
@@ -915,7 +920,8 @@ The algorithm:
          add all code points, feature tags, and design space segments from it to <var>entry</var>.
 
 7.  If [=Mapping Entry/format=] bit 2 is set, then an id delta is present. Read the id delta specified by [=Mapping Entry/entryIdDelta=]
-     from <var>entry bytes</var> and add the delta to <var>entry id</var>.
+     from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
+     and the mapping is malformed.
 
 8.  If [=Mapping Entry/format=] bit 3 is set, then a patch encoding is present. Read the encoding specified by
      [=Mapping Entry/patchEncoding=] from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.
@@ -933,9 +939,12 @@ The algorithm:
     *  Read the sparse bit set [=Mapping Entry/codepoints=] from <var>entry bytes</var> following [[#sparse-bit-set-decoding]]. For each
         codepoint add the bias value to it and then add the result to the codepoint set in <var>entry</var>.
 
-10. TODO apply URI template.
+10. If [=Mapping Entry/format=] bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.
 
-11. Return <var>entry id</var>, <var>entry</var>, and <var>consumed bytes</var>.
+11. Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]]. Set the patch uri of
+     <var>entry</var> to the generated URI.
+
+12. Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, and <var>ignored</var>.
 
 <h5 algorithm id="sparse-bit-set-decoding">Sparse Bit Set</h5>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -139,11 +139,11 @@ The IFT technology has four main pieces:
 At a high level an IFT font is used like this:
 
 1. The client downloads an initial font file, which contains some initial subset of data from the full version of the font along with
-   [[#font-format-extensions|embedded data]] describing the set of [[#font-patch-formats|patches]] which can be used to extend 
-   the font.
+    [[#font-format-extensions|embedded data]] describing the set of [[#font-patch-formats|patches]] which can be used to extend 
+    the font.
 
 2. Based on the content to be rendered, the client [[#extending-font-subset|selects, downloads, and applies]] patches to extend 
-   the font to cover additional characters. This step is repeated each time there is new content.
+    the font to cover additional characters. This step is repeated each time there is new content.
 
 Creating an Incremental Font {#making-incremental-fonts}
 --------------------------------------------------------
@@ -630,6 +630,162 @@ Coming soon.
 TODO:
 - how does this interact with woff2
 -->
+
+<h5 algorithm id="sparse-bit-set-decoding">Sparse Bit Set</h5>
+
+A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
+each node has a fixed number of children that recursively sub-divides an interval into equal partitions. A tree of height <i>H</i> with
+branching factor <i>B</i> can store set membership for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree
+is encoded into an array of bytes for transport.
+
+<dfn>Sparse Bit Set</dfn> encoding:
+<table>
+  <tr>
+    <th>Type</th><th>Name</th><th>Description</th>
+  </tr>
+  <tr>
+    <td>uint8</td>
+    <td>header</td>
+    <td>Bits 0 (least significant) and 1 encode the trees branch factor <i>B</i>. Bits 2 through 6 are a 5-bit unsigned integer which
+        encodes the value of <i>H</i>. Bit 7 is set to 0 and reserved for future use.
+    </td>
+  </tr>
+  <tr>
+    <td>uint8</td>
+    <td>treeData[variable]</td>
+    <td>Binary encoding of the tree.</td>
+  </tr>
+</table>
+
+The exact length of <var>treeData</var> is initially unknown, it's length is determined by executing the decoding algorithm. When using
+branch factors of 2 or 4 the last node may only partially consume the bits in a byte. In that case all remaining bits are unused and
+ignored.
+
+<dfn>Branch Factor Encoding</dfn>:
+<table>
+  <tr>
+    <th>Bit 1</th><th>Bit 0</th><th>Branch Factor (B)</th>
+  </tr>
+  <tr>
+    <td>0</td><td>0</td><td>2</td>
+  </tr>
+  <tr>
+    <td>0</td><td>1</td><td>4</td>
+  </tr>
+  <tr>
+    <td>1</td><td>0</td><td>8</td>
+  </tr>
+  <tr>
+    <td>1</td><td>1</td><td>32</td>
+  </tr>
+</table>
+
+<dfn abstract-op>Decoding sparse bit set treeData</dfn>
+
+The inputs to this algorithm are:
+
+* <var>H</var>: the tree height, <var>H</var>, from the header byte.
+
+* <var>B</var>: the branch factor, <var>B</var>, from the header byte.
+
+* <var>treeData</var>: array of bytes to be decoded.
+
+The algorithm outputs:
+
+* <var>S</var>: a set of unsigned integers.
+
+The algorithm, using a FIFO (first in first out) queue <var>Q</var>:
+
+1.  If <var>H</var> is equal to 0, then this is an empty set and no bytes of <var>treeData</var> are consumed. Return an empty set.
+
+2.  Insert the tuple (0, 1) into <var>Q</var>.
+
+3.  Initialize <var>S</var> to an empty set.
+
+4.  <var>treeData</var> is interpreted as a string of bits where the least significant bit of <var>treeData</var>[0] is the first bit in
+     the string, the most significant bit of <var>treeData</var>[0] is the 8th bit, and so on.
+
+5.  If <var>Q</var> is empty return <var>S</var>.
+
+6.  Extract the next tuple <var>t</var> from <var>Q</var>. The first value of
+     in <var>t</var> is <var>start</var> and the second value is <var>depth</var>.
+
+7.  Remove the next <var>B</var> bits from the <var>treeData</var> bit string. The first removed bit is <i>v<sub>1</sub></i>,
+     the second is <i>v<sub>2</sub></i>, and so on until the last removed bit which is <i>v<sub>B</sub></i>. If prior to removal there
+     were less than <var>B</var> bits left in <var>treeData</var>, then <var>treeData</var> is malformed, return an error.
+
+8.  If all bits <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i> are 0, then insert all integers in the interval
+    [<var>start</var>, <var>start</var> + <var>B</var><sup><var>H</var> - <var>depth</var> + 1</sup>)
+    into <var>S</var>. Go to step 5.
+
+9.  For each <i>v<sub>i</sub></i> which is equal to 1 in <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i>:
+     If <var>depth</var> is equal to <var>H</var> add
+     integer <var>start</var> + <i>i</i> - 1 to <var>S</var>. Otherwise, insert the tuple
+     (<var>start</var> + (i - 1) * <var>B</var><sup><var>H</var> - <var>depth</var></sup>, <var>depth</var> + 1)
+     into <var>Q</var>.
+
+10.  Go to step 5.
+
+Note: when encoding sparse bit sets the encoder can use any of the possible branching factors, but it is recommended to
+use 4 as that has <a href="https://github.com/w3c/PFE-analysis/blob/main/results/set_encoding_branch_factor.md">been shown</a>
+to give the smallest encodings for most unicode codepoint sets typically encountered.
+
+
+<div class=example>
+  The set {2, 33, 323} in a tree with a branching factor of 8 can be encoded as the bit string:
+
+  ```
+  bit string:
+  |-- header --|- lvl 0 |---- level 1 ----|------- level 2 -----------|
+  | B=8 H=3    |   n0   |   n1       n2   |   n3       n4       n5    |
+  [ 01  11000 0 10000100 10001000 10000000 00100000 01000000 00010000 ]
+
+  Which then becomes the byte string:
+  [
+    0b00001110,
+    0b00100001,
+    0b00010001,
+    0b00000001,
+    0b00000100,
+    0b00000010,
+    0b00001000
+  ]
+  ```
+</div>
+
+<div class=example>
+  The empty set in a tree with a branching factor of 2 is encoded as the bit string:
+
+  ```
+  bit string:
+  |-- header -- |
+  | B=2 H=0     |
+  [ 00  00000 0 ]
+
+  Which then becomes the byte string:
+  [
+    0b00000000,
+  ]
+  ```
+</div>
+
+<div class=example>
+  The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as:
+
+  ```
+  bit string:
+  |-- header --| l0 |- lvl 1 -| l2  |
+  | B=4 H=3    | n0 | n1 | n2 | n3  |
+  [ 10  11000 0 1100 0000 1000 1100 ]
+
+  byte string:
+  [
+    0b00001101,
+    0b00000011,
+    0b00110001
+  ]
+  ```
+</div>
 
 Font Patch Formats {#font-patch-formats}
 ========================================

--- a/Overview.bs
+++ b/Overview.bs
@@ -626,8 +626,6 @@ The algorithm:
 
 ### Patch Map Table: Format 2 ### {#patch-map-format-2}
 
-<!-- TODO: summary of this format -->
-<!-- TODO: provide normative validation requirements for each encoding -->
 <!-- TODO: clean up unreferenced definitions -->
 
 <dfn>Format 2 Patch Map</dfn> encoding:
@@ -652,7 +650,7 @@ The algorithm:
     <td>Unique ID used to identify patches that are compatible with this font.</td>
   </tr>
   <tr>
-    <td>uint8</td> <!-- TODO: uint32 to match format 1? -->
+    <td>uint8</td>
     <td><dfn for="Format 2 Patch Map">defaultPatchEncoding</dfn></td>
     <td>
       Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry). Uses the ID numbers from the

--- a/Overview.bs
+++ b/Overview.bs
@@ -361,6 +361,9 @@ Note: allowing the mapping to be split between two distinct tables allows an inc
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
 'IFTX' table. Those patches can make updates only to one of the mapping tables and avoid making conflicting updates.
 
+<!-- TODO add algorithm explaining how to union the two tables -->
+<!-- TODO: how does this interact with woff2 -->
+
 
 Patch Map Table {#patch-map}
 ----------------------------
@@ -442,7 +445,7 @@ encoded in one of two formats:
     <td>uint8</td>
     <td><dfn for="Format 1 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
     <td>
-      A [[!UTF-8]] encoded string. Contains a template (TODO) which is used to produce URIs associated with each entry.
+      A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URIs associated with each entry.
     </td>
   </tr>
   <tr>
@@ -623,13 +626,208 @@ The algorithm:
 
 ### Patch Map Table: Format 2 ### {#patch-map-format-2}
 
-<!-- TODO add algorithm explaining how to union the two tables -->
-Coming soon.
+<!-- TODO: summary of this format -->
+<!-- TODO: provide normative validation requirements for each encoding -->
+<!-- TODO: clean up unreferenced definitions -->
 
-<!-- 
-TODO:
-- how does this interact with woff2
--->
+<dfn>Format 2 Patch Map</dfn> encoding:
+
+<table>
+  <tr>
+    <th>Type</th><th>Name</th><th>Description</th>
+  </tr>
+  <tr>
+    <td>uint8</td>
+    <td><dfn for="Format 2 Patch Map">format</dfn></td>
+    <td>Set to 2, identifies this as format 2.</td>
+  </tr>
+  <tr>
+    <td>uint32</td>
+    <td><dfn for="Format 2 Patch Map">reserved</dfn></td>
+    <td>Not used, set to 0.</td>
+  </tr>
+  <tr>
+    <td>uint32</td>
+    <td><dfn for="Format 2 Patch Map">id</dfn>[4]</td>
+    <td>Unique ID used to identify patches that are compatible with this font.</td>
+  </tr>
+  <tr>
+    <td>uint8</td> <!-- TODO: uint32 to match format 1? -->
+    <td><dfn for="Format 2 Patch Map">defaultPatchEncoding</dfn></td>
+    <td>
+      Specifies the format of the patches linked to by uriTemplate. Using the ID number from the [[#font-patch-formats-summary]] table.
+    </td>
+  </tr>
+  <tr>
+    <td>uint16</td> <!-- TODO: uint32 to match format 1? -->
+    <td><dfn for="Format 2 Patch Map">entryCount</dfn></td>
+    <td>Number of entries encoded in this table.</td>
+  </tr>
+  <tr>
+    <td>Offset32</td>
+    <td><dfn for="Format 2 Patch Map">entries</dfn></td>
+    <td>Offset to a [=Mapping Entries=] sub table. Offset is from the start of this table.</td>
+  </tr>
+  <tr>
+    <td>uint16</td>
+    <td><dfn for="Format 2 Patch Map">uriTemplateLength</dfn></td>
+    <td>
+      Length of the uriTemplate string.
+    </td>
+  </tr>
+  <tr>
+    <td>uint8</td>
+    <td><dfn for="Format 2 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
+    <td>
+      A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URIs associated with each entry.
+    </td>
+  </tr>
+</table>
+
+<dfn>Mapping Entries</dfn> encoding:
+
+<table>
+  <tr>
+    <th>Type</th><th>Name</th><th>Description</th>
+  </tr>
+  <tr>
+    <td>[=Mapping Entry=]</td>
+    <td><dfn for="Mapping Entries">entries</dfn>&lsqb;[=Format 2 Patch Map/entryCount=]&rsqb;</td>
+    <td>List of entries. Each entry has a variable length.</td>
+  </tr>
+</table>
+
+<dfn>Mapping Entry</dfn> encoding:
+
+<table>
+  <tr>
+    <th>Type</th><th>Name</th><th>Description</th>
+  </tr>
+  <tr>
+    <td>uint8</td>
+    <td><dfn for="Mapping Entry">format</dfn></td>
+    <td>
+      A bit field. Bit 0 (least significant bit) through bit 5 indicate presence of optional fields. If bit 6 is set this entry is ignored.
+      Bit 7 is reserved for future use and set to 0.
+    </td>
+  </tr>
+
+  <tr>
+    <td>uint8</td>
+    <td><dfn for="Mapping Entry">featureCount</dfn></td>
+    <td>
+      Number of feature tags in the featureTags list. Only present if [=Mapping Entry/format=] bit 0 is set.
+    </td>
+  </tr>
+  <tr>
+    <td>Tag</td>
+    <td><dfn for="Mapping Entry">featureTags</dfn>[featureCount]</td>
+    <td>
+      Array of [[open-type/featuretags|feature tags]]. Only present if [=Mapping Entry/format=] bit 0 is set.
+    </td>
+  </tr>
+
+  <tr>
+    <td>uint8</td>
+    <td><dfn for="Mapping Entry">designSpaceCount</dfn></td>
+    <td>
+      Number of elements in the design space list. Only present if [=Mapping Entry/format=] bit 0 is set.
+    </td>
+  </tr>
+  <tr>
+    <td>[=Design Space Segment=]</td>
+    <td><dfn for="Mapping Entry">designSpaceSegments</dfn>[designSpaceCount]</td>
+    <td>
+      Array of [=Design Space Segment=]'s. Only present if [=Mapping Entry/format=] bit 0 is set.
+    </td>
+  </tr>
+
+  <tr>
+    <td>uint8</td>
+    <td><dfn for="Mapping Entry">copyCount</dfn></td>
+    <td>
+      Number of entries in the copyIndices list. Only present if [=Mapping Entry/format=] bit 1 is set.
+    </td>
+  </tr>
+  <tr>
+    <td>uint16</td>
+    <td><dfn for="Mapping Entry">copyIndices</dfn>[copyCount]</td>
+    <td>
+      Array of indices from the [=Mapping Entries/entries=] array which should be copied into this mapping. All values must be less than
+      the index of this [=Mapping Entry=]. Only present if [=Mapping Entry/format=] bit 1 is set.
+    </td>
+  </tr>
+
+  <tr>
+    <td>int16</td>
+    <td><dfn for="Mapping Entry">entryIndexDelta</dfn></td>
+    <td>
+      Delta which is added to the entry index of the previous [=Mapping Entry=] to produce the entry index for this entry.
+      Only present if [=Mapping Entry/format=] bit 2 is set.
+    </td>
+  </tr>
+
+  <tr>
+    <td>uint8</td>
+    <td><dfn for="Mapping Entry">patchEncoding</dfn></td>
+    <td>
+      Specifies the format of the patch linked to by this entry. Using the ID number from the [[#font-patch-formats-summary]] table.
+      Overrides [=Format 2 Patch Map/defaultPatchEncoding=].
+      Only present if [=Mapping Entry/format=] bit 3 is set.
+    </td>
+  </tr>
+
+
+  <tr>
+    <td>uint16/uint24</td>
+    <td><dfn for="Mapping Entry">bias</dfn></td>
+    <td>
+      Bias value which is added to all codepoint values encoded in the codepoints set.
+      If format bit 4 is 0 and bit 5 is 1, then this is present and a uint16.
+      If format bit 4 is 1 and bit 5 is 1, then this is present and a uint24.
+      Otherwise it is not present.
+    </td>
+  </tr>
+  <tr>
+    <td>uint8</td>
+    <td><dfn for="Mapping Entry">codepoints</dfn>[variable]</td>
+    <td>
+      Set of codepoints for this mapping. Encoded as a [[#sparse-bit-set-decoding]]. 
+      Only present if [=Mapping Entry/format=] bit 4 and/or 5 is set.
+    </td>
+  </tr>
+</table>
+
+<dfn>Design Space Segment</dfn> encoding:
+
+<table>
+  <tr>
+    <th>Type</th><th>Name</th><th>Description</th>
+  </tr>
+  <tr>
+    <td>Tag</td>
+    <td><dfn for="Design Space Segment">tag</dfn></td>
+    <td>
+      Axis tag value.
+    </td>
+  </tr>
+
+  <tr>
+    <td>Fixed</td>
+    <td><dfn for="Design Space Segment">start</dfn></td>
+    <td>
+      Start (inclusive) of the segment.
+    </td>
+  </tr>
+
+  <tr>
+    <td>Fixed</td>
+    <td><dfn for="Design Space Segment">end</dfn></td>
+    <td>
+      End (inclusive) of the segment. Must be greater than or equal to start.
+    </td>
+  </tr>
+</table>
 
 <h5 algorithm id="sparse-bit-set-decoding">Sparse Bit Set</h5>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -276,7 +276,8 @@ needed to render a subset of:
 supported by the original font. When a subsetted font is used to render text using any combination of the subset
 codepoints, [[open-type/featuretags|layout features]], or [[open-type/otvaroverview#terminology|design-variation space]]
 it should render identically to the original font. This includes rendering with the use of any optional typographic
-features that a renderer may choose to use from the original font, such as hinting instructions.
+features that a renderer may choose to use from the original font, such as hinting instructions. Design variation spaces
+are specified using the user-axis scales ([[open-type/otvaroverview#coordinate-scales-and-normalization]]).
 
 A <dfn dfn>font subset definition</dfn> describes the minimum data (codepoints, layout features,
 variation axis space) that a [=font subset=] should support.
@@ -690,9 +691,10 @@ The algorithm:
     <th>Type</th><th>Name</th><th>Description</th>
   </tr>
   <tr>
-    <td>[=Mapping Entry=]</td>
-    <td><dfn for="Mapping Entries">entries</dfn>&lsqb;[=Format 2 Patch Map/entryCount=]&rsqb;</td>
-    <td>List of entries. Each entry has a variable length, which is determined following [$Interpret Format 2 Patch Map Entry$].</td>
+    <td>uint8</td>
+    <td><dfn for="Mapping Entries">entries</dfn>[variable]</td>
+    <td>Byte array containing the encoded bytes of [=Format 2 Patch Map/entryCount=] [=Mapping Entry=]'s. Each entry has a variable
+        length, which is determined following [$Interpret Format 2 Patch Map Entry$].</td>
   </tr>
 </table>
 
@@ -704,7 +706,7 @@ The algorithm:
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Mapping Entry">format</dfn></td>
+    <td><dfn for="Mapping Entry">formatFlags</dfn></td>
     <td>
       A bit field. Bit 0 (least significant bit) through bit 5 indicate the presence of optional fields. If bit 6 is set this entry is
       ignored. Bit 7 is reserved for future use and set to 0.
@@ -715,7 +717,7 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Mapping Entry">featureCount</dfn></td>
     <td>
-      Number of feature tags in the featureTags list. Only present if [=Mapping Entry/format=] bit 0 is set.
+      Number of feature tags in the featureTags list. Only present if [=Mapping Entry/formatFlags=] bit 0 is set.
     </td>
   </tr>
   <tr>
@@ -723,7 +725,7 @@ The algorithm:
     <td><dfn for="Mapping Entry">featureTags</dfn>[featureCount]</td>
     <td>
       List of [[open-type/featuretags|feature tags]] in the entry's [=font subset definition=]. Only present if
-      [=Mapping Entry/format=] bit 0 is set.
+      [=Mapping Entry/formatFlags=] bit 0 is set.
     </td>
   </tr>
 
@@ -731,14 +733,14 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Mapping Entry">designSpaceCount</dfn></td>
     <td>
-      Number of elements in the design space list. Only present if [=Mapping Entry/format=] bit 0 is set.
+      Number of elements in the design space list. Only present if [=Mapping Entry/formatFlags=] bit 0 is set.
     </td>
   </tr>
   <tr>
     <td>[=Design Space Segment=]</td>
     <td><dfn for="Mapping Entry">designSpaceSegments</dfn>[designSpaceCount]</td>
     <td>
-      List of design space segments in the entry's [=font subset definition=]. Only present if [=Mapping Entry/format=] bit 0 is set.
+      List of design space segments in the entry's [=font subset definition=]. Only present if [=Mapping Entry/formatFlags=] bit 0 is set.
     </td>
   </tr>
 
@@ -746,7 +748,7 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Mapping Entry">copyCount</dfn></td>
     <td>
-      Number of entries in the copyIndices list. Only present if [=Mapping Entry/format=] bit 1 is set.
+      Number of entries in the copyIndices list. Only present if [=Mapping Entry/formatFlags=] bit 1 is set.
     </td>
   </tr>
   <tr>
@@ -755,7 +757,7 @@ The algorithm:
     <td>
       List of indices from the [=Mapping Entries/entries=] array whose [=font subset definition=] should be copied into this entry. All
       values must be less than the index of this [=Mapping Entry=] in [=Mapping Entries/entries=]. Only present if
-      [=Mapping Entry/format=] bit 1 is set.
+      [=Mapping Entry/formatFlags=] bit 1 is set.
     </td>
   </tr>
 
@@ -763,8 +765,9 @@ The algorithm:
     <td>int16</td>
     <td><dfn for="Mapping Entry">entryIdDelta</dfn></td>
     <td>
-      Signed delta which is added to the entry id of the previous [=Mapping Entry=] to produce the id for this entry.
-      Only present if [=Mapping Entry/format=] bit 2 is set.
+      Signed delta which is used to calculate the id for this entry. The id for this entry is the entry id of the previous
+      [=Mapping Entry=] + 1 + entryIdDelta. Only present if [=Mapping Entry/formatFlags=] bit 2 is set. If not present delta is assumed
+      to be 0.
     </td>
   </tr>
 
@@ -774,7 +777,7 @@ The algorithm:
     <td>
       Specifies the format of the patch linked to by this entry. Uses the ID numbers from the [[#font-patch-formats-summary]] table.
       Overrides [=Format 2 Patch Map/defaultPatchEncoding=].
-      Only present if [=Mapping Entry/format=] bit 3 is set.
+      Only present if [=Mapping Entry/formatFlags=] bit 3 is set.
     </td>
   </tr>
 
@@ -794,7 +797,7 @@ The algorithm:
     <td><dfn for="Mapping Entry">codepoints</dfn>[variable]</td>
     <td>
       Set of codepoints for this mapping. Encoded as a [[#sparse-bit-set-decoding]]. 
-      Only present if [=Mapping Entry/format=] bit 4 and/or 5 is set. The length is
+      Only present if [=Mapping Entry/formatFlags=] bit 4 and/or 5 is set. The length is
       determined by following the decoding procedures in [[#sparse-bit-set-decoding]].
     </td>
   </tr>
@@ -818,7 +821,8 @@ The algorithm:
     <td>Fixed</td>
     <td><dfn for="Design Space Segment">start</dfn></td>
     <td>
-      Start (inclusive) of the segment.
+      Start (inclusive) of the segment. This value uses the user axis scale:
+      [[open-type/otvaroverview#coordinate-scales-and-normalization]].
     </td>
   </tr>
 
@@ -826,7 +830,8 @@ The algorithm:
     <td>Fixed</td>
     <td><dfn for="Design Space Segment">end</dfn></td>
     <td>
-      End (inclusive) of the segment. Must be greater than or equal to start.
+      End (inclusive) of the segment. Must be greater than or equal to start. This value uses the user axis scale:
+      [[open-type/otvaroverview#coordinate-scales-and-normalization]].
     </td>
   </tr>
 </table>
@@ -854,7 +859,7 @@ The algorithm:
 
 3.  Invoke [$Interpret Format 2 Patch Map Entry$], [=Format 2 Patch Map/entryCount=] times. For each invocation:
 
-     *  pass in the bytes from <var>patch map</var> starting from index ([=Format 2 Patch Map/entries=] + <var>current byte</var>) to
+     *  pass in the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entries=][<var>current byte</var>] to
          the end of <var>patch map</var>,
          <var>last entry id</var>,
          [=Format 2 Patch Map/defaultPatchEncoding=], and
@@ -899,9 +904,9 @@ The algorithm:
 
 3.  Set the patch encoding of <var>entry</var> to <var>default patch encoding</var>.
 
-4.  Read [=Mapping Entry/format=] from <var>entry bytes</var>.
+4.  Read [=Mapping Entry/formatFlags=] from <var>entry bytes</var>.
 
-5.  If [=Mapping Entry/format=] bit 0 is set, then the feature tag and design space lists are present:
+5.  If [=Mapping Entry/formatFlags=] bit 0 is set, then the feature tag and design space lists are present:
 
     *  Read the feature tag list specified by [=Mapping Entry/featureCount=] and [=Mapping Entry/featureTags=] from <var>entry bytes</var>
         and add the loaded tags to <var>entry</var>.
@@ -909,7 +914,7 @@ The algorithm:
     *  Read the design space segment list specified by [=Mapping Entry/designSpaceCount=] and [=Mapping Entry/designSpaceSegments=]
         from <var>entry bytes</var> and add the design space segments to <var>entry</var>.
 
-6.  If [=Mapping Entry/format=] bit 1 is set, then the copy indices list is present:
+6.  If [=Mapping Entry/formatFlags=] bit 1 is set, then the copy indices list is present:
 
     *  Read the copy indices list specified by [=Mapping Entry/copyCount=] and [=Mapping Entry/copyIndices=] from <var>entry bytes</var>.
 
@@ -917,19 +922,19 @@ The algorithm:
          and so on. For each index in [=Mapping Entry/copyIndices=] locate the previously loaded entry with a matching index and
          add all code points, feature tags, and design space segments from it to <var>entry</var>.
 
-7.  If [=Mapping Entry/format=] bit 2 is set, then an id delta is present. Read the id delta specified by [=Mapping Entry/entryIdDelta=]
+7.  If [=Mapping Entry/formatFlags=] bit 2 is set, then an id delta is present. Read the id delta specified by [=Mapping Entry/entryIdDelta=]
      from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
      and the mapping is malformed.
 
-8.  If [=Mapping Entry/format=] bit 3 is set, then a patch encoding is present. Read the encoding specified by
+8.  If [=Mapping Entry/formatFlags=] bit 3 is set, then a patch encoding is present. Read the encoding specified by
      [=Mapping Entry/patchEncoding=] from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.
 
-9.  If one or both of [=Mapping Entry/format=] bit 4 and bit 5 are set, then a codepoint list is present:
+9.  If one or both of [=Mapping Entry/formatFlags=] bit 4 and bit 5 are set, then a codepoint list is present:
 
-    *  If [=Mapping Entry/format=] bit 4 is 0 and bit 5 is 1, then read the 2 byte (uint16) [=Mapping Entry/bias=] value
+    *  If [=Mapping Entry/formatFlags=] bit 4 is 0 and bit 5 is 1, then read the 2 byte (uint16) [=Mapping Entry/bias=] value
         from <var>entry bytes</var>.
 
-    *  If [=Mapping Entry/format=] bit 4 is 1 and bit 5 is 1, then read the 3 byte (uint24) [=Mapping Entry/bias=] value
+    *  If [=Mapping Entry/formatFlags=] bit 4 is 1 and bit 5 is 1, then read the 3 byte (uint24) [=Mapping Entry/bias=] value
         from <var>entry bytes</var>.
 
     *  Otherwise the bias is 0.
@@ -937,7 +942,7 @@ The algorithm:
     *  Read the sparse bit set [=Mapping Entry/codepoints=] from <var>entry bytes</var> following [[#sparse-bit-set-decoding]]. For each
         codepoint add the bias value to it and then add the result to the codepoint set in <var>entry</var>.
 
-10. If [=Mapping Entry/format=] bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.
+10. If [=Mapping Entry/formatFlags=] bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.
 
 11. Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]]. Set the patch uri of
      <var>entry</var> to the generated URI.

--- a/Overview.bs
+++ b/Overview.bs
@@ -760,9 +760,9 @@ The algorithm:
 
   <tr>
     <td>int16</td>
-    <td><dfn for="Mapping Entry">entryIndexDelta</dfn></td>
+    <td><dfn for="Mapping Entry">entryIdDelta</dfn></td>
     <td>
-      Delta which is added to the entry index of the previous [=Mapping Entry=] to produce the entry index for this entry.
+      Delta which is added to the entry id of the previous [=Mapping Entry=] to produce the entry id for this entry.
       Only present if [=Mapping Entry/format=] bit 2 is set.
     </td>
   </tr>
@@ -828,6 +828,114 @@ The algorithm:
     </td>
   </tr>
 </table>
+
+<h5 algorithm id="interpreting-patch-map-format-2">Interpreting Format 2</h5>
+
+This algorithm is used to convert a format 2 patch map into a list of [=patch map entries=].
+
+
+<dfn abstract-op>Interpret Format 2 Patch Map</dfn>
+
+The inputs to this algorithm are:
+
+* <var>patch map</var>: a [[#patch-map-format-2]] encoded patch map.
+
+The algorithm outputs:
+
+* <var>entry list</var>: a list of [=patch map entries=].
+
+The algorithm:
+
+1.  Check that the <var>patch map</var> is valid according to the requirements in [[#patch-map-format-2]]. If it is not return an error.
+
+2.  Initialize <var>last entry id</var> to 0, and <var>current byte</var> to 0.
+
+3.  Invoke [$Interpret Format 2 Patch Map Entry$], [=Format 2 Patch Map/entryCount=] times. For each invocation:
+
+     *  pass in the bytes from <var>patch map</var> starting from index ([=Format 2 Patch Map/entries=] + <var>current byte</var>) to
+         the end of <var>patch map</var>,
+         <var>last entry id</var>,
+         [=Format 2 Patch Map/defaultPatchEncoding=], and
+         [=Format 2 Patch Map/uriTemplate=].
+
+     *  Add the returned entry to <var>entry list</var>.
+
+     *  Set <var>last entry id</var> to the returned entry id.
+
+     *  Add the returned consumed byte count to <var>current byte</var>.
+     <!-- TODO handle the ignore bit -->
+
+4.  Return <var>entry list</var>.
+
+<dfn abstract-op>Interpret Format 2 Patch Map Entry</dfn>
+
+The inputs to this algorithm are:
+
+* <var>entry bytes</var>: a byte array that contains an encoded [=Mapping Entry=].
+
+* <var>last entry id</var>: the entry id of the entry preceding this one.
+
+* <var>default patch encoding</var>: the default patch encoding if one isn't specified.
+
+* <var>uri template</var>: the URI template used to locate patches.
+
+The algorithm outputs:
+
+* <var>entry id</var>: the numeric id of this entry.
+
+* <var>entry</var>: a single [=patch map entries|entry=].
+
+* <var>consumed bytes</var>: the number of bytes used to encode the entry.
+
+The algorithm:
+
+1.  For the all steps whenever data is loaded from <var>entry bytes</var> increment <var>consumed bytes</var> with the
+     number of bytes read.
+
+2.  Set <var>entry id</var> = <var>last entry id</var> + 1.
+
+3.  Set the patch encoding of <var>entry</var> to <var>default patch encoding</var>.
+
+4.  Read [=Mapping Entry/format=] from <var>entry bytes</var>.
+
+5.  If [=Mapping Entry/format=] bit 0 is set, then the feature tag and design space lists are present:
+
+    *  Read the feature tag list specified by [=Mapping Entry/featureCount=] and [=Mapping Entry/featureTags=] from <var>entry bytes</var>
+        and add the loaded tags to <var>entry</var>.
+
+    *  Read the design space segment list specified by [=Mapping Entry/designSpaceCount=] and [=Mapping Entry/designSpaceSegments=]
+        from <var>entry bytes</var> and add the design space segments to <var>entry</var>.
+
+6.  If [=Mapping Entry/format=] bit 1 is set, then the copy indices list is present:
+
+    *  Read the copy indices list specified by [=Mapping Entry/copyCount=] and [=Mapping Entry/copyIndices=] from <var>entry bytes</var>.
+
+    *  The copy indices refer to previously loaded entries. 0 is the first [=Mapping Entry=] in [=Mapping Entries/entries=], 1 the second
+         and so on. For each index in [=Mapping Entry/copyIndices=] locate the previously loaded entry with a matching index and
+         add all code points, feature tags, and design space segments from it to <var>entry</var>.
+
+7.  If [=Mapping Entry/format=] bit 2 is set, then an id delta is present. Read the id delta specified by [=Mapping Entry/entryIdDelta=]
+     from <var>entry bytes</var> and add the delta to <var>entry id</var>.
+
+8.  If [=Mapping Entry/format=] bit 3 is set, then a patch encoding is present. Read the encoding specified by
+     [=Mapping Entry/patchEncoding=] from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.
+
+9.  If one or both of [=Mapping Entry/format=] bit 4 and bit 5 are set, then a codepoint list is present:
+
+    *  If [=Mapping Entry/format=] bit 4 is 0 and bit 5 is 1, then read the 2 byte (uint16) [=Mapping Entry/bias=] value
+        from <var>entry bytes</var>.
+
+    *  If [=Mapping Entry/format=] bit 4 is 1 and bit 5 is 1, then read the 3 byte (uint24) [=Mapping Entry/bias=] value
+        from <var>entry bytes</var>.
+
+    *  Otherwise the bias is 0.
+
+    *  Read the sparse bit set [=Mapping Entry/codepoints=] from <var>entry bytes</var> following [[#sparse-bit-set-decoding]]. For each
+        codepoint add the bias value to it and then add the result to the codepoint set in <var>entry</var>.
+
+10. TODO apply URI template.
+
+11. Return <var>entry id</var>, <var>entry</var>, and <var>consumed bytes</var>.
 
 <h5 algorithm id="sparse-bit-set-decoding">Sparse Bit Set</h5>
 

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="0e69829c29eada0bf85089b1b6aa16f6f49d4f43" name="document-revision">
+  <meta content="827875fcca66b8013ac1720df53269b10ef69670" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="827875fcca66b8013ac1720df53269b10ef69670" name="document-revision">
+  <meta content="0793b5645769ed5afc324993e7c3a641cabe0fcb" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-03-06">6 March 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-03-07">7 March 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -784,7 +784,8 @@ needed to render a subset of:</p>
    </ul>
    <p>supported by the original font. When a subsetted font is used to render text using any combination of the subset
 codepoints, <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout features</a>, or <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a> it should render identically to the original font. This includes rendering with the use of any optional typographic
-features that a renderer may choose to use from the original font, such as hinting instructions.</p>
+features that a renderer may choose to use from the original font, such as hinting instructions. Design variation spaces
+are specified using the user-axis scales (<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>).</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-subset-definition">font subset definition</dfn> describes the minimum data (codepoints, layout features,
 variation axis space) that a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset">font subset</a> should support.</p>
    <p class="note" role="note"><span class="marker">Note:</span> For convenience the remainder of this document links to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">[open-type]</a> specification which is a copy of <a data-link-type="biblio" href="#biblio-iso14496-22" title="Information technology — Coding of audio-visual objects — Part 22: Open Font Format">[iso14496-22]</a>.</p>
@@ -1098,9 +1099,10 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <th>Name
       <th>Description
      <tr>
-      <td><a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry">Mapping Entry</a>
-      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entries" data-dfn-type="dfn" data-noexport id="mapping-entries-entries">entries</dfn>[<a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount">entryCount</a>]
-      <td>List of entries. Each entry has a variable length, which is determined following <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a>.
+      <td>uint8
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entries" data-dfn-type="dfn" data-noexport id="mapping-entries-entries">entries</dfn>[variable]
+      <td>Byte array containing the encoded bytes of <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount">entryCount</a> <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry">Mapping Entry</a>'s. Each entry has a variable
+        length, which is determined following <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a>.
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entry">Mapping Entry</dfn> encoding:</p>
    <table>
@@ -1111,45 +1113,45 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <th>Description
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-format">format</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-formatflags">formatFlags</dfn>
       <td> A bit field. Bit 0 (least significant bit) through bit 5 indicate the presence of optional fields. If bit 6 is set this entry is
       ignored. Bit 7 is reserved for future use and set to 0. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featurecount">featureCount</dfn>
-      <td> Number of feature tags in the featureTags list. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format">format</a> bit 0 is set. 
+      <td> Number of feature tags in the featureTags list. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags">formatFlags</a> bit 0 is set. 
      <tr>
       <td>Tag
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags</dfn>[featureCount]
-      <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①">format</a> bit 0 is set. 
+      <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount</dfn>
-      <td> Number of elements in the design space list. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format②">format</a> bit 0 is set. 
+      <td> Number of elements in the design space list. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags②">formatFlags</a> bit 0 is set. 
      <tr>
       <td><a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment">Design Space Segment</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments</dfn>[designSpaceCount]
-      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition④">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format③">format</a> bit 0 is set. 
+      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition④">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copycount">copyCount</dfn>
-      <td> Number of entries in the copyIndices list. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format④">format</a> bit 1 is set. 
+      <td> Number of entries in the copyIndices list. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags④">formatFlags</a> bit 1 is set. 
      <tr>
       <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices</dfn>[copyCount]
       <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definition</a> should be copied into this entry. All
-      values must be less than the index of this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑤">format</a> bit 1 is set. 
+      values must be less than the index of this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
      <tr>
       <td>int16
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>
-      <td> Signed delta which is added to the entry id of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> to produce the id for this entry.
-      Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑥">format</a> bit 2 is set. 
+      <td> Signed delta which is used to calculate the id for this entry. The id for this entry is the entry id of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> + 1 + entryIdDelta. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set. If not present delta is assumed
+      to be 0. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchencoding">patchEncoding</dfn>
       <td> Specifies the format of the patch linked to by this entry. Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table.
       Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a>.
-      Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑦">format</a> bit 3 is set. 
+      Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑦">formatFlags</a> bit 3 is set. 
      <tr>
       <td>uint16/uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-bias">bias</dfn>
@@ -1161,7 +1163,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codepoints</dfn>[variable]
       <td> Set of codepoints for this mapping. Encoded as a <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. 
-      Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑧">format</a> bit 4 and/or 5 is set. The length is
+      Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 4 and/or 5 is set. The length is
       determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="design-space-segment">Design Space Segment</dfn> encoding:</p>
@@ -1178,11 +1180,11 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <tr>
       <td>Fixed
       <td><dfn data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-start">start<a class="self-link" href="#design-space-segment-start"></a></dfn>
-      <td> Start (inclusive) of the segment. 
+      <td> Start (inclusive) of the segment. This value uses the user axis scale: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
      <tr>
       <td>Fixed
       <td><dfn data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-end">end<a class="self-link" href="#design-space-segment-end"></a></dfn>
-      <td> End (inclusive) of the segment. Must be greater than or equal to start. 
+      <td> End (inclusive) of the segment. Must be greater than or equal to start. This value uses the user axis scale: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
    </table>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="4.1.2.1" id="interpreting-patch-map-format-2"><span class="secno">4.1.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
    <p>This algorithm is used to convert a format 2 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a>.</p>
@@ -1207,7 +1209,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry①">Interpret Format 2 Patch Map Entry</a>, <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount①">entryCount</a> times. For each invocation:</p>
      <ul>
       <li data-md>
-       <p>pass in the bytes from <var>patch map</var> starting from index (<a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a> + <var>current byte</var>) to
+       <p>pass in the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding①">defaultPatchEncoding</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
@@ -1252,9 +1254,9 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
     <li data-md>
      <p>Set the patch encoding of <var>entry</var> to <var>default patch encoding</var>.</p>
     <li data-md>
-     <p>Read <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑨">format</a> from <var>entry bytes</var>.</p>
+     <p>Read <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑨">formatFlags</a> from <var>entry bytes</var>.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①⓪">format</a> bit 0 is set, then the feature tag and design space lists are present:</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⓪">formatFlags</a> bit 0 is set, then the feature tag and design space lists are present:</p>
      <ul>
       <li data-md>
        <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to <var>entry</var>.</p>
@@ -1262,7 +1264,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
        <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to <var>entry</var>.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①①">format</a> bit 1 is set, then the copy indices list is present:</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①①">formatFlags</a> bit 1 is set, then the copy indices list is present:</p>
      <ul>
       <li data-md>
        <p>Read the copy indices list specified by <a data-link-type="dfn" href="#mapping-entry-copycount" id="ref-for-mapping-entry-copycount">copyCount</a> and <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices">copyIndices</a> from <var>entry bytes</var>.</p>
@@ -1272,18 +1274,18 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
  add all code points, feature tags, and design space segments from it to <var>entry</var>.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①②">format</a> bit 2 is set, then an id delta is present. Read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①②">formatFlags</a> bit 2 is set, then an id delta is present. Read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
  and the mapping is malformed.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①③">format</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①③">formatFlags</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.</p>
     <li data-md>
-     <p>If one or both of <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①④">format</a> bit 4 and bit 5 are set, then a codepoint list is present:</p>
+     <p>If one or both of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①④">formatFlags</a> bit 4 and bit 5 are set, then a codepoint list is present:</p>
      <ul>
       <li data-md>
-       <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①⑤">format</a> bit 4 is 0 and bit 5 is 1, then read the 2 byte (uint16) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias">bias</a> value
+       <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑤">formatFlags</a> bit 4 is 0 and bit 5 is 1, then read the 2 byte (uint16) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias">bias</a> value
 from <var>entry bytes</var>.</p>
       <li data-md>
-       <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①⑥">format</a> bit 4 is 1 and bit 5 is 1, then read the 3 byte (uint24) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias①">bias</a> value
+       <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑥">formatFlags</a> bit 4 is 1 and bit 5 is 1, then read the 3 byte (uint24) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias①">bias</a> value
 from <var>entry bytes</var>.</p>
       <li data-md>
        <p>Otherwise the bias is 0.</p>
@@ -1292,7 +1294,7 @@ from <var>entry bytes</var>.</p>
 codepoint add the bias value to it and then add the result to the codepoint set in <var>entry</var>.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①⑦">format</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑦">formatFlags</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
     <li data-md>
      <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 3.3 URI Templates</a>. Set the patch uri of <var>entry</var> to the generated URI.</p>
     <li data-md>
@@ -2076,12 +2078,12 @@ required too many patches.</p>
      <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
      <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
      <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 5.5</span>
-     <li><a href="#mapping-entry-format">dfn for Mapping Entry</a><span>, in § 4.1.2</span>
      <li><a href="#per-table-shared-brotli-patch-format">dfn for Per table shared brotli patch</a><span>, in § 5.4</span>
      <li><a href="#shared-brotli-patch-format">dfn for Shared brotli patch</a><span>, in § 5.3</span>
     </ul>
    <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 4.1.1</span>
    <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 4.1.2</span>
+   <li><a href="#mapping-entry-formatflags">formatFlags</a><span>, in § 4.1.2</span>
    <li><a href="#abstract-opdef-fully-expand-a-font-subset">Fully Expand a Font Subset</a><span>, in § 6.1</span>
    <li>
     glyphCount
@@ -2368,7 +2370,7 @@ window.dfnpanelData['format-2-patch-map-uritemplate'] = {"dfnID": "format-2-patc
 window.dfnpanelData['mapping-entries'] = {"dfnID": "mapping-entries", "url": "#mapping-entries", "dfnText": "Mapping Entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
 window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}, {"id": "ref-for-mapping-entries-entries\u2460"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entries-entries\u2461"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry'] = {"dfnID": "mapping-entry", "url": "#mapping-entry", "dfnText": "Mapping Entry", "refSections": [{"refs": [{"id": "ref-for-mapping-entry"}, {"id": "ref-for-mapping-entry\u2460"}, {"id": "ref-for-mapping-entry\u2461"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry\u2462"}, {"id": "ref-for-mapping-entry\u2463"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-format'] = {"dfnID": "mapping-entry-format", "url": "#mapping-entry-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-format"}, {"id": "ref-for-mapping-entry-format\u2460"}, {"id": "ref-for-mapping-entry-format\u2461"}, {"id": "ref-for-mapping-entry-format\u2462"}, {"id": "ref-for-mapping-entry-format\u2463"}, {"id": "ref-for-mapping-entry-format\u2464"}, {"id": "ref-for-mapping-entry-format\u2465"}, {"id": "ref-for-mapping-entry-format\u2466"}, {"id": "ref-for-mapping-entry-format\u2467"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-format\u2468"}, {"id": "ref-for-mapping-entry-format\u2460\u24ea"}, {"id": "ref-for-mapping-entry-format\u2460\u2460"}, {"id": "ref-for-mapping-entry-format\u2460\u2461"}, {"id": "ref-for-mapping-entry-format\u2460\u2462"}, {"id": "ref-for-mapping-entry-format\u2460\u2463"}, {"id": "ref-for-mapping-entry-format\u2460\u2464"}, {"id": "ref-for-mapping-entry-format\u2460\u2465"}, {"id": "ref-for-mapping-entry-format\u2460\u2466"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-formatflags'] = {"dfnID": "mapping-entry-formatflags", "url": "#mapping-entry-formatflags", "dfnText": "formatFlags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-formatflags"}, {"id": "ref-for-mapping-entry-formatflags\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2466"}, {"id": "ref-for-mapping-entry-formatflags\u2467"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-formatflags\u2468"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u24ea"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2466"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-featurecount'] = {"dfnID": "mapping-entry-featurecount", "url": "#mapping-entry-featurecount", "dfnText": "featureCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featurecount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-featuretags'] = {"dfnID": "mapping-entry-featuretags", "url": "#mapping-entry-featuretags", "dfnText": "featureTags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featuretags"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-designspacecount'] = {"dfnID": "mapping-entry-designspacecount", "url": "#mapping-entry-designspacecount", "dfnText": "designSpaceCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacecount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="bd53e4b272a3e46dc3fb59ce13672a9e0af8cd65" name="document-revision">
+  <meta content="bec0db47e3db30924456223afc29dc26e9b4ad51" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-02-15">15 February 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-03-04">4 March 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -586,7 +586,11 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
          <ol class="toc">
           <li><a href="#interpreting-patch-map-format-1"><span class="secno">4.1.1.1</span> <span class="content">Interpreting Format 1</span></a>
          </ol>
-        <li><a href="#patch-map-format-2"><span class="secno">4.1.2</span> <span class="content">Patch Map Table: Format 2</span></a>
+        <li>
+         <a href="#patch-map-format-2"><span class="secno">4.1.2</span> <span class="content">Patch Map Table: Format 2</span></a>
+         <ol class="toc">
+          <li><a href="#sparse-bit-set-decoding"><span class="secno">4.1.2.1</span> <span class="content">Sparse Bit Set</span></a>
+         </ol>
        </ol>
      </ol>
     <li>
@@ -652,52 +656,51 @@ decreasing the perceived latency between the time when a browser realizes it nee
 necessary text can be rendered with that font.</p>
    <p>The success of WebFonts is unevenly distributed. This specification allows WebFonts to be used where
 slow networks, very large fonts, or complex subsetting requirements currently preclude their use. For
-example, even using WOFF 2 <a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a>, fonts for CJK languages are too large to be practical.</p>
+example, even using WOFF 2 <a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a>, fonts for CJK languages can be too large to be practical.</p>
    <h3 class="heading settled" data-level="1.1" id="evaluation-report"><span class="secno">1.1. </span><span class="content">Technical Motivation: Evaluation Report</span><a class="self-link" href="#evaluation-report"></a></h3>
    <p>See the Progressive Font Enrichment: Evaluation Report <a data-link-type="biblio" href="#biblio-pfe-report" title="Progressive Font Enrichment: Evaluation Report">[PFE-report]</a> for the investigation which led
 to this specification.</p>
    <h3 class="heading settled" data-level="1.2" id="overview"><span class="secno">1.2. </span><span class="content">Overview</span><a class="self-link" href="#overview"></a></h3>
-   <p>An IFT font is a regular <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> font that is extended to include the incremental functionality via the addition
-of a two new <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a>. Using these new tables the font can be augmented (eg. to cover more codepoints)
+   <p>An IFT font is a regular <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> font that is reformated to include incremental functionality, partly in virtue of
+of two additional <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a>. Using these new tables the font can be augmented (eg. to cover more codepoints)
 by loading and applying patches to it.</p>
    <p>The IFT technology has four main pieces:</p>
    <ul>
     <li data-md>
      <p><a href="#font-format-extensions">§ 4 Extensions to the Font Format</a>: defines the new tables which contain a list of patches that are available to be applied to a font.</p>
     <li data-md>
-     <p><a href="#font-patch-formats">§ 5 Font Patch Formats</a>: defines three different types of patches that can be used. These range from generic binary patches, to a patch
- format that is specific to the font format.</p>
+     <p><a href="#font-patch-formats">§ 5 Font Patch Formats</a>: defines three different types of patches that can be used. Two are "generic" binary patches, one is
+ specific to the font’s format for storing glyph data.</p>
     <li data-md>
      <p><a href="#extending-font-subset">§ 6 Extending a Font Subset</a>: provides the algorithm that is used by a client to select and apply patches.</p>
     <li data-md>
-     <p><a href="#encoder">§ 7 Encoder</a>: encoders create the font and associated patches that form an incremental font.</p>
+     <p><a href="#encoder">§ 7 Encoder</a>: creates the font and associated patches that form an incremental font.</p>
    </ul>
    <p>At a high level an IFT font is used like this:</p>
    <ol>
     <li data-md>
-     <p>The client downloads an initial font file, which contains some subset of data from the full version of the font.</p>
+     <p>The client downloads an initial font file, which contains some initial subset of data from the full version of the font along with <a href="#font-format-extensions">embedded data</a> describing the set of <a href="#font-patch-formats">patches</a> which can be used to extend 
+the font.</p>
     <li data-md>
-     <p>Inside the font file there is <a href="#font-format-extensions">embedded data</a> which informs the client about
-a set of <a href="#font-patch-formats">patches</a> which are available and can be used to extend the font.</p>
-    <li data-md>
-     <p>Based on the content the client is trying to render it <a href="#extending-font-subset">selects, downloads, and applies</a> these patches to
-extend the font to cover additional characters. This step is repeated every time new content is being rendered.</p>
+     <p>Based on the content to be rendered, the client <a href="#extending-font-subset">selects, downloads, and applies</a> patches to extend
+the font to cover additional characters. This step is repeated each time there is new content.</p>
    </ol>
    <h3 class="heading settled" data-level="1.3" id="making-incremental-fonts"><span class="secno">1.3. </span><span class="content">Creating an Incremental Font</span><a class="self-link" href="#making-incremental-fonts"></a></h3>
    <p>It is expected that the most common way to produce an incremental font will be to convert an existing font to use the incremental
 encoding defined in this specification. At a high level converting an existing font to be incremental will look like this:</p>
    <ol>
     <li data-md>
-     <p>Create the base <a href="#font-subset-info">subset</a>, this will be the initial font file the client will load and usually will include the data
- from the original font that is expected to be always needed.</p>
+     <p>Choose the content of the initial <a href="#font-subset-info">subset</a>, this will be included in the initial font file the client loads
+and usually consists of any data from the original font that is expected to always be needed.</p>
     <li data-md>
      <p>Choose a segmentation of the font. Individual segments will be added to the base subset by the client using patches. Choosing an
- appropriate segmentation is one of the most important parts of producing an efficient encoding.</p>
+appropriate segmentation is one of the most important parts of producing an efficient encoding.</p>
     <li data-md>
-     <p>Based on the chosen segmentation generate a set of patches where each patch will add the data for a particular segment.</p>
+     <p>Based on these choices, generate a set of patches, where each patch adds the data for a particular segment relative to either
+the initial font file or a previous patch.</p>
     <li data-md>
-     <p>Add a <a href="#font-format-extensions">patch mapping</a> to the base subset. This mapping lists all of the available patch files,
-the url they reside at, and information on what data the patch will add to the font.</p>
+     <p>Generate the initial font file including the initial subset and a <a href="#font-format-extensions">patch mapping</a>. This mapping
+lists all of the available patch files, the url they reside at, and information on what data the patch will add to the font.</p>
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> this is a highly simplified description of creating an incremental font, a more in-depth discussion of generating an encoding and
 requirements on the encoding can be found in the <a href="#encoder">§ 7 Encoder</a> section.</p>
@@ -729,15 +732,15 @@ often the case for Chinese, Japanese, Korean, Emoji, and Icon fonts.</p>
 headline.</p>
    </ul>
    <p>An alternative to incremental transfer is to break a font into distinct subsets (typically by script)
-and use the unicode range feature of @font-face to load only the subsets needed. However, this can
-break rendering <a href="https://www.w3.org/TR/PFE-evaluation/#fail-subset">Progressive Font Enrichment: Evaluation Report § fail-subset</a> if there are layout rules between characters in
-different subsets. Incremental font transfer does not suffer from this issue as it maintains the
-original font and all it’s layout rules.</p>
+and use the unicode range feature of @font-face to load only the subsets needed. However, this can alter
+the rendering of some content <a href="https://www.w3.org/TR/PFE-evaluation/#fail-subset">Progressive Font Enrichment: Evaluation Report § fail-subset</a> if there are layout rules between characters in
+different subsets. Incremental font transfer does not suffer from this issue as it can emcompass the
+original font and all of it’s layout rules.</p>
    <h4 class="heading settled" data-level="1.4.1" id="reduce-requests"><span class="secno">1.4.1. </span><span class="content">Reducing the Number of Network Requests</span><a class="self-link" href="#reduce-requests"></a></h4>
    <p>As discussed in the previous section the most basic implementation of incremental font transfer will
 tend to increase the total number of requests made vs traditional font loading. Since each augmentation
-will require at least one round trip time, performance can be negatively impacted if too many requests
-are made. It’s possible for a client to preemptively request patches for codepoints that are not
+will typically require at least one round trip time, performance can be negatively impacted if too many requests
+are made. Depending on which patch types are available and how much information is provided in the <a href="#font-format-extensions">patch mapping</a>, a client might preemptively request patches for codepoints that are not
 currently needed, but expected to be needed in the future. Intelligent use of this feature by an
 implementation can help reduce the total number of requests being made. The evaluation report explored
 this by testing the performance of a basic character frequency based <a href="https://www.w3.org/TR/PFE-evaluation/#codepredict">codepoint prediction</a> scheme and found it improved overall performance.</p>
@@ -782,11 +785,11 @@ needed to render a subset of:</p>
 codepoints, <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout features</a>, or <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a> it should render identically to the original font. This includes rendering with the use of any optional typographic
 features that a renderer may choose to use from the original font, such as hinting instructions.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-subset-definition">font subset definition</dfn> describes the minimum data (codepoints, layout features,
-variation axis space) that a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset">font subset</a> should possess.</p>
+variation axis space) that a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset">font subset</a> should support.</p>
    <p class="note" role="note"><span class="marker">Note:</span> For convenience the remainder of this document links to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">[open-type]</a> specification which is a copy of <a data-link-type="biblio" href="#biblio-iso14496-22" title="Information technology — Coding of audio-visual objects — Part 22: Open Font Format">[iso14496-22]</a>.</p>
    <h3 class="heading settled" data-level="3.2" id="data-types"><span class="secno">3.2. </span><span class="content">Data Types</span><a class="self-link" href="#data-types"></a></h3>
    <p>Encoded data structures in the remainder of this specification are described in terms of the data types defined
-in <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types">OpenType Specification § otff#data-types</a>. As with the rest of OpenType, all fields use Big Endian byte ordering.</p>
+in <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types">OpenType Specification § otff#data-types</a>. As with the rest of OpenType, all fields use "big-endian" byte ordering.</p>
    <h3 class="heading settled" data-level="3.3" id="uri-templates"><span class="secno">3.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h3>
    <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric indices into URIs where patch files are located. Given a numeric index value,
 several variables are defined which are used to produce the expansion of the template:</p>
@@ -837,8 +840,9 @@ several variables are defined which are used to produce the expansion of the tem
    </div>
    <h2 class="heading settled" data-level="4" id="font-format-extensions"><span class="secno">4. </span><span class="content">Extensions to the Font Format</span><a class="self-link" href="#font-format-extensions"></a></h2>
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="incremental-font">incremental font</dfn> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but include two new <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both <a href="#patch-map">patch maps</a>, which encode a collection of mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which
-host <a href="#font-patch-formats">patches</a> that extend the incremental font. The mappings from the two tables is unioned together to produce
-the final mapping. All incremental fonts must contain at least an 'IFT ' table. The 'IFTX' table is optional.</p>
+host <a href="#font-patch-formats">patches</a> that extend the incremental font. All incremental fonts must contain the 'IFT ' table.
+The 'IFTX' table is optional. When both tables are present, the mapping of the font as a whole is the union of the mappings of
+the two tables.</p>
    <p class="note" role="note"><span class="marker">Note:</span> allowing the mapping to be split between two distinct tables allows an incremental font to more easily make use of multiple
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
 'IFTX' table. Those patches can make updates only to one of the mapping tables and avoid making conflicting updates.</p>
@@ -847,10 +851,11 @@ patch types. For example all patches of one type can be specified in the 'IFT ' 
 encoded in one of two formats:</p>
    <ul>
     <li data-md>
-     <p>Format 1: a limited, but more compact encoding. Encodes a one-to-one mapping from glyph id to patch URIs. Does not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
+     <p>Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URIs. It does
+not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
     <li data-md>
-     <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, typically less
-compact than format 1.</p>
+     <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
+is typically less compact than format 1.</p>
    </ul>
    <h4 class="heading settled" data-level="4.1.1" id="patch-map-format-1"><span class="secno">4.1.1. </span><span class="content">Patch Map Table: Format 1</span><a class="self-link" href="#patch-map-format-1"></a></h4>
    <p><dfn data-dfn-type="dfn" data-noexport id="format-1-patch-map">Format 1 Patch Map<a class="self-link" href="#format-1-patch-map"></a></dfn> encoding:</p>
@@ -1045,13 +1050,161 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
    </ol>
    <h4 class="heading settled" data-level="4.1.2" id="patch-map-format-2"><span class="secno">4.1.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
    <p>Coming soon.</p>
+   <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.1.2.1" id="sparse-bit-set-decoding"><span class="secno">4.1.2.1. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
+   <p>A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
+each node has a fixed number of children that recursively sub-divides an interval into equal partitions. A tree of height <i>H</i> with
+branching factor <i>B</i> can store set membership for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree
+is encoded into an array of bytes for transport.</p>
+   <p><dfn data-dfn-type="dfn" data-noexport id="sparse-bit-set">Sparse Bit Set<a class="self-link" href="#sparse-bit-set"></a></dfn> encoding:</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Type
+      <th>Name
+      <th>Description
+     <tr>
+      <td>uint8
+      <td>header
+      <td>Bits 0 (least significant) and 1 encode the trees branch factor <i>B</i>. Bits 2 through 6 are a 5-bit unsigned integer which
+        encodes the value of <i>H</i>. Bit 7 is set to 0 and reserved for future use. 
+     <tr>
+      <td>uint8
+      <td>treeData[variable]
+      <td>Binary encoding of the tree.
+   </table>
+   <p>The exact length of <var>treeData</var> is initially unknown, it’s length is determined by executing the decoding algorithm. When using
+branch factors of 2 or 4 the last node may only partially consume the bits in a byte. In that case all remaining bits are unused and
+ignored.</p>
+   <p><dfn data-dfn-type="dfn" data-noexport id="branch-factor-encoding">Branch Factor Encoding<a class="self-link" href="#branch-factor-encoding"></a></dfn>:</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Bit 1
+      <th>Bit 0
+      <th>Branch Factor (B)
+     <tr>
+      <td>0
+      <td>0
+      <td>2
+     <tr>
+      <td>0
+      <td>1
+      <td>4
+     <tr>
+      <td>1
+      <td>0
+      <td>8
+     <tr>
+      <td>1
+      <td>1
+      <td>32
+   </table>
+   <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData<a class="self-link" href="#abstract-opdef-decoding-sparse-bit-set-treedata"></a></dfn></p>
+   <p>The inputs to this algorithm are:</p>
+   <ul>
+    <li data-md>
+     <p><var>H</var>: the tree height, <var>H</var>, from the header byte.</p>
+    <li data-md>
+     <p><var>B</var>: the branch factor, <var>B</var>, from the header byte.</p>
+    <li data-md>
+     <p><var>treeData</var>: array of bytes to be decoded.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p><var>S</var>: a set of unsigned integers.</p>
+   </ul>
+   <p>The algorithm, using a FIFO (first in first out) queue <var>Q</var>:</p>
+   <ol>
+    <li data-md>
+     <p>If <var>H</var> is equal to 0, then this is an empty set and no bytes of <var>treeData</var> are consumed. Return an empty set.</p>
+    <li data-md>
+     <p>Insert the tuple (0, 1) into <var>Q</var>.</p>
+    <li data-md>
+     <p>Initialize <var>S</var> to an empty set.</p>
+    <li data-md>
+     <p><var>treeData</var> is interpreted as a string of bits where the least significant bit of <var>treeData</var>[0] is the first bit in
+ the string, the most significant bit of <var>treeData</var>[0] is the 8th bit, and so on.</p>
+    <li data-md>
+     <p>If <var>Q</var> is empty return <var>S</var>.</p>
+    <li data-md>
+     <p>Extract the next tuple <var>t</var> from <var>Q</var>. The first value of
+ in <var>t</var> is <var>start</var> and the second value is <var>depth</var>.</p>
+    <li data-md>
+     <p>Remove the next <var>B</var> bits from the <var>treeData</var> bit string. The first removed bit is <i>v<sub>1</sub></i>,
+ the second is <i>v<sub>2</sub></i>, and so on until the last removed bit which is <i>v<sub>B</sub></i>. If prior to removal there
+ were less than <var>B</var> bits left in <var>treeData</var>, then <var>treeData</var> is malformed, return an error.</p>
+    <li data-md>
+     <p>If all bits <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i> are 0, then insert all integers in the interval
+[<var>start</var>, <var>start</var> + <var>B</var><sup><var>H</var> - <var>depth</var> + 1</sup>)
+into <var>S</var>. Go to step 5.</p>
+    <li data-md>
+     <p>For each <i>v<sub>i</sub></i> which is equal to 1 in <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i>:
+ If <var>depth</var> is equal to <var>H</var> add
+ integer <var>start</var> + <i>i</i> - 1 to <var>S</var>. Otherwise, insert the tuple
+ (<var>start</var> + (i - 1) * <var>B</var><sup><var>H</var> - <var>depth</var></sup>, <var>depth</var> + 1)
+ into <var>Q</var>.</p>
+    <li data-md>
+     <p>Go to step 5.</p>
+   </ol>
+   <p class="note" role="note"><span class="marker">Note:</span> when encoding sparse bit sets the encoder can use any of the possible branching factors, but it is recommended to
+use 4 as that has <a href="https://github.com/w3c/PFE-analysis/blob/main/results/set_encoding_branch_factor.md">been shown</a> to give the smallest encodings for most unicode codepoint sets typically encountered.</p>
+   <div class="example" id="example-eb491b43">
+    <a class="self-link" href="#example-eb491b43"></a> The set {2, 33, 323} in a tree with a branching factor of 8 can be encoded as the bit string: 
+<pre>bit string:
+|-- header --|- lvl 0 |---- level 1 ----|------- level 2 -----------|
+| B=8 H=3    |   n0   |   n1       n2   |   n3       n4       n5    |
+[ 01  11000 0 10000100 10001000 10000000 00100000 01000000 00010000 ]
+
+Which then becomes the byte string:
+[
+  0b00001110,
+  0b00100001,
+  0b00010001,
+  0b00000001,
+  0b00000100,
+  0b00000010,
+  0b00001000
+]
+</pre>
+   </div>
+   <div class="example" id="example-e803ad63">
+    <a class="self-link" href="#example-e803ad63"></a> The empty set in a tree with a branching factor of 2 is encoded as the bit string: 
+<pre>bit string:
+|-- header -- |
+| B=2 H=0     |
+[ 00  00000 0 ]
+
+Which then becomes the byte string:
+[
+  0b00000000,
+]
+</pre>
+   </div>
+   <div class="example" id="example-cc307778">
+    <a class="self-link" href="#example-cc307778"></a> The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as: 
+<pre>bit string:
+|-- header --| l0 |- lvl 1 -| l2  |
+| B=4 H=3    | n0 | n1 | n2 | n3  |
+[ 10  11000 0 1100 0000 1000 1100 ]
+
+byte string:
+[
+  0b00001101,
+  0b00000011,
+  0b00110001
+]
+</pre>
+   </div>
    <h2 class="heading settled" data-level="5" id="font-patch-formats"><span class="secno">5. </span><span class="content">Font Patch Formats</span><a class="self-link" href="#font-patch-formats"></a></h2>
-   <p>In incremental font transfer <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②">font subsets</a> are extended by applying patches. Due to the different
-capabilities required in different situations this specification defines three different patch formats that can be used.</p>
+   <p>In incremental font transfer <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②">font subsets</a> are extended by applying patches.
+This specification defines three patch formats, each appropriate to its own set of augmentation scenarios. A single
+encoding can make use of more than one patch format.</p>
    <h3 class="heading settled" data-level="5.1" id="font-patch-definitions"><span class="secno">5.1. </span><span class="content">Definitions</span><a class="self-link" href="#font-patch-definitions"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-patch">font patch</dfn> is a file which encodes changes to be made to an existing font file. Patches are used to extend
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-patch">font patch</dfn> is a file which encodes changes to be made to an IFT-encoded font. Patches are used to extend
 an existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> and provide expanded coverage.</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-format">patch format</dfn> is a specified encoding used to encode changes to be applied to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a> into a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Every <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs a new extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a>. Each <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> can be categorized as either independent or dependent. Given a set of <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch②">font patches</a>, <code>P</code>, that are all valid to be applied to a specific <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a>, <code>F</code>:</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-format">patch format</dfn> is a specified encoding of changes to be applied relative to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>. A set of
+changes encoded according to the format is a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Each <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a>. Each <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> can be categorized as either independent or dependent. Given a set of <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch②">font patches</a>, <code>P</code>, that are all valid to be applied to a specific <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a>, <code>F</code>:</p>
    <ul>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="dependent">dependent</dfn> patches are only valid to be applied to <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a> <code>F</code>. Applying any patches from <code>P</code> to <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a> <code>F</code> will change the subset and thus invalidate any remaining dependent patches
@@ -1608,6 +1761,7 @@ required too many patches.</p>
    <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 5.5.1</span>
    <li><a href="#abstract-opdef-apply-per-table-shared-brotli-patch">Apply per table shared brotli patch</a><span>, in § 5.4.1</span>
    <li><a href="#abstract-opdef-apply-shared-brotli-patch">Apply shared brotli patch</a><span>, in § 5.3.1</span>
+   <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 4.1.2.1</span>
    <li>
     brotliStream
     <ul>
@@ -1616,6 +1770,7 @@ required too many patches.</p>
      <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 5.4</span>
     </ul>
    <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 6</span>
+   <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 4.1.2.1</span>
    <li><a href="#dependent">dependent</a><span>, in § 5.1</span>
    <li><a href="#format-1-patch-map-entrycount">entryCount</a><span>, in § 4.1.1</span>
    <li><a href="#glyph-map-entryindex">entryIndex</a><span>, in § 4.1.1</span>
@@ -1687,6 +1842,7 @@ required too many patches.</p>
    <li><a href="#per-table-shared-brotli-patch">Per table shared brotli patch</a><span>, in § 5.4</span>
    <li><a href="#format-1-patch-map-reserved">reserved</a><span>, in § 4.1.1</span>
    <li><a href="#shared-brotli-patch">Shared brotli patch</a><span>, in § 5.3</span>
+   <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.1.2.1</span>
    <li><a href="#glyphpatches-tablecount">tableCount</a><span>, in § 5.5</span>
    <li><a href="#tablepatch">TablePatch</a><span>, in § 5.4</span>
    <li><a href="#glyphpatches-tables">tables</a><span>, in § 5.5</span>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="bec0db47e3db30924456223afc29dc26e9b4ad51" name="document-revision">
+  <meta content="e77d47cc46d8f681a12b98228f9ecf3c1a25d101" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-03-04">4 March 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-03-05">5 March 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -905,7 +905,7 @@ is typically less compact than format 1.</p>
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a template (TODO) which is used to produce URIs associated with each entry. 
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 3.3 URI Templates</a> which is used to produce URIs associated with each entry. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchencoding">patchEncoding</dfn>
@@ -1049,7 +1049,139 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      </ul>
    </ol>
    <h4 class="heading settled" data-level="4.1.2" id="patch-map-format-2"><span class="secno">4.1.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
-   <p>Coming soon.</p>
+   <p><dfn data-dfn-type="dfn" data-noexport id="format-2-patch-map">Format 2 Patch Map<a class="self-link" href="#format-2-patch-map"></a></dfn> encoding:</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Type
+      <th>Name
+      <th>Description
+     <tr>
+      <td>uint8
+      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-format">format<a class="self-link" href="#format-2-patch-map-format"></a></dfn>
+      <td>Set to 2, identifies this as format 2.
+     <tr>
+      <td>uint32
+      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-reserved">reserved<a class="self-link" href="#format-2-patch-map-reserved"></a></dfn>
+      <td>Not used, set to 0.
+     <tr>
+      <td>uint32
+      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-id">id<a class="self-link" href="#format-2-patch-map-id"></a></dfn>[4]
+      <td>Unique ID used to identify patches that are compatible with this font.
+     <tr>
+      <td>uint8
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</dfn>
+      <td> Specifies the format of the patches linked to by uriTemplate. Using the ID number from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table. 
+     <tr>
+      <td>uint16
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entrycount">entryCount</dfn>
+      <td>Number of entries encoded in this table.
+     <tr>
+      <td>Offset32
+      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entries">entries<a class="self-link" href="#format-2-patch-map-entries"></a></dfn>
+      <td>Offset to a <a data-link-type="dfn" href="#mapping-entries" id="ref-for-mapping-entries">Mapping Entries</a> sub table. Offset is from the start of this table.
+     <tr>
+      <td>uint16
+      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplatelength">uriTemplateLength<a class="self-link" href="#format-2-patch-map-uritemplatelength"></a></dfn>
+      <td> Length of the uriTemplate string. 
+     <tr>
+      <td>uint8
+      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplate">uriTemplate<a class="self-link" href="#format-2-patch-map-uritemplate"></a></dfn>[uriTemplateLength]
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 3.3 URI Templates</a> which is used to produce URIs associated with each entry. 
+   </table>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entries">Mapping Entries</dfn> encoding:</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Type
+      <th>Name
+      <th>Description
+     <tr>
+      <td><a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry">Mapping Entry</a>
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entries" data-dfn-type="dfn" data-noexport id="mapping-entries-entries">entries</dfn>[<a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount">entryCount</a>]
+      <td>List of entries. Each entry has a variable length.
+   </table>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entry">Mapping Entry</dfn> encoding:</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Type
+      <th>Name
+      <th>Description
+     <tr>
+      <td>uint8
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-format">format</dfn>
+      <td> A bit field. Bit 0 (least significant bit) through bit 5 indicate presence of optional fields. If bit 6 is set this entry is ignored.
+      Bit 7 is reserved for future use and set to 0. 
+     <tr>
+      <td>uint8
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featurecount">featureCount<a class="self-link" href="#mapping-entry-featurecount"></a></dfn>
+      <td> Number of feature tags in the featureTags list. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format">format</a> bit 0 is set. 
+     <tr>
+      <td>Tag
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags<a class="self-link" href="#mapping-entry-featuretags"></a></dfn>[featureCount]
+      <td> Array of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①">format</a> bit 0 is set. 
+     <tr>
+      <td>uint8
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount<a class="self-link" href="#mapping-entry-designspacecount"></a></dfn>
+      <td> Number of elements in the design space list. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format②">format</a> bit 0 is set. 
+     <tr>
+      <td><a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment">Design Space Segment</a>
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments<a class="self-link" href="#mapping-entry-designspacesegments"></a></dfn>[designSpaceCount]
+      <td> Array of <a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment①">Design Space Segment</a>'s. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format③">format</a> bit 0 is set. 
+     <tr>
+      <td>uint8
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copycount">copyCount<a class="self-link" href="#mapping-entry-copycount"></a></dfn>
+      <td> Number of entries in the copyIndices list. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format④">format</a> bit 1 is set. 
+     <tr>
+      <td>uint16
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices<a class="self-link" href="#mapping-entry-copyindices"></a></dfn>[copyCount]
+      <td> Array of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array which should be copied into this mapping. All values must be less than
+      the index of this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑤">format</a> bit 1 is set. 
+     <tr>
+      <td>int16
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryindexdelta">entryIndexDelta<a class="self-link" href="#mapping-entry-entryindexdelta"></a></dfn>
+      <td> Delta which is added to the entry index of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> to produce the entry index for this entry.
+      Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑥">format</a> bit 2 is set. 
+     <tr>
+      <td>uint8
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchencoding">patchEncoding<a class="self-link" href="#mapping-entry-patchencoding"></a></dfn>
+      <td> Specifies the format of the patch linked to by this entry. Using the ID number from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table.
+      Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a>.
+      Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑦">format</a> bit 3 is set. 
+     <tr>
+      <td>uint16/uint24
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-bias">bias<a class="self-link" href="#mapping-entry-bias"></a></dfn>
+      <td> Bias value which is added to all codepoint values encoded in the codepoints set.
+      If format bit 4 is 0 and bit 5 is 1, then this is present and a uint16.
+      If format bit 4 is 1 and bit 5 is 1, then this is present and a uint24.
+      Otherwise it is not present. 
+     <tr>
+      <td>uint8
+      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codepoints<a class="self-link" href="#mapping-entry-codepoints"></a></dfn>[variable]
+      <td> Set of codepoints for this mapping. Encoded as a <a href="#sparse-bit-set-decoding">§ 4.1.2.1 Sparse Bit Set</a>. 
+      Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑧">format</a> bit 4 and/or 5 is set. 
+   </table>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="design-space-segment">Design Space Segment</dfn> encoding:</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Type
+      <th>Name
+      <th>Description
+     <tr>
+      <td>Tag
+      <td><dfn data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-tag">tag<a class="self-link" href="#design-space-segment-tag"></a></dfn>
+      <td> Axis tag value. 
+     <tr>
+      <td>Fixed
+      <td><dfn data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-start">start<a class="self-link" href="#design-space-segment-start"></a></dfn>
+      <td> Start (inclusive) of the segment. 
+     <tr>
+      <td>Fixed
+      <td><dfn data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-end">end<a class="self-link" href="#design-space-segment-end"></a></dfn>
+      <td> End (inclusive) of the segment. Must be greater than or equal to start. 
+   </table>
    <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.1.2.1" id="sparse-bit-set-decoding"><span class="secno">4.1.2.1. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
    <p>A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
 each node has a fixed number of children that recursively sub-divides an interval into equal partitions. A tree of height <i>H</i> with
@@ -1761,6 +1893,7 @@ required too many patches.</p>
    <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 5.5.1</span>
    <li><a href="#abstract-opdef-apply-per-table-shared-brotli-patch">Apply per table shared brotli patch</a><span>, in § 5.4.1</span>
    <li><a href="#abstract-opdef-apply-shared-brotli-patch">Apply shared brotli patch</a><span>, in § 5.3.1</span>
+   <li><a href="#mapping-entry-bias">bias</a><span>, in § 4.1.2</span>
    <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 4.1.2.1</span>
    <li>
     brotliStream
@@ -1770,20 +1903,46 @@ required too many patches.</p>
      <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 5.4</span>
     </ul>
    <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 6</span>
+   <li><a href="#mapping-entry-codepoints">codepoints</a><span>, in § 4.1.2</span>
+   <li><a href="#mapping-entry-copycount">copyCount</a><span>, in § 4.1.2</span>
+   <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 4.1.2</span>
    <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 4.1.2.1</span>
+   <li><a href="#format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a><span>, in § 4.1.2</span>
    <li><a href="#dependent">dependent</a><span>, in § 5.1</span>
-   <li><a href="#format-1-patch-map-entrycount">entryCount</a><span>, in § 4.1.1</span>
+   <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 4.1.2</span>
+   <li><a href="#design-space-segment">Design Space Segment</a><span>, in § 4.1.2</span>
+   <li><a href="#mapping-entry-designspacesegments">designSpaceSegments</a><span>, in § 4.1.2</span>
+   <li><a href="#design-space-segment-end">end</a><span>, in § 4.1.2</span>
+   <li>
+    entries
+    <ul>
+     <li><a href="#format-2-patch-map-entries">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
+     <li><a href="#mapping-entries-entries">dfn for Mapping Entries</a><span>, in § 4.1.2</span>
+    </ul>
+   <li>
+    entryCount
+    <ul>
+     <li><a href="#format-1-patch-map-entrycount">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
+     <li><a href="#format-2-patch-map-entrycount">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
+    </ul>
    <li><a href="#glyph-map-entryindex">entryIndex</a><span>, in § 4.1.1</span>
+   <li><a href="#mapping-entry-entryindexdelta">entryIndexDelta</a><span>, in § 4.1.2</span>
    <li><a href="#featurerecord-entrymapcount">entryMapCount</a><span>, in § 4.1.1</span>
    <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 4.1.1</span>
    <li><a href="#feature-map-entrymaprecords">entryMapRecords</a><span>, in § 4.1.1</span>
    <li><a href="#abstract-opdef-extend-a-font-subset">Extend a Font Subset</a><span>, in § 6</span>
-   <li><a href="#feature-map-featurecount">featureCount</a><span>, in § 4.1.1</span>
+   <li>
+    featureCount
+    <ul>
+     <li><a href="#feature-map-featurecount">dfn for Feature Map</a><span>, in § 4.1.1</span>
+     <li><a href="#mapping-entry-featurecount">dfn for Mapping Entry</a><span>, in § 4.1.2</span>
+    </ul>
    <li><a href="#feature-map">Feature Map</a><span>, in § 4.1.1</span>
    <li><a href="#format-1-patch-map-featuremapoffset">featureMapOffset</a><span>, in § 4.1.1</span>
    <li><a href="#featurerecord">FeatureRecord</a><span>, in § 4.1.1</span>
    <li><a href="#feature-map-featurerecords">featureRecords</a><span>, in § 4.1.1</span>
    <li><a href="#featurerecord-featuretag">featureTag</a><span>, in § 4.1.1</span>
+   <li><a href="#mapping-entry-featuretags">featureTags</a><span>, in § 4.1.2</span>
    <li>
     firstEntryIndex
     <ul>
@@ -1799,11 +1958,14 @@ required too many patches.</p>
     format
     <ul>
      <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
+     <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
      <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 5.5</span>
+     <li><a href="#mapping-entry-format">dfn for Mapping Entry</a><span>, in § 4.1.2</span>
      <li><a href="#per-table-shared-brotli-patch-format">dfn for Per table shared brotli patch</a><span>, in § 5.4</span>
      <li><a href="#shared-brotli-patch-format">dfn for Shared brotli patch</a><span>, in § 5.3</span>
     </ul>
    <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 4.1.1</span>
+   <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 4.1.2</span>
    <li><a href="#abstract-opdef-fully-expand-a-font-subset">Fully Expand a Font Subset</a><span>, in § 6.1</span>
    <li>
     glyphCount
@@ -1823,6 +1985,7 @@ required too many patches.</p>
     id
     <ul>
      <li><a href="#format-1-patch-map-id">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
+     <li><a href="#format-2-patch-map-id">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
      <li><a href="#glyph-keyed-patch-id">dfn for Glyph keyed patch</a><span>, in § 5.5</span>
      <li><a href="#per-table-shared-brotli-patch-id">dfn for Per table shared brotli patch</a><span>, in § 5.4</span>
      <li><a href="#shared-brotli-patch-id">dfn for Shared brotli patch</a><span>, in § 5.3</span>
@@ -1833,22 +1996,50 @@ required too many patches.</p>
    <li><a href="#entrymaprecord-lastentryindex">lastEntryIndex</a><span>, in § 4.1.1</span>
    <li><a href="#glyph-keyed-patch-length">length</a><span>, in § 5.5</span>
    <li><a href="#abstract-opdef-load-patch-file">Load patch file</a><span>, in § 6</span>
+   <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 4.1.2</span>
+   <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 4.1.2</span>
    <li><a href="#patch-application-algorithm">patch application algorithm</a><span>, in § 5.1</span>
-   <li><a href="#format-1-patch-map-patchencoding">patchEncoding</a><span>, in § 4.1.1</span>
+   <li>
+    patchEncoding
+    <ul>
+     <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
+     <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 4.1.2</span>
+    </ul>
    <li><a href="#per-table-shared-brotli-patch-patches">patches</a><span>, in § 5.4</span>
    <li><a href="#per-table-shared-brotli-patch-patchescount">patchesCount</a><span>, in § 5.4</span>
    <li><a href="#patch-format">patch format</a><span>, in § 5.1</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 4.1</span>
    <li><a href="#per-table-shared-brotli-patch">Per table shared brotli patch</a><span>, in § 5.4</span>
-   <li><a href="#format-1-patch-map-reserved">reserved</a><span>, in § 4.1.1</span>
+   <li>
+    reserved
+    <ul>
+     <li><a href="#format-1-patch-map-reserved">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
+     <li><a href="#format-2-patch-map-reserved">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
+    </ul>
    <li><a href="#shared-brotli-patch">Shared brotli patch</a><span>, in § 5.3</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.1.2.1</span>
+   <li><a href="#design-space-segment-start">start</a><span>, in § 4.1.2</span>
    <li><a href="#glyphpatches-tablecount">tableCount</a><span>, in § 5.5</span>
    <li><a href="#tablepatch">TablePatch</a><span>, in § 5.4</span>
    <li><a href="#glyphpatches-tables">tables</a><span>, in § 5.5</span>
-   <li><a href="#tablepatch-tag">tag</a><span>, in § 5.4</span>
-   <li><a href="#format-1-patch-map-uritemplate">uriTemplate</a><span>, in § 4.1.1</span>
-   <li><a href="#format-1-patch-map-uritemplatelength">uriTemplateLength</a><span>, in § 4.1.1</span>
+   <li>
+    tag
+    <ul>
+     <li><a href="#design-space-segment-tag">dfn for Design Space Segment</a><span>, in § 4.1.2</span>
+     <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 5.4</span>
+    </ul>
+   <li>
+    uriTemplate
+    <ul>
+     <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
+     <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
+    </ul>
+   <li>
+    uriTemplateLength
+    <ul>
+     <li><a href="#format-1-patch-map-uritemplatelength">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
+     <li><a href="#format-2-patch-map-uritemplatelength">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
+    </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -2052,6 +2243,13 @@ window.dfnpanelData['entrymaprecord'] = {"dfnID": "entrymaprecord", "url": "#ent
 window.dfnpanelData['entrymaprecord-firstentryindex'] = {"dfnID": "entrymaprecord-firstentryindex", "url": "#entrymaprecord-firstentryindex", "dfnText": "firstEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-firstentryindex"}, {"id": "ref-for-entrymaprecord-firstentryindex\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['entrymaprecord-lastentryindex'] = {"dfnID": "entrymaprecord-lastentryindex", "url": "#entrymaprecord-lastentryindex", "dfnText": "lastEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-lastentryindex"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-1-patch-map'] = {"dfnID": "abstract-opdef-interpret-format-1-patch-map", "url": "#abstract-opdef-interpret-format-1-patch-map", "dfnText": "Interpret Format 1 Patch Map", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-1-patch-map"}], "title": "6. Extending a Font Subset"}], "external": false};
+window.dfnpanelData['format-2-patch-map-defaultpatchencoding'] = {"dfnID": "format-2-patch-map-defaultpatchencoding", "url": "#format-2-patch-map-defaultpatchencoding", "dfnText": "defaultPatchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch-map-entrycount", "url": "#format-2-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entrycount"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['mapping-entries'] = {"dfnID": "mapping-entries", "url": "#mapping-entries", "dfnText": "Mapping Entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry'] = {"dfnID": "mapping-entry", "url": "#mapping-entry", "dfnText": "Mapping Entry", "refSections": [{"refs": [{"id": "ref-for-mapping-entry"}, {"id": "ref-for-mapping-entry\u2460"}, {"id": "ref-for-mapping-entry\u2461"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-format'] = {"dfnID": "mapping-entry-format", "url": "#mapping-entry-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-format"}, {"id": "ref-for-mapping-entry-format\u2460"}, {"id": "ref-for-mapping-entry-format\u2461"}, {"id": "ref-for-mapping-entry-format\u2462"}, {"id": "ref-for-mapping-entry-format\u2463"}, {"id": "ref-for-mapping-entry-format\u2464"}, {"id": "ref-for-mapping-entry-format\u2465"}, {"id": "ref-for-mapping-entry-format\u2466"}, {"id": "ref-for-mapping-entry-format\u2467"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['design-space-segment'] = {"dfnID": "design-space-segment", "url": "#design-space-segment", "dfnText": "Design Space Segment", "refSections": [{"refs": [{"id": "ref-for-design-space-segment"}, {"id": "ref-for-design-space-segment\u2460"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
 window.dfnpanelData['font-patch'] = {"dfnID": "font-patch", "url": "#font-patch", "dfnText": "font patch", "refSections": [{"refs": [{"id": "ref-for-font-patch"}, {"id": "ref-for-font-patch\u2460"}, {"id": "ref-for-font-patch\u2461"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-patch\u2462"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-format'] = {"dfnID": "patch-format", "url": "#patch-format", "dfnText": "patch format", "refSections": [{"refs": [{"id": "ref-for-patch-format"}, {"id": "ref-for-patch-format\u2460"}], "title": "5.1. Definitions"}], "external": false};
 window.dfnpanelData['patch-application-algorithm'] = {"dfnID": "patch-application-algorithm", "url": "#patch-application-algorithm", "dfnText": "patch application algorithm", "refSections": [{"refs": [{"id": "ref-for-patch-application-algorithm"}], "title": "5.1. Definitions"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="e77d47cc46d8f681a12b98228f9ecf3c1a25d101" name="document-revision">
+  <meta content="761cdb0b3f1a196e3e45baf0058e47c9e341f2e0" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-03-05">5 March 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-03-06">6 March 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -589,7 +589,8 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
         <li>
          <a href="#patch-map-format-2"><span class="secno">4.1.2</span> <span class="content">Patch Map Table: Format 2</span></a>
          <ol class="toc">
-          <li><a href="#sparse-bit-set-decoding"><span class="secno">4.1.2.1</span> <span class="content">Sparse Bit Set</span></a>
+          <li><a href="#interpreting-patch-map-format-2"><span class="secno">4.1.2.1</span> <span class="content">Interpreting Format 2</span></a>
+          <li><a href="#sparse-bit-set-decoding"><span class="secno">4.1.2.2</span> <span class="content">Sparse Bit Set</span></a>
          </ol>
        </ol>
      </ol>
@@ -1078,7 +1079,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td>Number of entries encoded in this table.
      <tr>
       <td>Offset32
-      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entries">entries<a class="self-link" href="#format-2-patch-map-entries"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entries">entries</dfn>
       <td>Offset to a <a data-link-type="dfn" href="#mapping-entries" id="ref-for-mapping-entries">Mapping Entries</a> sub table. Offset is from the start of this table.
      <tr>
       <td>uint16
@@ -1086,7 +1087,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td> Length of the uriTemplate string. 
      <tr>
       <td>uint8
-      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplate">uriTemplate<a class="self-link" href="#format-2-patch-map-uritemplate"></a></dfn>[uriTemplateLength]
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
       <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 3.3 URI Templates</a> which is used to produce URIs associated with each entry. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entries">Mapping Entries</dfn> encoding:</p>
@@ -1115,51 +1116,51 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       Bit 7 is reserved for future use and set to 0. 
      <tr>
       <td>uint8
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featurecount">featureCount<a class="self-link" href="#mapping-entry-featurecount"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featurecount">featureCount</dfn>
       <td> Number of feature tags in the featureTags list. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format">format</a> bit 0 is set. 
      <tr>
       <td>Tag
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags<a class="self-link" href="#mapping-entry-featuretags"></a></dfn>[featureCount]
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags</dfn>[featureCount]
       <td> Array of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①">format</a> bit 0 is set. 
      <tr>
       <td>uint8
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount<a class="self-link" href="#mapping-entry-designspacecount"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount</dfn>
       <td> Number of elements in the design space list. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format②">format</a> bit 0 is set. 
      <tr>
       <td><a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment">Design Space Segment</a>
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments<a class="self-link" href="#mapping-entry-designspacesegments"></a></dfn>[designSpaceCount]
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments</dfn>[designSpaceCount]
       <td> Array of <a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment①">Design Space Segment</a>'s. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format③">format</a> bit 0 is set. 
      <tr>
       <td>uint8
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copycount">copyCount<a class="self-link" href="#mapping-entry-copycount"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copycount">copyCount</dfn>
       <td> Number of entries in the copyIndices list. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format④">format</a> bit 1 is set. 
      <tr>
       <td>uint16
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices<a class="self-link" href="#mapping-entry-copyindices"></a></dfn>[copyCount]
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices</dfn>[copyCount]
       <td> Array of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array which should be copied into this mapping. All values must be less than
       the index of this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑤">format</a> bit 1 is set. 
      <tr>
       <td>int16
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryindexdelta">entryIndexDelta<a class="self-link" href="#mapping-entry-entryindexdelta"></a></dfn>
-      <td> Delta which is added to the entry index of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> to produce the entry index for this entry.
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>
+      <td> Delta which is added to the entry id of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> to produce the entry id for this entry.
       Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑥">format</a> bit 2 is set. 
      <tr>
       <td>uint8
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchencoding">patchEncoding<a class="self-link" href="#mapping-entry-patchencoding"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchencoding">patchEncoding</dfn>
       <td> Specifies the format of the patch linked to by this entry. Using the ID number from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table.
       Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑦">format</a> bit 3 is set. 
      <tr>
       <td>uint16/uint24
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-bias">bias<a class="self-link" href="#mapping-entry-bias"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-bias">bias</dfn>
       <td> Bias value which is added to all codepoint values encoded in the codepoints set.
       If format bit 4 is 0 and bit 5 is 1, then this is present and a uint16.
       If format bit 4 is 1 and bit 5 is 1, then this is present and a uint24.
       Otherwise it is not present. 
      <tr>
       <td>uint8
-      <td><dfn data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codepoints<a class="self-link" href="#mapping-entry-codepoints"></a></dfn>[variable]
-      <td> Set of codepoints for this mapping. Encoded as a <a href="#sparse-bit-set-decoding">§ 4.1.2.1 Sparse Bit Set</a>. 
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codepoints</dfn>[variable]
+      <td> Set of codepoints for this mapping. Encoded as a <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. 
       Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑧">format</a> bit 4 and/or 5 is set. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="design-space-segment">Design Space Segment</dfn> encoding:</p>
@@ -1182,7 +1183,116 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td><dfn data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-end">end<a class="self-link" href="#design-space-segment-end"></a></dfn>
       <td> End (inclusive) of the segment. Must be greater than or equal to start. 
    </table>
-   <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.1.2.1" id="sparse-bit-set-decoding"><span class="secno">4.1.2.1. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
+   <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="4.1.2.1" id="interpreting-patch-map-format-2"><span class="secno">4.1.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
+   <p>This algorithm is used to convert a format 2 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a>.</p>
+   <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map<a class="self-link" href="#abstract-opdef-interpret-format-2-patch-map"></a></dfn></p>
+   <p>The inputs to this algorithm are:</p>
+   <ul>
+    <li data-md>
+     <p><var>patch map</var>: a <a href="#patch-map-format-2">§ 4.1.2 Patch Map Table: Format 2</a> encoded patch map.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">patch map entries</a>.</p>
+   </ul>
+   <p>The algorithm:</p>
+   <ol>
+    <li data-md>
+     <p>Check that the <var>patch map</var> is valid according to the requirements in <a href="#patch-map-format-2">§ 4.1.2 Patch Map Table: Format 2</a>. If it is not return an error.</p>
+    <li data-md>
+     <p>Initialize <var>last entry id</var> to 0, and <var>current byte</var> to 0.</p>
+    <li data-md>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a>, <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount①">entryCount</a> times. For each invocation:</p>
+     <ul>
+      <li data-md>
+       <p>pass in the bytes from <var>patch map</var> starting from index (<a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a> + <var>current byte</var>) to
+ the end of <var>patch map</var>, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding①">defaultPatchEncoding</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
+      <li data-md>
+       <p>Add the returned entry to <var>entry list</var>.</p>
+      <li data-md>
+       <p>Set <var>last entry id</var> to the returned entry id.</p>
+      <li data-md>
+       <p>Add the returned consumed byte count to <var>current byte</var>.</p>
+     </ul>
+    <li data-md>
+     <p>Return <var>entry list</var>.</p>
+   </ol>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</dfn></p>
+   <p>The inputs to this algorithm are:</p>
+   <ul>
+    <li data-md>
+     <p><var>entry bytes</var>: a byte array that contains an encoded <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry③">Mapping Entry</a>.</p>
+    <li data-md>
+     <p><var>last entry id</var>: the entry id of the entry preceding this one.</p>
+    <li data-md>
+     <p><var>default patch encoding</var>: the default patch encoding if one isn’t specified.</p>
+    <li data-md>
+     <p><var>uri template</var>: the URI template used to locate patches.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p><var>entry id</var>: the numeric id of this entry.</p>
+    <li data-md>
+     <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a>.</p>
+    <li data-md>
+     <p><var>consumed bytes</var>: the number of bytes used to encode the entry.</p>
+   </ul>
+   <p>The algorithm:</p>
+   <ol>
+    <li data-md>
+     <p>For the all steps whenever data is loaded from <var>entry bytes</var> increment <var>consumed bytes</var> with the
+ number of bytes read.</p>
+    <li data-md>
+     <p>Set <var>entry id</var> = <var>last entry id</var> + 1.</p>
+    <li data-md>
+     <p>Set the patch encoding of <var>entry</var> to <var>default patch encoding</var>.</p>
+    <li data-md>
+     <p>Read <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑨">format</a> from <var>entry bytes</var>.</p>
+    <li data-md>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①⓪">format</a> bit 0 is set, then the feature tag and design space lists are present:</p>
+     <ul>
+      <li data-md>
+       <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to <var>entry</var>.</p>
+      <li data-md>
+       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to <var>entry</var>.</p>
+     </ul>
+    <li data-md>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①①">format</a> bit 1 is set, then the copy indices list is present:</p>
+     <ul>
+      <li data-md>
+       <p>Read the copy indices list specified by <a data-link-type="dfn" href="#mapping-entry-copycount" id="ref-for-mapping-entry-copycount">copyCount</a> and <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices">copyIndices</a> from <var>entry bytes</var>.</p>
+      <li data-md>
+       <p>The copy indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry④">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>, 1 the second
+ and so on. For each index in <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices①">copyIndices</a> locate the previously loaded entry with a matching index and
+ add all code points, feature tags, and design space segments from it to <var>entry</var>.</p>
+     </ul>
+    <li data-md>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①②">format</a> bit 2 is set, then an id delta is present. Read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>.</p>
+    <li data-md>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①③">format</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.</p>
+    <li data-md>
+     <p>If one or both of <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①④">format</a> bit 4 and bit 5 are set, then a codepoint list is present:</p>
+     <ul>
+      <li data-md>
+       <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①⑤">format</a> bit 4 is 0 and bit 5 is 1, then read the 2 byte (uint16) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias">bias</a> value
+from <var>entry bytes</var>.</p>
+      <li data-md>
+       <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①⑥">format</a> bit 4 is 1 and bit 5 is 1, then read the 3 byte (uint24) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias①">bias</a> value
+from <var>entry bytes</var>.</p>
+      <li data-md>
+       <p>Otherwise the bias is 0.</p>
+      <li data-md>
+       <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codepoints</a> from <var>entry bytes</var> following <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. For each
+codepoint add the bias value to it and then add the result to the codepoint set in <var>entry</var>.</p>
+     </ul>
+    <li data-md>
+     <p>TODO apply URI template.</p>
+    <li data-md>
+     <p>Return <var>entry id</var>, <var>entry</var>, and <var>consumed bytes</var>.</p>
+   </ol>
+   <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.1.2.2" id="sparse-bit-set-decoding"><span class="secno">4.1.2.2. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
    <p>A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
 each node has a fixed number of children that recursively sub-divides an interval into equal partitions. A tree of height <i>H</i> with
 branching factor <i>B</i> can store set membership for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree
@@ -1676,7 +1786,7 @@ invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-
     <li data-md>
      <p>If <var>entry list</var> is empty, then the extension operation is finished, return <var>extended font subset</var>.</p>
     <li data-md>
-     <p>If <var>entry list</var> contains one or more <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a> which have a patch format that is <a data-link-type="dfn" href="#dependent" id="ref-for-dependent②">dependent</a>, then select
+     <p>If <var>entry list</var> contains one or more <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">patch map entries</a> which have a patch format that is <a data-link-type="dfn" href="#dependent" id="ref-for-dependent②">dependent</a>, then select
 exactly one of the <a data-link-type="dfn" href="#dependent" id="ref-for-dependent③">dependent</a> entries in <var>entry list</var> and remove all others. The criteria for selecting the single <a data-link-type="dfn" href="#dependent" id="ref-for-dependent④">dependent</a> entry is left up to the implementation to decide.</p>
     <li data-md>
      <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the entries URI. Collect the returned patch
@@ -1691,7 +1801,7 @@ the implementation.</p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>mapping entry</var>: a <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">patch map entry</a>.</p>
+     <p><var>mapping entry</var>: a <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entry</a>.</p>
     <li data-md>
      <p><var>subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition④">font subset definition</a>.</p>
    </ul>
@@ -1894,7 +2004,7 @@ required too many patches.</p>
    <li><a href="#abstract-opdef-apply-per-table-shared-brotli-patch">Apply per table shared brotli patch</a><span>, in § 5.4.1</span>
    <li><a href="#abstract-opdef-apply-shared-brotli-patch">Apply shared brotli patch</a><span>, in § 5.3.1</span>
    <li><a href="#mapping-entry-bias">bias</a><span>, in § 4.1.2</span>
-   <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 4.1.2.1</span>
+   <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 4.1.2.2</span>
    <li>
     brotliStream
     <ul>
@@ -1906,7 +2016,7 @@ required too many patches.</p>
    <li><a href="#mapping-entry-codepoints">codepoints</a><span>, in § 4.1.2</span>
    <li><a href="#mapping-entry-copycount">copyCount</a><span>, in § 4.1.2</span>
    <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 4.1.2</span>
-   <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 4.1.2.1</span>
+   <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 4.1.2.2</span>
    <li><a href="#format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a><span>, in § 4.1.2</span>
    <li><a href="#dependent">dependent</a><span>, in § 5.1</span>
    <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 4.1.2</span>
@@ -1925,8 +2035,8 @@ required too many patches.</p>
      <li><a href="#format-1-patch-map-entrycount">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
      <li><a href="#format-2-patch-map-entrycount">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
     </ul>
+   <li><a href="#mapping-entry-entryiddelta">entryIdDelta</a><span>, in § 4.1.2</span>
    <li><a href="#glyph-map-entryindex">entryIndex</a><span>, in § 4.1.1</span>
-   <li><a href="#mapping-entry-entryindexdelta">entryIndexDelta</a><span>, in § 4.1.2</span>
    <li><a href="#featurerecord-entrymapcount">entryMapCount</a><span>, in § 4.1.1</span>
    <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 4.1.1</span>
    <li><a href="#feature-map-entrymaprecords">entryMapRecords</a><span>, in § 4.1.1</span>
@@ -1993,6 +2103,8 @@ required too many patches.</p>
    <li><a href="#incremental-font">incremental font</a><span>, in § 4</span>
    <li><a href="#independent">independent</a><span>, in § 5.1</span>
    <li><a href="#abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a><span>, in § 4.1.1.1</span>
+   <li><a href="#abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a><span>, in § 4.1.2.1</span>
+   <li><a href="#abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a><span>, in § 4.1.2.1</span>
    <li><a href="#entrymaprecord-lastentryindex">lastEntryIndex</a><span>, in § 4.1.1</span>
    <li><a href="#glyph-keyed-patch-length">length</a><span>, in § 5.5</span>
    <li><a href="#abstract-opdef-load-patch-file">Load patch file</a><span>, in § 6</span>
@@ -2017,7 +2129,7 @@ required too many patches.</p>
      <li><a href="#format-2-patch-map-reserved">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
     </ul>
    <li><a href="#shared-brotli-patch">Shared brotli patch</a><span>, in § 5.3</span>
-   <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.1.2.1</span>
+   <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.1.2.2</span>
    <li><a href="#design-space-segment-start">start</a><span>, in § 4.1.2</span>
    <li><a href="#glyphpatches-tablecount">tableCount</a><span>, in § 5.5</span>
    <li><a href="#tablepatch">TablePatch</a><span>, in § 5.4</span>
@@ -2226,7 +2338,7 @@ window.dfnpanelData = {};
 window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subset", "dfnText": "font subset", "refSections": [{"refs": [{"id": "ref-for-font-subset"}], "title": "3.1. Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-font-subset\u2461"}], "title": "5. Font Patch Formats"}, {"refs": [{"id": "ref-for-font-subset\u2462"}, {"id": "ref-for-font-subset\u2463"}, {"id": "ref-for-font-subset\u2464"}, {"id": "ref-for-font-subset\u2465"}, {"id": "ref-for-font-subset\u2466"}, {"id": "ref-for-font-subset\u2467"}, {"id": "ref-for-font-subset\u2468"}, {"id": "ref-for-font-subset\u2460\u24ea"}, {"id": "ref-for-font-subset\u2460\u2460"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2461"}, {"id": "ref-for-font-subset\u2460\u2462"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2463"}], "title": "5.3. Shared Brotli Patch"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2464"}, {"id": "ref-for-font-subset\u2460\u2465"}, {"id": "ref-for-font-subset\u2460\u2466"}], "title": "5.3.1. Applying Shared Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2467"}, {"id": "ref-for-font-subset\u2460\u2468"}], "title": "5.4. Per Table Shared Brotli"}, {"refs": [{"id": "ref-for-font-subset\u2461\u24ea"}, {"id": "ref-for-font-subset\u2461\u2460"}, {"id": "ref-for-font-subset\u2461\u2461"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2462"}], "title": "5.5. Glyph Keyed"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2463"}, {"id": "ref-for-font-subset\u2461\u2464"}, {"id": "ref-for-font-subset\u2461\u2465"}], "title": "5.5.1. Applying Glyph Keyed Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2466"}, {"id": "ref-for-font-subset\u2461\u2467"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2468"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-font-subset\u2462\u24ea"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.1. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2464"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['incremental-font'] = {"dfnID": "incremental-font", "url": "#incremental-font", "dfnText": "incremental font", "refSections": [{"refs": [{"id": "ref-for-incremental-font"}, {"id": "ref-for-incremental-font\u2460"}, {"id": "ref-for-incremental-font\u2461"}, {"id": "ref-for-incremental-font\u2462"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-incremental-font\u2463"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-incremental-font\u2464"}, {"id": "ref-for-incremental-font\u2465"}, {"id": "ref-for-incremental-font\u2466"}, {"id": "ref-for-incremental-font\u2467"}, {"id": "ref-for-incremental-font\u2468"}, {"id": "ref-for-incremental-font\u2460\u24ea"}, {"id": "ref-for-incremental-font\u2460\u2460"}], "title": "7. Encoder"}], "external": false};
-window.dfnpanelData['patch-map-entries'] = {"dfnID": "patch-map-entries", "url": "#patch-map-entries", "dfnText": "patch map entries", "refSections": [{"refs": [{"id": "ref-for-patch-map-entries"}, {"id": "ref-for-patch-map-entries\u2460"}, {"id": "ref-for-patch-map-entries\u2461"}, {"id": "ref-for-patch-map-entries\u2462"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-patch-map-entries\u2463"}, {"id": "ref-for-patch-map-entries\u2464"}], "title": "6. Extending a Font Subset"}], "external": false};
+window.dfnpanelData['patch-map-entries'] = {"dfnID": "patch-map-entries", "url": "#patch-map-entries", "dfnText": "patch map entries", "refSections": [{"refs": [{"id": "ref-for-patch-map-entries"}, {"id": "ref-for-patch-map-entries\u2460"}, {"id": "ref-for-patch-map-entries\u2461"}, {"id": "ref-for-patch-map-entries\u2462"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-patch-map-entries\u2463"}, {"id": "ref-for-patch-map-entries\u2464"}, {"id": "ref-for-patch-map-entries\u2465"}], "title": "4.1.2.1. Interpreting Format 2"}, {"refs": [{"id": "ref-for-patch-map-entries\u2466"}, {"id": "ref-for-patch-map-entries\u2467"}], "title": "6. Extending a Font Subset"}], "external": false};
 window.dfnpanelData['format-1-patch-map-entrycount'] = {"dfnID": "format-1-patch-map-entrycount", "url": "#format-1-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-entrycount"}, {"id": "ref-for-format-1-patch-map-entrycount\u2460"}, {"id": "ref-for-format-1-patch-map-entrycount\u2461"}, {"id": "ref-for-format-1-patch-map-entrycount\u2462"}, {"id": "ref-for-format-1-patch-map-entrycount\u2463"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
 window.dfnpanelData['format-1-patch-map-glyphcount'] = {"dfnID": "format-1-patch-map-glyphcount", "url": "#format-1-patch-map-glyphcount", "dfnText": "glyphCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-glyphcount"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
 window.dfnpanelData['format-1-patch-map-appliedentriesbitmap'] = {"dfnID": "format-1-patch-map-appliedentriesbitmap", "url": "#format-1-patch-map-appliedentriesbitmap", "dfnText": "appliedEntriesBitMap", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-appliedentriesbitmap"}, {"id": "ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
@@ -2243,13 +2355,26 @@ window.dfnpanelData['entrymaprecord'] = {"dfnID": "entrymaprecord", "url": "#ent
 window.dfnpanelData['entrymaprecord-firstentryindex'] = {"dfnID": "entrymaprecord-firstentryindex", "url": "#entrymaprecord-firstentryindex", "dfnText": "firstEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-firstentryindex"}, {"id": "ref-for-entrymaprecord-firstentryindex\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['entrymaprecord-lastentryindex'] = {"dfnID": "entrymaprecord-lastentryindex", "url": "#entrymaprecord-lastentryindex", "dfnText": "lastEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-lastentryindex"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-1-patch-map'] = {"dfnID": "abstract-opdef-interpret-format-1-patch-map", "url": "#abstract-opdef-interpret-format-1-patch-map", "dfnText": "Interpret Format 1 Patch Map", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-1-patch-map"}], "title": "6. Extending a Font Subset"}], "external": false};
-window.dfnpanelData['format-2-patch-map-defaultpatchencoding'] = {"dfnID": "format-2-patch-map-defaultpatchencoding", "url": "#format-2-patch-map-defaultpatchencoding", "dfnText": "defaultPatchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
-window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch-map-entrycount", "url": "#format-2-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entrycount"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-defaultpatchencoding'] = {"dfnID": "format-2-patch-map-defaultpatchencoding", "url": "#format-2-patch-map-defaultpatchencoding", "dfnText": "defaultPatchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch-map-entrycount", "url": "#format-2-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entrycount"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entrycount\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-entries'] = {"dfnID": "format-2-patch-map-entries", "url": "#format-2-patch-map-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entries"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-uritemplate'] = {"dfnID": "format-2-patch-map-uritemplate", "url": "#format-2-patch-map-uritemplate", "dfnText": "uriTemplate", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-uritemplate"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entries'] = {"dfnID": "mapping-entries", "url": "#mapping-entries", "dfnText": "Mapping Entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
-window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry'] = {"dfnID": "mapping-entry", "url": "#mapping-entry", "dfnText": "Mapping Entry", "refSections": [{"refs": [{"id": "ref-for-mapping-entry"}, {"id": "ref-for-mapping-entry\u2460"}, {"id": "ref-for-mapping-entry\u2461"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-format'] = {"dfnID": "mapping-entry-format", "url": "#mapping-entry-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-format"}, {"id": "ref-for-mapping-entry-format\u2460"}, {"id": "ref-for-mapping-entry-format\u2461"}, {"id": "ref-for-mapping-entry-format\u2462"}, {"id": "ref-for-mapping-entry-format\u2463"}, {"id": "ref-for-mapping-entry-format\u2464"}, {"id": "ref-for-mapping-entry-format\u2465"}, {"id": "ref-for-mapping-entry-format\u2466"}, {"id": "ref-for-mapping-entry-format\u2467"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entries-entries\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry'] = {"dfnID": "mapping-entry", "url": "#mapping-entry", "dfnText": "Mapping Entry", "refSections": [{"refs": [{"id": "ref-for-mapping-entry"}, {"id": "ref-for-mapping-entry\u2460"}, {"id": "ref-for-mapping-entry\u2461"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry\u2462"}, {"id": "ref-for-mapping-entry\u2463"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-format'] = {"dfnID": "mapping-entry-format", "url": "#mapping-entry-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-format"}, {"id": "ref-for-mapping-entry-format\u2460"}, {"id": "ref-for-mapping-entry-format\u2461"}, {"id": "ref-for-mapping-entry-format\u2462"}, {"id": "ref-for-mapping-entry-format\u2463"}, {"id": "ref-for-mapping-entry-format\u2464"}, {"id": "ref-for-mapping-entry-format\u2465"}, {"id": "ref-for-mapping-entry-format\u2466"}, {"id": "ref-for-mapping-entry-format\u2467"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-format\u2468"}, {"id": "ref-for-mapping-entry-format\u2460\u24ea"}, {"id": "ref-for-mapping-entry-format\u2460\u2460"}, {"id": "ref-for-mapping-entry-format\u2460\u2461"}, {"id": "ref-for-mapping-entry-format\u2460\u2462"}, {"id": "ref-for-mapping-entry-format\u2460\u2463"}, {"id": "ref-for-mapping-entry-format\u2460\u2464"}, {"id": "ref-for-mapping-entry-format\u2460\u2465"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-featurecount'] = {"dfnID": "mapping-entry-featurecount", "url": "#mapping-entry-featurecount", "dfnText": "featureCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featurecount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-featuretags'] = {"dfnID": "mapping-entry-featuretags", "url": "#mapping-entry-featuretags", "dfnText": "featureTags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featuretags"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-designspacecount'] = {"dfnID": "mapping-entry-designspacecount", "url": "#mapping-entry-designspacecount", "dfnText": "designSpaceCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacecount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-designspacesegments'] = {"dfnID": "mapping-entry-designspacesegments", "url": "#mapping-entry-designspacesegments", "dfnText": "designSpaceSegments", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacesegments"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-copycount'] = {"dfnID": "mapping-entry-copycount", "url": "#mapping-entry-copycount", "dfnText": "copyCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copycount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-copyindices'] = {"dfnID": "mapping-entry-copyindices", "url": "#mapping-entry-copyindices", "dfnText": "copyIndices", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copyindices"}, {"id": "ref-for-mapping-entry-copyindices\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-entryiddelta'] = {"dfnID": "mapping-entry-entryiddelta", "url": "#mapping-entry-entryiddelta", "dfnText": "entryIdDelta", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryiddelta"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-patchencoding'] = {"dfnID": "mapping-entry-patchencoding", "url": "#mapping-entry-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-patchencoding"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-bias'] = {"dfnID": "mapping-entry-bias", "url": "#mapping-entry-bias", "dfnText": "bias", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-bias"}, {"id": "ref-for-mapping-entry-bias\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-codepoints'] = {"dfnID": "mapping-entry-codepoints", "url": "#mapping-entry-codepoints", "dfnText": "codepoints", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-codepoints"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['design-space-segment'] = {"dfnID": "design-space-segment", "url": "#design-space-segment", "dfnText": "Design Space Segment", "refSections": [{"refs": [{"id": "ref-for-design-space-segment"}, {"id": "ref-for-design-space-segment\u2460"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map-entry'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map-entry", "url": "#abstract-opdef-interpret-format-2-patch-map-entry", "dfnText": "Interpret Format 2 Patch Map Entry", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['font-patch'] = {"dfnID": "font-patch", "url": "#font-patch", "dfnText": "font patch", "refSections": [{"refs": [{"id": "ref-for-font-patch"}, {"id": "ref-for-font-patch\u2460"}, {"id": "ref-for-font-patch\u2461"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-patch\u2462"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-format'] = {"dfnID": "patch-format", "url": "#patch-format", "dfnText": "patch format", "refSections": [{"refs": [{"id": "ref-for-patch-format"}, {"id": "ref-for-patch-format\u2460"}], "title": "5.1. Definitions"}], "external": false};
 window.dfnpanelData['patch-application-algorithm'] = {"dfnID": "patch-application-algorithm", "url": "#patch-application-algorithm", "dfnText": "patch application algorithm", "refSections": [{"refs": [{"id": "ref-for-patch-application-algorithm"}], "title": "5.1. Definitions"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="761cdb0b3f1a196e3e45baf0058e47c9e341f2e0" name="document-revision">
+  <meta content="0e69829c29eada0bf85089b1b6aa16f6f49d4f43" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -1072,7 +1072,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</dfn>
-      <td> Specifies the format of the patches linked to by uriTemplate. Using the ID number from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table. 
+      <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry). Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table. 
      <tr>
       <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entrycount">entryCount</dfn>
@@ -1100,7 +1100,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <tr>
       <td><a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry">Mapping Entry</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entries" data-dfn-type="dfn" data-noexport id="mapping-entries-entries">entries</dfn>[<a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount">entryCount</a>]
-      <td>List of entries. Each entry has a variable length.
+      <td>List of entries. Each entry has a variable length, which is determined following <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a>.
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entry">Mapping Entry</dfn> encoding:</p>
    <table>
@@ -1112,8 +1112,8 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-format">format</dfn>
-      <td> A bit field. Bit 0 (least significant bit) through bit 5 indicate presence of optional fields. If bit 6 is set this entry is ignored.
-      Bit 7 is reserved for future use and set to 0. 
+      <td> A bit field. Bit 0 (least significant bit) through bit 5 indicate the presence of optional fields. If bit 6 is set this entry is
+      ignored. Bit 7 is reserved for future use and set to 0. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featurecount">featureCount</dfn>
@@ -1121,7 +1121,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <tr>
       <td>Tag
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags</dfn>[featureCount]
-      <td> Array of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①">format</a> bit 0 is set. 
+      <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①">format</a> bit 0 is set. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount</dfn>
@@ -1129,7 +1129,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <tr>
       <td><a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment">Design Space Segment</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments</dfn>[designSpaceCount]
-      <td> Array of <a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment①">Design Space Segment</a>'s. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format③">format</a> bit 0 is set. 
+      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition④">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format③">format</a> bit 0 is set. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copycount">copyCount</dfn>
@@ -1137,23 +1137,23 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <tr>
       <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices</dfn>[copyCount]
-      <td> Array of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array which should be copied into this mapping. All values must be less than
-      the index of this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑤">format</a> bit 1 is set. 
+      <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definition</a> should be copied into this entry. All
+      values must be less than the index of this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑤">format</a> bit 1 is set. 
      <tr>
       <td>int16
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>
-      <td> Delta which is added to the entry id of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> to produce the entry id for this entry.
+      <td> Signed delta which is added to the entry id of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> to produce the id for this entry.
       Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑥">format</a> bit 2 is set. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchencoding">patchEncoding</dfn>
-      <td> Specifies the format of the patch linked to by this entry. Using the ID number from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table.
+      <td> Specifies the format of the patch linked to by this entry. Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table.
       Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑦">format</a> bit 3 is set. 
      <tr>
       <td>uint16/uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-bias">bias</dfn>
-      <td> Bias value which is added to all codepoint values encoded in the codepoints set.
+      <td> Bias value which is added to all codepoint values in the codepoints set.
       If format bit 4 is 0 and bit 5 is 1, then this is present and a uint16.
       If format bit 4 is 1 and bit 5 is 1, then this is present and a uint24.
       Otherwise it is not present. 
@@ -1161,7 +1161,8 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codepoints</dfn>[variable]
       <td> Set of codepoints for this mapping. Encoded as a <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. 
-      Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑧">format</a> bit 4 and/or 5 is set. 
+      Only present if <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format⑧">format</a> bit 4 and/or 5 is set. The length is
+      determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="design-space-segment">Design Space Segment</dfn> encoding:</p>
    <table>
@@ -1203,17 +1204,17 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
     <li data-md>
      <p>Initialize <var>last entry id</var> to 0, and <var>current byte</var> to 0.</p>
     <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a>, <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount①">entryCount</a> times. For each invocation:</p>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry①">Interpret Format 2 Patch Map Entry</a>, <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount①">entryCount</a> times. For each invocation:</p>
      <ul>
       <li data-md>
        <p>pass in the bytes from <var>patch map</var> starting from index (<a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a> + <var>current byte</var>) to
  the end of <var>patch map</var>, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding①">defaultPatchEncoding</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
       <li data-md>
-       <p>Add the returned entry to <var>entry list</var>.</p>
-      <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
        <p>Add the returned consumed byte count to <var>current byte</var>.</p>
+      <li data-md>
+       <p>If the returned value of ignored is false, then add the returned entry to <var>entry list</var>.</p>
      </ul>
     <li data-md>
      <p>Return <var>entry list</var>.</p>
@@ -1238,6 +1239,8 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a>.</p>
     <li data-md>
      <p><var>consumed bytes</var>: the number of bytes used to encode the entry.</p>
+    <li data-md>
+     <p><var>ignored</var>: if true, then this entry should be ignored.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1264,12 +1267,13 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <li data-md>
        <p>Read the copy indices list specified by <a data-link-type="dfn" href="#mapping-entry-copycount" id="ref-for-mapping-entry-copycount">copyCount</a> and <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices">copyIndices</a> from <var>entry bytes</var>.</p>
       <li data-md>
-       <p>The copy indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry④">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>, 1 the second
+       <p>The copy indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry④">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries②">entries</a>, 1 the second
  and so on. For each index in <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices①">copyIndices</a> locate the previously loaded entry with a matching index and
  add all code points, feature tags, and design space segments from it to <var>entry</var>.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①②">format</a> bit 2 is set, then an id delta is present. Read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>.</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①②">format</a> bit 2 is set, then an id delta is present. Read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
+ and the mapping is malformed.</p>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①③">format</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.</p>
     <li data-md>
@@ -1288,9 +1292,11 @@ from <var>entry bytes</var>.</p>
 codepoint add the bias value to it and then add the result to the codepoint set in <var>entry</var>.</p>
      </ul>
     <li data-md>
-     <p>TODO apply URI template.</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-format" id="ref-for-mapping-entry-format①⑦">format</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
     <li data-md>
-     <p>Return <var>entry id</var>, <var>entry</var>, and <var>consumed bytes</var>.</p>
+     <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 3.3 URI Templates</a>. Set the patch uri of <var>entry</var> to the generated URI.</p>
+    <li data-md>
+     <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, and <var>ignored</var>.</p>
    </ol>
    <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.1.2.2" id="sparse-bit-set-decoding"><span class="secno">4.1.2.2. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
    <p>A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
@@ -1763,7 +1769,7 @@ codepoints, layout features and/or design space.</p>
     <li data-md>
      <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a>.</p>
     <li data-md>
-     <p><var>target subset definition</var>: the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a> that the client wants to extend <var>font subset</var> to cover.</p>
+     <p><var>target subset definition</var>: the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑥">font subset definition</a> that the client wants to extend <var>font subset</var> to cover.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1803,7 +1809,7 @@ the implementation.</p>
     <li data-md>
      <p><var>mapping entry</var>: a <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entry</a>.</p>
     <li data-md>
-     <p><var>subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition④">font subset definition</a>.</p>
+     <p><var>subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definition</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1880,7 +1886,7 @@ The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-fon
     <li data-md>
      <p>Must meet all of the requirements in <a href="#font-format-extensions">§ 4 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 5 Font Patch Formats</a>.</p>
     <li data-md>
-     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset①">Extend a Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑦">incremental font</a> must always be the same regardless of the particular order
+     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset①">Extend a Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑦">incremental font</a> must always be the same regardless of the particular order
 of dependent patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset②">Extend a Font Subset</a>.</p>
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font, that is:
@@ -2336,7 +2342,7 @@ required too many patches.</p>
 <script>/* Boilerplate: script-dfn-panel-json */
 window.dfnpanelData = {};
 window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subset", "dfnText": "font subset", "refSections": [{"refs": [{"id": "ref-for-font-subset"}], "title": "3.1. Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-font-subset\u2461"}], "title": "5. Font Patch Formats"}, {"refs": [{"id": "ref-for-font-subset\u2462"}, {"id": "ref-for-font-subset\u2463"}, {"id": "ref-for-font-subset\u2464"}, {"id": "ref-for-font-subset\u2465"}, {"id": "ref-for-font-subset\u2466"}, {"id": "ref-for-font-subset\u2467"}, {"id": "ref-for-font-subset\u2468"}, {"id": "ref-for-font-subset\u2460\u24ea"}, {"id": "ref-for-font-subset\u2460\u2460"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2461"}, {"id": "ref-for-font-subset\u2460\u2462"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2463"}], "title": "5.3. Shared Brotli Patch"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2464"}, {"id": "ref-for-font-subset\u2460\u2465"}, {"id": "ref-for-font-subset\u2460\u2466"}], "title": "5.3.1. Applying Shared Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2467"}, {"id": "ref-for-font-subset\u2460\u2468"}], "title": "5.4. Per Table Shared Brotli"}, {"refs": [{"id": "ref-for-font-subset\u2461\u24ea"}, {"id": "ref-for-font-subset\u2461\u2460"}, {"id": "ref-for-font-subset\u2461\u2461"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2462"}], "title": "5.5. Glyph Keyed"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2463"}, {"id": "ref-for-font-subset\u2461\u2464"}, {"id": "ref-for-font-subset\u2461\u2465"}], "title": "5.5.1. Applying Glyph Keyed Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2466"}, {"id": "ref-for-font-subset\u2461\u2467"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2468"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-font-subset\u2462\u24ea"}], "title": "7. Encoder"}], "external": false};
-window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.1. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2464"}], "title": "7. Encoder"}], "external": false};
+window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.1. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}, {"id": "ref-for-font-subset-definition\u2464"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-font-subset-definition\u2465"}, {"id": "ref-for-font-subset-definition\u2466"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2467"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['incremental-font'] = {"dfnID": "incremental-font", "url": "#incremental-font", "dfnText": "incremental font", "refSections": [{"refs": [{"id": "ref-for-incremental-font"}, {"id": "ref-for-incremental-font\u2460"}, {"id": "ref-for-incremental-font\u2461"}, {"id": "ref-for-incremental-font\u2462"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-incremental-font\u2463"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-incremental-font\u2464"}, {"id": "ref-for-incremental-font\u2465"}, {"id": "ref-for-incremental-font\u2466"}, {"id": "ref-for-incremental-font\u2467"}, {"id": "ref-for-incremental-font\u2468"}, {"id": "ref-for-incremental-font\u2460\u24ea"}, {"id": "ref-for-incremental-font\u2460\u2460"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-map-entries'] = {"dfnID": "patch-map-entries", "url": "#patch-map-entries", "dfnText": "patch map entries", "refSections": [{"refs": [{"id": "ref-for-patch-map-entries"}, {"id": "ref-for-patch-map-entries\u2460"}, {"id": "ref-for-patch-map-entries\u2461"}, {"id": "ref-for-patch-map-entries\u2462"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-patch-map-entries\u2463"}, {"id": "ref-for-patch-map-entries\u2464"}, {"id": "ref-for-patch-map-entries\u2465"}], "title": "4.1.2.1. Interpreting Format 2"}, {"refs": [{"id": "ref-for-patch-map-entries\u2466"}, {"id": "ref-for-patch-map-entries\u2467"}], "title": "6. Extending a Font Subset"}], "external": false};
 window.dfnpanelData['format-1-patch-map-entrycount'] = {"dfnID": "format-1-patch-map-entrycount", "url": "#format-1-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-entrycount"}, {"id": "ref-for-format-1-patch-map-entrycount\u2460"}, {"id": "ref-for-format-1-patch-map-entrycount\u2461"}, {"id": "ref-for-format-1-patch-map-entrycount\u2462"}, {"id": "ref-for-format-1-patch-map-entrycount\u2463"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
@@ -2360,9 +2366,9 @@ window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch
 window.dfnpanelData['format-2-patch-map-entries'] = {"dfnID": "format-2-patch-map-entries", "url": "#format-2-patch-map-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entries"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-uritemplate'] = {"dfnID": "format-2-patch-map-uritemplate", "url": "#format-2-patch-map-uritemplate", "dfnText": "uriTemplate", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-uritemplate"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entries'] = {"dfnID": "mapping-entries", "url": "#mapping-entries", "dfnText": "Mapping Entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
-window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entries-entries\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}, {"id": "ref-for-mapping-entries-entries\u2460"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entries-entries\u2461"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry'] = {"dfnID": "mapping-entry", "url": "#mapping-entry", "dfnText": "Mapping Entry", "refSections": [{"refs": [{"id": "ref-for-mapping-entry"}, {"id": "ref-for-mapping-entry\u2460"}, {"id": "ref-for-mapping-entry\u2461"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry\u2462"}, {"id": "ref-for-mapping-entry\u2463"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-format'] = {"dfnID": "mapping-entry-format", "url": "#mapping-entry-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-format"}, {"id": "ref-for-mapping-entry-format\u2460"}, {"id": "ref-for-mapping-entry-format\u2461"}, {"id": "ref-for-mapping-entry-format\u2462"}, {"id": "ref-for-mapping-entry-format\u2463"}, {"id": "ref-for-mapping-entry-format\u2464"}, {"id": "ref-for-mapping-entry-format\u2465"}, {"id": "ref-for-mapping-entry-format\u2466"}, {"id": "ref-for-mapping-entry-format\u2467"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-format\u2468"}, {"id": "ref-for-mapping-entry-format\u2460\u24ea"}, {"id": "ref-for-mapping-entry-format\u2460\u2460"}, {"id": "ref-for-mapping-entry-format\u2460\u2461"}, {"id": "ref-for-mapping-entry-format\u2460\u2462"}, {"id": "ref-for-mapping-entry-format\u2460\u2463"}, {"id": "ref-for-mapping-entry-format\u2460\u2464"}, {"id": "ref-for-mapping-entry-format\u2460\u2465"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-format'] = {"dfnID": "mapping-entry-format", "url": "#mapping-entry-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-format"}, {"id": "ref-for-mapping-entry-format\u2460"}, {"id": "ref-for-mapping-entry-format\u2461"}, {"id": "ref-for-mapping-entry-format\u2462"}, {"id": "ref-for-mapping-entry-format\u2463"}, {"id": "ref-for-mapping-entry-format\u2464"}, {"id": "ref-for-mapping-entry-format\u2465"}, {"id": "ref-for-mapping-entry-format\u2466"}, {"id": "ref-for-mapping-entry-format\u2467"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-format\u2468"}, {"id": "ref-for-mapping-entry-format\u2460\u24ea"}, {"id": "ref-for-mapping-entry-format\u2460\u2460"}, {"id": "ref-for-mapping-entry-format\u2460\u2461"}, {"id": "ref-for-mapping-entry-format\u2460\u2462"}, {"id": "ref-for-mapping-entry-format\u2460\u2463"}, {"id": "ref-for-mapping-entry-format\u2460\u2464"}, {"id": "ref-for-mapping-entry-format\u2460\u2465"}, {"id": "ref-for-mapping-entry-format\u2460\u2466"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-featurecount'] = {"dfnID": "mapping-entry-featurecount", "url": "#mapping-entry-featurecount", "dfnText": "featureCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featurecount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-featuretags'] = {"dfnID": "mapping-entry-featuretags", "url": "#mapping-entry-featuretags", "dfnText": "featureTags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featuretags"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-designspacecount'] = {"dfnID": "mapping-entry-designspacecount", "url": "#mapping-entry-designspacecount", "dfnText": "designSpaceCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacecount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
@@ -2373,8 +2379,8 @@ window.dfnpanelData['mapping-entry-entryiddelta'] = {"dfnID": "mapping-entry-ent
 window.dfnpanelData['mapping-entry-patchencoding'] = {"dfnID": "mapping-entry-patchencoding", "url": "#mapping-entry-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-patchencoding"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-bias'] = {"dfnID": "mapping-entry-bias", "url": "#mapping-entry-bias", "dfnText": "bias", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-bias"}, {"id": "ref-for-mapping-entry-bias\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-codepoints'] = {"dfnID": "mapping-entry-codepoints", "url": "#mapping-entry-codepoints", "dfnText": "codepoints", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-codepoints"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['design-space-segment'] = {"dfnID": "design-space-segment", "url": "#design-space-segment", "dfnText": "Design Space Segment", "refSections": [{"refs": [{"id": "ref-for-design-space-segment"}, {"id": "ref-for-design-space-segment\u2460"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
-window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map-entry'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map-entry", "url": "#abstract-opdef-interpret-format-2-patch-map-entry", "dfnText": "Interpret Format 2 Patch Map Entry", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['design-space-segment'] = {"dfnID": "design-space-segment", "url": "#design-space-segment", "dfnText": "Design Space Segment", "refSections": [{"refs": [{"id": "ref-for-design-space-segment"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map-entry'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map-entry", "url": "#abstract-opdef-interpret-format-2-patch-map-entry", "dfnText": "Interpret Format 2 Patch Map Entry", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['font-patch'] = {"dfnID": "font-patch", "url": "#font-patch", "dfnText": "font patch", "refSections": [{"refs": [{"id": "ref-for-font-patch"}, {"id": "ref-for-font-patch\u2460"}, {"id": "ref-for-font-patch\u2461"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-patch\u2462"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-format'] = {"dfnID": "patch-format", "url": "#patch-format", "dfnText": "patch format", "refSections": [{"refs": [{"id": "ref-for-patch-format"}, {"id": "ref-for-patch-format\u2460"}], "title": "5.1. Definitions"}], "external": false};
 window.dfnpanelData['patch-application-algorithm'] = {"dfnID": "patch-application-algorithm", "url": "#patch-application-algorithm", "dfnText": "patch application algorithm", "refSections": [{"refs": [{"id": "ref-for-patch-application-algorithm"}], "title": "5.1. Definitions"}], "external": false};


### PR DESCRIPTION
Adds spec text for the missing format 2 patch map section. Format 2 provides a general purpose mapping that supports design spaces and overlapping mapping entries.

Preview can be seen here: https://garretrieger.github.io/IFT/Overview.html#patch-map-format-2


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/garretrieger/IFT/pull/159.html" title="Last updated on Mar 7, 2024, 10:52 PM UTC (9b8fd31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/159/bec0db4...garretrieger:9b8fd31.html" title="Last updated on Mar 7, 2024, 10:52 PM UTC (9b8fd31)">Diff</a>