### PR TITLE
Updates to the encoder section + TODO cleanup

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1148,13 +1148,13 @@ The following patch formats are defined by this specification:
     <th>Description</th>
   </tr>
   <tr>
-    <td>[[#shared-brotli]]</td>
+    <td>[[#brotli]]</td>
     <td>[=dependent=]</td>
     <td>1</td>
     <td>A brotli encoded binary diff that uses the entire [=font subset=] as a base.</td>
   </tr>
   <tr>
-    <td>[[#per-table-shared-brotli]]</td>
+    <td>[[#per-table-brotli]]</td>
     <td>[=dependent=]</td>
     <td>2</td>
     <td>A collection of brotli encoded binary diffs that use tables from the [=font subset=] as bases.</td>
@@ -1169,7 +1169,7 @@ The following patch formats are defined by this specification:
 
 More detailed descriptions of each algorithm can be found in the following sections.
 
-Brotli Patch {#shared-brotli}
+Brotli Patch {#brotli}
 ------------------------------------
 
 In a brotli patch the target file is encoded with [[!RFC7932|brotli compression]] using the
@@ -1202,7 +1202,7 @@ of a short header followed by brotli encoded data.
   </tr>
 </table>
 
-<h4 algorithm id="apply-shared-brotli">Applying Brotli Patches</h4>
+<h4 algorithm id="apply-brotli">Applying Brotli Patches</h4>
 
 This algorithm is used to apply a brotli patch to extend a [=font subset=] to cover additional codepoints,
 features, and/or design-variation space.
@@ -1235,7 +1235,7 @@ The algorithm:
     using the <var>base font subset</var> as a [[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. Return the decoded
     result as the <var>extended font subset</var>
 
-Per Table Brotli {#per-table-shared-brotli}
+Per Table Brotli {#per-table-brotli}
 --------------------------------------------------
 
 A per table brotli patch contains a collection of patches which are applied to the individual
@@ -1301,7 +1301,7 @@ of that [=TablePatch=].
 </table>
 
 
-<h4 algorithm id="apply-per-table-shared-brotli">Applying Per Table Brotli Patches</h4>
+<h4 algorithm id="apply-per-table-brotli">Applying Per Table Brotli Patches</h4>
 
 This algorithm is used to apply a per table brotli patch to extend a [=font subset=] to cover additional codepoints,
 features, and/or design-variation space.
@@ -1668,7 +1668,10 @@ The [=incremental font=] and associated patches produced by a compliant encoder:
      render identically to the fully expanded font for that content.
 
 4.  When an encoder is used to transform an existing font into an [=incremental font=] the associated
-     [$Fully Expand a Font Subset|fully expanded font$] should be equal to the existing font.
+     [$Fully Expand a Font Subset|fully expanded font$] should be equivalent to the existing font. An equivalent fully expanded font
+     should have all of the same [[open-type/otff#table-directory|tables]] as the existing font (excluding the incremental IFT/IFTX
+     tables) and each of those tables should be functionally equivalent to the corresponding table in the existing font. Note: the fully
+     expanded may not always be an exact binary match with the existing font.
 
 When an encoder is used to transform an existing font file into and [=incremental font=] and a client is implemented according to the
 other sections of this document, the intent of the IFT specification is that appearance and behavior of the font in the client will be the
@@ -1698,11 +1701,58 @@ guidance that encoder implementations may want to consider.
 
 <b>Utilize an existing font subsetter implementation</b>
 
-<!-- TODO: A high quality encoder should preserve functionality as discussed above. Existing font subsetters can be used to assist
-     constructing encodings that meet this requirement. They provide all of the logic needed to preserve functionality. High quality
-     open source subsetters exist -->
+<!-- TODO(garretrieger): subsetter implementations are not trivial they consider many interactions within the font to determine what
+     data is reachable -->
 
-<!-- TODO: describe a simple encoder which utilizes only a subsetter -->
+As discussed in [[#encoder]] a high quality encoder should preserve the functionality of the original font. One way to
+achieve this is to leverage an existing font subsetter implementation to produce font subsets that retain the functionality
+of the original font. The IFT patches can then be derived from these subsets.
+
+A font subsetter produces a [=font subset=] from an input font based on a desired [=font subset definition=]. The practice of reliably
+subsetting a font is well understood and has multiple open-source implementations (a full formal description is
+beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
+relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
+Any reachable data is retained in the generated font subset, while any unreachable data may be removed.
+
+Example pseudo code for a very basic encoder implementation using a font subsetter:
+
+```
+# Encodes a font (full_font) into an incremental font that starts at base_subset_def
+# and can incrementally add any of subset_definitions. Returns the IFT encoded font
+# and set of associated patches.
+encode_as_ift(full_font, base_subset_def, subset_definitions):
+  base_font = subset(full_font, base_subset_def)
+  patches = encode_node(full_font, base_font, base_subset_def, subset_definitions)
+  return base_font, patches
+
+# Update base_font to add all of the ift patch mappings to reach any of
+# subset_definitions and produces the associated patches.
+encode_node(full_font, base_font, cur_def, subset_definitions):
+  patches = []
+  next_fonts = []
+  
+  for each subset_def in subset_definitions not fully covered by cur_def:
+    next_def = subset_def union cur_def
+    next_font = subset(full_font, next_def)
+    let patch_url be a new unique url
+    
+    add patch map entry into base_font from (subset_def - cur_def) to patch_url
+    patches += encode(full_font, next_font, next_def, subset_definitions)
+
+    next_fonts += (next_font, next_def, patch_url)
+
+  for each (next_font, next_def, patch_url):
+    patch = dependent_patch_diff(base_font, next_font)
+    patches += (patch, patch_url)
+  
+  return patches
+```
+
+In this example implementation if the union of the input base subset definition and the list of subset definitions fully covers the input
+full font, and the subsetter implementation used correctly retains all functionality then the above implementation should meet the
+requirements in [[#encoder]] to be a neutral encoding. This basic encoder implementation is for demonstration purposes and not meant
+to be representative of all possible encoder implementations. Most encoders will likely be more complex and need to consider additional
+factors some of which are discussed in the remaining sections.
 
 <b>Choosing segmentations</b>
 
@@ -1717,14 +1767,11 @@ During segmentation an encoder should also consider how codepoints interact with
 in the same segment can avoid having to duplicate data between patches, which may be necessary to preserve the functionality of the
 original font when interacting codepoints reside in different segments.
 
-<b>Dependent patches can form patch graphs</b>
+<b>Dependent patches can form graphs</b>
 
-<!-- TODO:
-     a dependent patch can modify the mapping table to point to new patches which are valid against the updated font subset.
-     This forms a graph, and it can be helpful to reason about the encoding in terms of the graph.
-     Since only one dependent patch can be applied and loaded at a time the graph can encode edges that patch in multiple segments
-     in a single patch, alongside patches that patch in single segments. -->
-
+[=dependent|Dependent=] patches can modify the mapping table in the current font subset, which allows a patch to update the mapping table
+to point to a different set of patches which are valid against the result of the patch application. This allows a graph to be formed
+where a font subset is the node and each patch is an edge.
 
 <b>Choosing patch formats</b>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -409,13 +409,12 @@ encoded in one of two formats:
   </tr>
   <tr>
     <td>Offset32</td>
-    <td><dfn for="Format 1 Patch Map">glyphMapOffset</dfn></td>
-    <!-- TODO link -->
+    <td>glyphMapOffset</td>
     <td>Offset to a [=Glyph Map=] sub table. Offset is from the start of this table.</td>
   </tr>
   <tr>
     <td>Offset32</td>
-    <td><dfn for="Format 1 Patch Map">featureMapOffset</dfn></td>
+    <td>featureMapOffset</td>
     <td>Offset to a [=Feature Map=] sub table. Offset is from the start of this table.</td>
   </tr>
   <tr>
@@ -429,7 +428,7 @@ encoded in one of two formats:
   </tr>
   <tr>
     <td>uint16</td>
-    <td><dfn for="Format 1 Patch Map">uriTemplateLength</dfn></td>
+    <td>uriTemplateLength</td>
     <td>
       Length of the uriTemplate string.
     </td>
@@ -467,7 +466,7 @@ A glyph map table associates each glyph index in the font with an entry index.
     <td>uint8/uint16</td>
     <td><dfn for="Glyph Map">entryIndex</dfn>[[=Format 1 Patch Map/glyphCount=] - firstMappedGlyph]</td>
     <td>
-      The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - firstMappedGlyph]. Array members
+      The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - [=Glyph Map/firstMappedGlyph=]]. Array members
       are uint8 if [=Format 1 Patch Map/entryCount=] is less than 256, otherwise they are uint16.
     </td>
   </tr>
@@ -484,7 +483,7 @@ A feature map table associates combinations of [[open-type/featuretags|feature t
   </tr>
   <tr>
     <td>uint16</td>
-    <td><dfn for="Feature Map">featureCount</dfn></td>
+    <td>featureCount</td>
     <td>Number of featureRecords.</td>
   </tr>
   <tr>
@@ -585,7 +584,7 @@ The algorithm:
 1.  Check that the <var>patch map</var> has [=Format 1 Patch Map/format=] equal to 1 and is valid according to the requirements in
      [[#patch-map-format-1]]. If it is not return an error.
 
-2.  For each unique <var>entry index</var> in [=Glyph Map=]:
+2.  For each unique <var>entry index</var> in [=Glyph Map/entryIndex=]:
 
     <!-- TODO: use ol and style which characters instead of numbers -->
     *  a. If the bit for <var>entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this
@@ -601,7 +600,7 @@ The algorithm:
     *  e. Add an [=patch map entries|entry=] to <var>entry list</var> whose subset definition contains only the unicode code point set and
         maps to the generated URI and the patch encoding specified by [=Format 1 Patch Map/patchEncoding=].
 
-3.  For each [=FeatureRecord=] and associated [=EntryMapRecord=] in [=Feature Map/featureRecords=]:
+3.  For each [=FeatureRecord=] and associated [=EntryMapRecord=] in [=Feature Map/featureRecords=] and [=Feature Map/entryMapRecords=]:
 
     *  For each <var>entry index</var> between [=EntryMapRecord/firstEntryIndex=] (inclusive) and [=EntryMapRecord/lastEntryIndex=]
         (inclusive), find the set of unicode codepoints associated with that entry index using the same process as in step 2b through

--- a/Overview.bs
+++ b/Overview.bs
@@ -340,22 +340,23 @@ Some example inputs and the corresponding expansions:
 Extensions to the Font Format {#font-format-extensions}
 =======================================================
 
-<!-- TODO: Note that these new tables are extensions specific to this specification and not part of the broader open type specifications. -->
-
 An <dfn dfn>incremental font</dfn> follows the existing [[open-type|OpenType]] format, but includes two new
 [[open-type/otff#table-directory|tables]] identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both
 [[#patch-map|patch maps]], which encode a collection of mappings from [=font subset definition|font subset definitions=] to URIs which
 host [[#font-patch-formats|patches]] that extend the incremental font. All incremental fonts must contain the 'IFT ' table.
 The 'IFTX' table is optional. When both tables are present, the mapping of the font as a whole is the union of the mappings of
-the two tables.
+the two tables. The two new tables are used only in this specification and are not being added to the [[open-type|Open-Type]]
+specification.
 
 Note: allowing the mapping to be split between two distinct tables allows an incremental font to more easily make use of multiple
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
 'IFTX' table. Those patches can make updates only to one of the mapping tables and avoid making conflicting updates.
 
+Note: [=incremental font|incremental fonts=] can be converted to [[WOFF2]] and still be utilized as an incremental fonts. In this
+case the user agent would first decode the woff2, and patches are relative to the decoded bytes.
+
 <!-- TODO: instead of IFT/IFTX consider having a one table be specific to dependent patches and the other to independent patches -->
 <!-- TODO add algorithm explaining how to union the two tables -->
-<!-- TODO: how does this interact with woff2 -->
 
 
 Patch Map Table {#patch-map}
@@ -373,7 +374,6 @@ encoded in one of two formats:
 
 ### Patch Map Table: Format 1 ### {#patch-map-format-1}
 
-<!-- TODO: summary of this format -->
 <!-- TODO: provide normative validation requirements for each encoding -->
 <!-- TODO: clean up unreferenced definitions -->
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1260,7 +1260,7 @@ or remove tables in a [=font subset=].
   </tr>
   <tr>
     <td>uint16</td>
-    <td><dfn for="Per table brotli patch">patchesCount</dfn></td>
+    <td>patchesCount</td>
     <td>The number of entries in the patches array.</td>
   </tr>
   <tr>
@@ -1384,7 +1384,7 @@ A glyph keyed patch contains a collection of data chunks that are each associate
   <!-- TODO: we probably need patch id to allow for removal in step 6. -->
   <tr>
     <td>uint32</td>
-    <td><dfn for="Glyph keyed patch">length</dfn></td>
+    <td>length</td>
     <td>The uncompressed length of [=Glyph keyed patch/brotliStream=].</td>
   </tr>
   <tr>
@@ -1406,7 +1406,7 @@ A glyph keyed patch contains a collection of data chunks that are each associate
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="GlyphPatches">tableCount</dfn></td>
+    <td>tableCount</td>
     <td>The number of [[open-type/otff#table-directory|tables]] the patch has data for.</td>
   </tr>
   <tr>

--- a/Overview.bs
+++ b/Overview.bs
@@ -1707,7 +1707,7 @@ beyond the scope of this document). It typically involves a reachability analysi
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
 Any reachable data is retained in the generated font subset, while any unreachable data may be removed.
 
-Example pseudo code for a very basic encoder implementation using a font subsetter:
+In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only dependent patches:
 
 ```
 # Encodes a font (full_font) into an incremental font that starts at base_subset_def
@@ -1715,7 +1715,7 @@ Example pseudo code for a very basic encoder implementation using a font subsett
 # and set of associated patches.
 encode_as_ift(full_font, base_subset_def, subset_definitions):
   base_font = subset(full_font, base_subset_def)
-  patches = encode_node(full_font, base_font, base_subset_def, subset_definitions)
+  base_font, patches  = encode_node(full_font, base_font, base_subset_def, subset_definitions)
   return base_font, patches
 
 # Update base_font to add all of the ift patch mappings to reach any of
@@ -1728,24 +1728,25 @@ encode_node(full_font, base_font, cur_def, subset_definitions):
     next_def = subset_def union cur_def
     next_font = subset(full_font, next_def)
     let patch_url be a new unique url
-    
-    add patch map entry into base_font from (subset_def - cur_def) to patch_url
-    patches += encode(full_font, next_font, next_def, subset_definitions)
+
+    add a mapping from, (subset_def - cur_def) to patch_url, into base_font
+    next_font, patches += encode(full_font, next_font, next_def, subset_definitions)
 
     next_fonts += (next_font, next_def, patch_url)
 
-  for each (next_font, next_def, patch_url):
+  for each (next_font, next_def, patch_url) in next_fonts:
     patch = dependent_patch_diff(base_font, next_font)
     patches += (patch, patch_url)
   
-  return patches
+  return base_font, patches
 ```
 
 In this example implementation if the union of the input base subset definition and the list of subset definitions fully covers the input
-full font, and the subsetter implementation used correctly retains all functionality then the above implementation should meet the
+full font, and the subsetter implementation used correctly retains all functionality then, the above implementation should meet the
 requirements in [[#encoder]] to be a neutral encoding. This basic encoder implementation is for demonstration purposes and not meant
-to be representative of all possible encoder implementations. Most encoders will likely be more complex and need to consider additional
-factors some of which are discussed in the remaining sections.
+to be representative of all possible encoder implementations. Notably it does not make use of nor demonstrate utilizing independent
+patches. Most encoders will likely be more complex and need to consider additional factors some of which are discussed in the remaining
+sections.
 
 <b>Choosing segmentations</b>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -232,14 +232,6 @@ only be loaded by a user agent which supports incremental font transfer.
 </pre>
 </div>
 
-<!-- TODO: the unicode range requirement should very likely be removed. This was copied from patch subset
-     where it provided significant value in allowing early pruning of the codepoints in the first request.
-     That's no longer needed in the new scheme. -->
-@font-face's that include the <code>incremental</code> tech keyword should also include a
-[[css-fonts-4#unicode-range-desc|unicode-range descriptor]]. This informs the client which codepoints
-are available in the font prior to making the first request, which can be used to avoid requesting
-the font unnecessarily.
-
 Note: Each individual <code>@font-face</code> block may or may not opt-in to IFT. This is due to the
 variety of ways fonts are used on web pages. Authors have control over which fonts they want to use
 this technology with, and which they do not.

--- a/Overview.bs
+++ b/Overview.bs
@@ -1730,7 +1730,7 @@ encode_node(full_font, base_font, cur_def, subset_definitions):
     let patch_url be a new unique url
 
     add a mapping from, (subset_def - cur_def) to patch_url, into base_font
-    next_font, patches += encode(full_font, next_font, next_def, subset_definitions)
+    next_font, patches += encode_node(full_font, next_font, next_def, subset_definitions)
 
     next_fonts += (next_font, next_def, patch_url)
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -358,8 +358,8 @@ patch types. For example all patches of one type can be specified in the 'IFT ' 
 Incremental Font Transfer and WOFF2 {#ift-and-woff2}
 ----------------------------------------------------
 
-[[WOFF2]] is a commonly used to encode fonts for transfer on the web. Incremental fonts can encoded with WOFF2 as long as special care is
-taken. If an incremental font will be encoded by WOFF2 for transfer:
+[[WOFF2]] is a commonly used to encode fonts for transfer on the web. Incremental fonts can be encoded with WOFF2 as long as special care
+is taken. If an incremental font will be encoded by WOFF2 for transfer:
 
 1.  The incremental font should not make use of [[#brotli]] patches. The WOFF2 format does not guarantee the ordering of tables in
      the decoded font. [[#brotli]] patches are relative to a specific fixed set of bytes and thus cannot be used if the decoded font

--- a/Overview.bs
+++ b/Overview.bs
@@ -375,7 +375,6 @@ encoded in one of two formats:
 ### Patch Map Table: Format 1 ### {#patch-map-format-1}
 
 <!-- TODO: provide normative validation requirements for each encoding -->
-<!-- TODO: clean up unreferenced definitions -->
 
 <dfn>Format 1 Patch Map</dfn> encoding:
 <table>
@@ -623,8 +622,6 @@ The algorithm:
 
 ### Patch Map Table: Format 2 ### {#patch-map-format-2}
 
-<!-- TODO: clean up unreferenced definitions -->
-
 <dfn>Format 2 Patch Map</dfn> encoding:
 
 <table>
@@ -638,7 +635,7 @@ The algorithm:
   </tr>
   <tr>
     <td>uint32</td>
-    <td><dfn for="Format 2 Patch Map">reserved</dfn></td>
+    <td>reserved</td>
     <td>Not used, set to 0.</td>
   </tr>
   <tr>
@@ -666,7 +663,7 @@ The algorithm:
   </tr>
   <tr>
     <td>uint16</td>
-    <td><dfn for="Format 2 Patch Map">uriTemplateLength</dfn></td>
+    <td>uriTemplateLength</td>
     <td>
       Length of the uriTemplate string.
     </td>
@@ -841,7 +838,7 @@ This algorithm is used to convert a format 2 patch map into a list of [=patch ma
 
 The inputs to this algorithm are:
 
-* <var>patch map</var>: a [[#patch-map-format-2]] encoded patch map.
+* <var>patch map</var>: a [=Format 2 Patch Map=] encoded patch map.
 
 The algorithm outputs:
 
@@ -851,7 +848,8 @@ The algorithm outputs:
 
 The algorithm:
 
-1.  Check that the <var>patch map</var> is valid according to the requirements in [[#patch-map-format-2]]. If it is not return an error.
+1.  Check that the <var>patch map</var> has [=Format 2 Patch Map/format=] equal to 2 and is valid according to the requirements in
+     [[#patch-map-format-2]]. If it is not return an error.
 
 2.  Initialize <var>last entry id</var> to 0, and <var>current byte</var> to 0.
 
@@ -910,7 +908,8 @@ The algorithm:
         and add the loaded tags to <var>entry</var>.
 
     *  Read the design space segment list specified by [=Mapping Entry/designSpaceCount=] and [=Mapping Entry/designSpaceSegments=]
-        from <var>entry bytes</var> and add the design space segments to <var>entry</var>.
+        from <var>entry bytes</var> and add the design space segments to <var>entry</var>. Each segment defines an interval from
+        [=Design Space Segment/start=] to [=Design Space Segment/end=] inclusive for the axis identified by [=Design Space Segment/tag=].
 
 6.  If [=Mapping Entry/formatFlags=] bit 1 is set, then the copy indices list is present:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -351,7 +351,7 @@ Extensions to the Font Format {#font-format-extensions}
 
 <!-- TODO: Note that these new tables are extensions specific to this specification and not part of the broader open type specifications. -->
 
-An <dfn dfn>incremental font</dfn> follows the existing [[open-type|OpenType]] format, but include two new
+An <dfn dfn>incremental font</dfn> follows the existing [[open-type|OpenType]] format, but includes two new
 [[open-type/otff#table-directory|tables]] identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both
 [[#patch-map|patch maps]], which encode a collection of mappings from [=font subset definition|font subset definitions=] to URIs which
 host [[#font-patch-formats|patches]] that extend the incremental font. All incremental fonts must contain the 'IFT ' table.
@@ -362,6 +362,7 @@ Note: allowing the mapping to be split between two distinct tables allows an inc
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
 'IFTX' table. Those patches can make updates only to one of the mapping tables and avoid making conflicting updates.
 
+<!-- TODO: instead of IFT/IFTX consider having a one table be specific to dependent patches and the other to independent patches -->
 <!-- TODO add algorithm explaining how to union the two tables -->
 <!-- TODO: how does this interact with woff2 -->
 
@@ -1150,13 +1151,13 @@ The following patch formats are defined by this specification:
     <td>[[#shared-brotli]]</td>
     <td>[=dependent=]</td>
     <td>1</td>
-    <td>A shared brotli encoded binary diff that uses the entire [=font subset=] as a base.</td>
+    <td>A brotli encoded binary diff that uses the entire [=font subset=] as a base.</td>
   </tr>
   <tr>
     <td>[[#per-table-shared-brotli]]</td>
     <td>[=dependent=]</td>
     <td>2</td>
-    <td>A collection of shared brotli encoded binary diffs that use tables from the [=font subset=] as bases.</td>
+    <td>A collection of brotli encoded binary diffs that use tables from the [=font subset=] as bases.</td>
   </tr>
   <tr>
     <td>[[#glyph-keyed]]</td>
@@ -1168,14 +1169,14 @@ The following patch formats are defined by this specification:
 
 More detailed descriptions of each algorithm can be found in the following sections.
 
-Shared Brotli Patch {#shared-brotli}
+Brotli Patch {#shared-brotli}
 ------------------------------------
 
-In a shared brotli patch the target file is encoded with [[!RFC7932|brotli compression]] using the
-source file as a [[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. A shared brotli encoded patch consists
+In a brotli patch the target file is encoded with [[!RFC7932|brotli compression]] using the
+source file as a [[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. A brotli encoded patch consists
 of a short header followed by brotli encoded data.
 
-<dfn>Shared brotli patch</dfn> encoding:
+<dfn>Brotli patch</dfn> encoding:
 <table>
   <tr>
     <th>Type</th><th>Name</th><th>Description</th>
@@ -1185,34 +1186,34 @@ of a short header followed by brotli encoded data.
   <!-- TODO: field for the uncompressed length of brotliStream? -->
   <tr>
     <td>Tag</td>
-    <td><dfn for="Shared brotli patch">format</dfn></td>
-    <td>Identifies the encoding as shared brotli, set to 'ifbr'</td>
+    <td><dfn for="Brotli patch">format</dfn></td>
+    <td>Identifies the encoding as brotli, set to 'ifbr'</td>
   </tr>
   <tr>
     <!-- TODO link to the IFT table section on ID once added. -->
     <td>uint32</td>
-    <td><dfn for="Shared brotli patch">id</dfn>[4]</td>
+    <td><dfn for="Brotli patch">id</dfn>[4]</td>
     <td>The id of the [=font subset=] which this patch can be applied too.</td>
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Shared brotli patch">brotliStream</dfn>[variable]</td>
+    <td><dfn for="Brotli patch">brotliStream</dfn>[variable]</td>
     <td>Brotli encoded byte stream.</td>
   </tr>
 </table>
 
-<h4 algorithm id="apply-shared-brotli">Applying Shared Brotli Patches</h4>
+<h4 algorithm id="apply-shared-brotli">Applying Brotli Patches</h4>
 
-This algorithm is used to apply a shared brotli patch to extend a [=font subset=] to cover additional codepoints,
+This algorithm is used to apply a brotli patch to extend a [=font subset=] to cover additional codepoints,
 features, and/or design-variation space.
 
-<dfn abstract-op>Apply shared brotli patch</dfn>
+<dfn abstract-op>Apply brotli patch</dfn>
 
 The inputs to this algorithm are:
 
 * <var>base font subset</var>: a [=font subset=] which is to be extended.
 
-* <var>patch</var>: a [=shared brotli patch=] to be applied to <var>base font subset</var>.
+* <var>patch</var>: a [=brotli patch=] to be applied to <var>base font subset</var>.
 
 The algorithm outputs:
 
@@ -1220,31 +1221,31 @@ The algorithm outputs:
 
 The algorithm:
 
-1. Check that the [=Shared brotli patch/format=] field in <var>patch</var> is equal to 'ifbr', if it is
+1. Check that the [=Brotli patch/format=] field in <var>patch</var> is equal to 'ifbr', if it is
     not equal, then <var>patch</var> is not correctly formatted. Patch application has failed, return
     an error.
 
 <!-- TODO: link to IFT/IFTX section once it's written for the id field. -->
-2. Check that the [=Shared brotli patch/id=] field in <var>patch</var> is equal to the at least one of the ids
+2. Check that the [=Brotli patch/id=] field in <var>patch</var> is equal to the at least one of the ids
     found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or
     <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
     return an error.
 
-3. Decode the brotli encoded data in [=Shared brotli patch/brotliStream=] following [[RFC7932#section-10]] and
+3. Decode the brotli encoded data in [=Brotli patch/brotliStream=] following [[RFC7932#section-10]] and
     using the <var>base font subset</var> as a [[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. Return the decoded
     result as the <var>extended font subset</var>
 
-Per Table Shared Brotli {#per-table-shared-brotli}
+Per Table Brotli {#per-table-shared-brotli}
 --------------------------------------------------
 
-A per table shared brotli patch contains a collection of patches which are applied to the individual
+A per table brotli patch contains a collection of patches which are applied to the individual
 [[open-type/otff#table-directory|font tables]] in the input font file. Each table patch is encoded with
 [[!RFC7932|brotli compression]] using the corresponding table from the input font file as a
-[[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. A per table shared brotli encoded patch consists of a short header followed
+[[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. A per table brotli encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
 or remove tables in a [=font subset=].
 
-<dfn>Per table shared brotli patch</dfn> encoding:
+<dfn>Per table brotli patch</dfn> encoding:
 <table>
   <!-- TODO: reserved flags and/or version field? -->
   <tr>
@@ -1252,28 +1253,28 @@ or remove tables in a [=font subset=].
   </tr>
   <tr>
     <td>Tag</td>
-    <td><dfn for="Per table shared brotli patch">format</dfn></td>
-    <td>Identifies the encoding as shared brotli, set to 'ifbt'</td>
+    <td><dfn for="Per table brotli patch">format</dfn></td>
+    <td>Identifies the encoding as per table brotli, set to 'ifbt'</td>
   </tr>
   <tr>
     <!-- TODO link to the IFT table section on ID once added. -->
     <td>uint32</td>
-    <td><dfn for="Per table shared brotli patch">id</dfn>[4]</td>
+    <td><dfn for="Per table brotli patch">id</dfn>[4]</td>
     <td>The id of the [=font subset=] which this patch can be applied too.</td>
   </tr>
   <tr>
     <td>uint16</td>
-    <td><dfn for="Per table shared brotli patch">patchesCount</dfn></td>
+    <td><dfn for="Per table brotli patch">patchesCount</dfn></td>
     <td>The number of entries in the patches array.</td>
   </tr>
   <tr>
     <td>Offset32</td>
-    <td><dfn for="Per table shared brotli patch">patches</dfn>[patchesCount+1]</td>
+    <td><dfn for="Per table brotli patch">patches</dfn>[patchesCount+1]</td>
     <td>Each entry is an offset from the start of this table to a [=TablePatch=]. Offsets must be sorted in ascending order.</td>
   </tr>
 </table>
 
-The difference between two consecutive offsets in the [=Per table shared brotli patch/patches=] array gives the size
+The difference between two consecutive offsets in the [=Per table brotli patch/patches=] array gives the size
 of that [=TablePatch=].
 
 <dfn>TablePatch</dfn> encoding:
@@ -1300,18 +1301,18 @@ of that [=TablePatch=].
 </table>
 
 
-<h4 algorithm id="apply-per-table-shared-brotli">Applying Per Table Shared Brotli Patches</h4>
+<h4 algorithm id="apply-per-table-shared-brotli">Applying Per Table Brotli Patches</h4>
 
-This algorithm is used to apply a per table shared brotli patch to extend a [=font subset=] to cover additional codepoints,
+This algorithm is used to apply a per table brotli patch to extend a [=font subset=] to cover additional codepoints,
 features, and/or design-variation space.
 
-<dfn abstract-op>Apply per table shared brotli patch</dfn>
+<dfn abstract-op>Apply per table brotli patch</dfn>
 
 The inputs to this algorithm are:
 
 * <var>base font subset</var>: a [=font subset=] which is to be extended.
 
-* <var>patch</var>: a [=per table shared brotli patch=] to be applied to <var>base font subset</var>.
+* <var>patch</var>: a [=per table brotli patch=] to be applied to <var>base font subset</var>.
 
 The algorithm outputs:
 
@@ -1319,26 +1320,26 @@ The algorithm outputs:
 
 The algorithm:
 
-1. Check that the [=Per table shared brotli patch/format=] field in <var>patch</var> is equal to 'ifbt', if it is
+1. Check that the [=Per table brotli patch/format=] field in <var>patch</var> is equal to 'ifbt', if it is
     not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
     an error.
 
 <!-- TODO: link to IFT/IFTX section once it's written for the id field. -->
-2. Check that the [=Per table shared brotli patch/id=] field in <var>patch</var> is equal to the at least one of the ids
+2. Check that the [=Per table brotli patch/id=] field in <var>patch</var> is equal to the at least one of the ids
     found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or
     <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
     return an error.
 
-3. For each entry in [=Per table shared brotli patch/patches=], with index <var>i</var>:
+3. For each entry in [=Per table brotli patch/patches=], with index <var>i</var>:
 
     *  Find the [=TablePatch=] associated with index <var>i</var>. The object starts at the offset
-        [=Per table shared brotli patch/patches|patches[i]=] (inclusive) and ends at the offset
-        [=Per table shared brotli patch/patches|patches[i+1]=] (exclusive). Both offsets are relative to the start of
+        [=Per table brotli patch/patches|patches[i]=] (inclusive) and ends at the offset
+        [=Per table brotli patch/patches|patches[i+1]=] (exclusive). Both offsets are relative to the start of
         the <var>patch</var>.
 
-    *  If an entry in [=Per table shared brotli patch/patches=] was previously applied that has the same [=TablePatch/tag=] as
+    *  If an entry in [=Per table brotli patch/patches=] was previously applied that has the same [=TablePatch/tag=] as
         this entry, then ignore this entry and continue the iteration to the next one. Entries are processed in same order as they
-        are listed in the [=Per table shared brotli patch/patches=] array.
+        are listed in the [=Per table brotli patch/patches=] array.
 
 
     *  If bit 0 (least significant bit) of [=TablePatch/flags=] is set, then decode [=TablePatch/brotliStream=] following
@@ -1739,7 +1740,7 @@ Using per-table brotli patches and two mapping tables it becomes possible to mix
 incremental font. This can be accomplished by:
 
 1. Keep all dependent patch entries in one mapping table and all independent entries in the other mapping table.
-2. Use per-table shared brotli patches to update all tables except for the tables touched by the independent patches (outline,
+2. Use per-table brotli patches to update all tables except for the tables touched by the independent patches (outline,
     variation deltas, and the independent patch mapping table). These patches should use a small number of large segments to keep
     the patch count reasonable.
 3. Lastly, use independent patches to update the remaining tables, here much smaller fine-grained segments can be utilized without

--- a/Overview.bs
+++ b/Overview.bs
@@ -352,12 +352,28 @@ Note: allowing the mapping to be split between two distinct tables allows an inc
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
 'IFTX' table. Those patches can make updates only to one of the mapping tables and avoid making conflicting updates.
 
-Note: [=incremental font|incremental fonts=] can be converted to [[WOFF2]] and still be utilized as an incremental fonts. In this
-case the user agent would first decode the woff2, and patches are relative to the decoded bytes.
-
 <!-- TODO: instead of IFT/IFTX consider having a one table be specific to dependent patches and the other to independent patches -->
 <!-- TODO add algorithm explaining how to union the two tables -->
 
+Incremental Font Transfer and WOFF2 {#ift-and-woff2}
+----------------------------------------------------
+
+[[WOFF2]] is a commonly used to encode fonts for transfer on the web. Incremental fonts can encoded with WOFF2 as long as special care is
+taken. If an incremental font will be encoded by WOFF2 for transfer:
+
+1.  The incremental font should not make use of [[#brotli]] patches. The WOFF2 format does not guarantee the ordering of tables in
+     the decoded font. [[#brotli]] patches are relative to a specific fixed set of bytes and thus cannot be used if the decoded font
+     has unpredictable decoded bytes. [[#per-table-brotli]] patches do not depend on a specific table ordering and may be used.
+
+2.  If the WOFF2 encoding will include a transformed glyf and loca table ([[WOFF2#glyf_table_format]]) then, the incremental
+     font should not contain [[#per-table-brotli]] patches which modify either the glyf or loca table. The WOFF2 format does not
+     guarantee the specific bytes that result from decoding a transformed glyf and loca table, so as with #1 brotli patches cannot
+     be used. [[#glyph-keyed]] patches may be used in conjunction with a transformed glyf and loca table.
+
+3.  When utilizing a WOFF2 encoded IFT font, the client must first fully decode the WOFF2 font before [[#extending-font-subset]].
+
+The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in
+[[WOFF2#table_format]].
 
 Patch Map Table {#patch-map}
 ----------------------------

--- a/Overview.bs
+++ b/Overview.bs
@@ -93,20 +93,14 @@ th, td {
 Introduction {#intro}
 =====================
 
-<!-- TODO: from feedback:
-     1. Move the "does not break layout" up to the end of the introduction.
-     2. Add variable fonts where only a subset of axes are needed to 1.2 -->
-
-<!-- TODO: consider recommended hosting by at least HTTP2 capable server for performance of making multiple patch requests in parallel. -->
-
-
 <em>This section is not normative.</em>
 
 Incremental Font Transfer (IFT) is a technology to improve the latency of remote fonts (or "web fonts") on
 the web. Without this technology, a browser needs to download every last byte of a font before it can render
 any characters using that font. IFT allows the browser to download only some of the bytes in the file, thereby
 decreasing the perceived latency between the time when a browser realizes it needs a font and when the
-necessary text can be rendered with that font.
+necessary text can be rendered with that font. Unlike traditional font subsetting approaches Incremental Font Transfer
+retains the encoding of layout rules between segments ([[PFE-report#fail-subset]]).
 
 The success of WebFonts is unevenly distributed. This specification allows WebFonts to be used where
 slow networks, very large fonts, or complex subsetting requirements currently preclude their use. For
@@ -143,7 +137,8 @@ At a high level an IFT font is used like this:
     the font.
 
 2. Based on the content to be rendered, the client [[#extending-font-subset|selects, downloads, and applies]] patches to extend 
-    the font to cover additional characters. This step is repeated each time there is new content.
+    the font to cover additional characters, layout features, and/or variation space. This step is repeated each time there is new
+    content.
 
 Creating an Incremental Font {#making-incremental-fonts}
 --------------------------------------------------------
@@ -172,6 +167,10 @@ Performance Considerations and the use of Incremental Font Transfer {#performanc
 Using incremental transfer may not always be beneficial, depending on the characteristics of the font,
 the network, and the content being rendered. This section provides non-normative guidance to help decide
 when incremental transfer should be utilized.
+
+It is common for an incremental font to trigger the loading of multiple patches in parallel. So to maximize performance, when
+serving an incremental font it is recommended that an HTTP server which is capable of multiplexing (such as [[rfc9113]] or [[rfc9114]])
+is used.
 
 Incrementally loading a font has a fundamental performance trade off versus loading the whole font.
 Simplistically, under incremental transfer less bytes may be transferred at the potential cost of
@@ -1700,9 +1699,6 @@ The details of the encoding process may differ by encoder and are beyond the sco
 guidance that encoder implementations may want to consider.
 
 <b>Utilize an existing font subsetter implementation</b>
-
-<!-- TODO(garretrieger): subsetter implementations are not trivial they consider many interactions within the font to determine what
-     data is reachable -->
 
 As discussed in [[#encoder]] a high quality encoder should preserve the functionality of the original font. One way to
 achieve this is to leverage an existing font subsetter implementation to produce font subsets that retain the functionality

--- a/Overview.bs
+++ b/Overview.bs
@@ -789,7 +789,7 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Mapping Entry">codepoints</dfn>[variable]</td>
     <td>
-      Set of codepoints for this mapping. Encoded as a [[#sparse-bit-set-decoding]]. 
+      Set of codepoints for this mapping. Encoded as a [=Sparse Bit Set=].
       Only present if [=Mapping Entry/formatFlags=] bit 4 and/or 5 is set. The length is
       determined by following the decoding procedures in [[#sparse-bit-set-decoding]].
     </td>
@@ -961,8 +961,8 @@ is encoded into an array of bytes for transport.
   <tr>
     <td>uint8</td>
     <td>header</td>
-    <td>Bits 0 (least significant) and 1 encode the trees branch factor <i>B</i>. Bits 2 through 6 are a 5-bit unsigned integer which
-        encodes the value of <i>H</i>. Bit 7 is set to 0 and reserved for future use.
+    <td>Bits 0 (least significant) and 1 encode the trees branch factor <i>B</i> via [=Branch Factor Encoding=]. Bits 2 through 6 are a
+        5-bit unsigned integer which encodes the value of <i>H</i>. Bit 7 is set to 0 and reserved for future use.
     </td>
   </tr>
   <tr>

--- a/Overview.bs
+++ b/Overview.bs
@@ -389,7 +389,7 @@ encoded in one of two formats:
   </tr>
   <tr>
     <td>uint32</td>
-    <td><dfn for="Format 1 Patch Map">reserved</dfn></td>
+    <td>reserved</td>
     <td>Not used, set to 0.</td>
   </tr>
   <tr>
@@ -570,7 +570,7 @@ This algorithm is used to convert a format 1 patch map into a list of [=patch ma
 
 The inputs to this algorithm are:
 
-* <var>patch map</var>: a [[#patch-map-format-1]] encoded patch map.
+* <var>patch map</var>: a [=Format 1 Patch Map=] encoded patch map.
 
 * <var>font subset</var>: the [=font subset=] which contains <var>patch map</var>.
 
@@ -578,9 +578,12 @@ The algorithm outputs:
 
 * <var>entry list</var>: a list of [=patch map entries=].
 
+* <var>id</var>: the ID associated with this table.
+
 The algorithm:
 
-1.  Check that the <var>patch map</var> is valid according to the requirements in [[#patch-map-format-1]]. If it is not return an error.
+1.  Check that the <var>patch map</var> has [=Format 1 Patch Map/format=] equal to 1 and is valid according to the requirements in
+     [[#patch-map-format-1]]. If it is not return an error.
 
 2.  For each unique <var>entry index</var> in [=Glyph Map=]:
 
@@ -616,6 +619,8 @@ The algorithm:
         *  Add an [=patch map entries|entry=] to <var>entry list</var> whose subset definition contains the unicode code point set and
             a feature tag set containing only [=FeatureRecord/featureTag=]. The entry  maps to the generated URI and the patch encoding
             specified by [=Format 1 Patch Map/patchEncoding=].
+
+4.  Return <var>entry list</var> and [=Format 1 Patch Map/id=] as <var>id</var>.
 
 ### Patch Map Table: Format 2 ### {#patch-map-format-2}
 
@@ -843,6 +848,8 @@ The algorithm outputs:
 
 * <var>entry list</var>: a list of [=patch map entries=].
 
+* <var>id</var>: the ID associated with this table.
+
 The algorithm:
 
 1.  Check that the <var>patch map</var> is valid according to the requirements in [[#patch-map-format-2]]. If it is not return an error.
@@ -863,7 +870,7 @@ The algorithm:
 
      *  If the returned value of ignored is false, then add the returned entry to <var>entry list</var>.
 
-4.  Return <var>entry list</var>.
+4.  Return <var>entry list</var> and [=Format 2 Patch Map/id=] as <var>id</var>.
 
 <dfn abstract-op>Interpret Format 2 Patch Map Entry</dfn>
 
@@ -1206,6 +1213,8 @@ The inputs to this algorithm are:
 
 * <var>patch</var>: a [=brotli patch=] to be applied to <var>base font subset</var>.
 
+* <var>ids</var>: The ID numbers from the 'IFT ' and 'IFTX' tables of <var>base font subset</var>.
+
 The algorithm outputs:
 
 * <var>extended font subset</var>: a [=font subset=] that has been extended by the <var>patch</var>.
@@ -1216,11 +1225,9 @@ The algorithm:
     not equal, then <var>patch</var> is not correctly formatted. Patch application has failed, return
     an error.
 
-<!-- TODO: link to IFT/IFTX section once it's written for the id field. -->
-2. Check that the [=Brotli patch/id=] field in <var>patch</var> is equal to the at least one of the ids
-    found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or
-    <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
-    return an error.
+2. Check that the [=Brotli patch/id=] field in <var>patch</var> is equal to at least one of <var>ids</var>.
+    If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
+    has failed, return an error.
 
 3. Decode the brotli encoded data in [=Brotli patch/brotliStream=] following [[RFC7932#section-10]] and
     using the <var>base font subset</var> as a [[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. Return the decoded
@@ -1305,6 +1312,8 @@ The inputs to this algorithm are:
 
 * <var>patch</var>: a [=per table brotli patch=] to be applied to <var>base font subset</var>.
 
+* <var>ids</var>: The ID numbers from the 'IFT ' and 'IFTX' tables of <var>base font subset</var>.
+
 The algorithm outputs:
 
 * <var>extended font subset</var>: a [=font subset=] that has been extended by the <var>patch</var>.
@@ -1315,11 +1324,9 @@ The algorithm:
     not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
     an error.
 
-<!-- TODO: link to IFT/IFTX section once it's written for the id field. -->
-2. Check that the [=Per table brotli patch/id=] field in <var>patch</var> is equal to the at least one of the ids
-    found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or
-    <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
-    return an error.
+2. Check that the [=Per table brotli patch/id=] field in <var>patch</var> is equal to at least one of <var>ids</var>.
+    If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
+    has failed, return an error.
 
 3. For each entry in [=Per table brotli patch/patches=], with index <var>i</var>:
 
@@ -1450,6 +1457,8 @@ The inputs to this algorithm are:
 
 * <var>patch</var>: a [=glyph keyed patch=] to be applied to <var>base font subset</var>.
 
+* <var>ids</var>: The ID numbers from the 'IFT ' and 'IFTX' tables of <var>base font subset</var>.
+
 The algorithm outputs:
 
 * <var>extended font subset</var>: a [=font subset=] that has been extended by the <var>patch</var>.
@@ -1460,11 +1469,9 @@ The algorithm:
     not equal, then <var>patch</var> is not correctly formatted and patch application has failed, return
     an error.
 
-<!-- TODO: link to IFT/IFTX section once it's written for the id field. -->
-2. Check that the [=Glyph keyed patch/id=] field in <var>patch</var> is equal to the at least one of the ids
-    found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or
-    <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
-    return an error.
+2. Check that the [=Glyph keyed patch/id=] field in <var>patch</var> is equal to at least one of <var>ids</var>.
+    If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has
+    failed, return an error.
 
 3. Decode the brotli encoded data in [=Glyph keyed patch/brotliStream=] following [[RFC7932#section-10]]. The
     decoded data is a [=GlyphPatches=] table.
@@ -1525,9 +1532,9 @@ The algorithm:
     is not valid, invoke [$Handle errors$]. If <var>extended font subset</var> does not have an 'IFT ' table, then it is not an
     [=incremental font=] and cannot be extended, return <var>extended font subset</var>.
 
-<!-- TODO: reference format 2 interpret algorithm once defined. -->
 3.  For each of [[open-type/otff#table-directory|tables]] 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
-    invoking [$Interpret Format 1 Patch Map$]. Concatenate the output entry lists into a single list, <var>entry list</var>.
+    invoking [$Interpret Format 1 Patch Map$] or [$Interpret Format 2 Patch Map$]. Concatenate the returned entry lists into a single list,
+    <var>entry list</var>, and the returned IDs into a single list <var>ids</var>.
 
 4.  For each <var>entry</var> in <var>entry list</var> invoke [$Check entry intersection$] with <var>entry</var> and
     <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var>
@@ -1544,8 +1551,8 @@ The algorithm:
     files into <var>patch list</var>.
 
 8.  For each <var>patch</var> in <var>patch list</var> use the appropriate application algorithm (matching the patches format) from
-    [[#font-patch-formats]] to apply the <var>patch</var> to <var>extended font subset</var>. The order of patch application is left up to
-    the implementation.
+    [[#font-patch-formats]] to apply the <var>patch</var> to <var>extended font subset</var>. Pass in
+    <var>entry list</var> and <var>ids</var>. The order of patch application is left up to the implementation.
 
 9.  Go to step 2.
 

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,11 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
+<<<<<<< HEAD
   <meta content="27d662b865c94d64b35015c955f6abe490cbe810" name="document-revision">
+=======
+  <meta content="db12e20a3b706a51eb62e3cc7d62920a504c85cc" name="document-revision">
+>>>>>>> b1da24c (Cleanup unused definitions in the format 1 patch map section.)
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +507,11 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
+<<<<<<< HEAD
    <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-12">12 April 2024</time></p>
+=======
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-04">4 April 2024</time></p>
+>>>>>>> b1da24c (Cleanup unused definitions in the format 1 patch map section.)
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -893,11 +901,11 @@ is typically less compact than format 1.</p>
       <td>Number of glyphs that mappings are provided for. Must match the numGlyphs field from <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a>.
      <tr>
       <td>Offset32
-      <td><dfn data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-glyphmapoffset">glyphMapOffset<a class="self-link" href="#format-1-patch-map-glyphmapoffset"></a></dfn>
+      <td>glyphMapOffset
       <td>Offset to a <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map">Glyph Map</a> sub table. Offset is from the start of this table.
      <tr>
       <td>Offset32
-      <td><dfn data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-featuremapoffset">featureMapOffset<a class="self-link" href="#format-1-patch-map-featuremapoffset"></a></dfn>
+      <td>featureMapOffset
       <td>Offset to a <a data-link-type="dfn" href="#feature-map" id="ref-for-feature-map">Feature Map</a> sub table. Offset is from the start of this table.
      <tr>
       <td>uint8
@@ -906,7 +914,7 @@ is typically less compact than format 1.</p>
       the most significant bit. Bit 8 is the least significant bit of appliedEntriesBitMap[1] and so on. 
      <tr>
       <td>uint16
-      <td><dfn data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-uritemplatelength">uriTemplateLength<a class="self-link" href="#format-1-patch-map-uritemplatelength"></a></dfn>
+      <td>uriTemplateLength
       <td> Length of the uriTemplate string. 
      <tr>
       <td>uint8
@@ -927,12 +935,12 @@ is typically less compact than format 1.</p>
       <th>Description
      <tr>
       <td>uint16
-      <td><dfn data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-firstmappedglyph">firstMappedGlyph<a class="self-link" href="#glyph-map-firstmappedglyph"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-firstmappedglyph">firstMappedGlyph</dfn>
       <td>All glyph indices less than firstMappedGlyph are implicitly mapped to entry index 0.
      <tr>
       <td>uint8/uint16
-      <td><dfn data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-entryindex">entryIndex<a class="self-link" href="#glyph-map-entryindex"></a></dfn>[<a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> - firstMappedGlyph]
-      <td> The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - firstMappedGlyph]. Array members
+      <td><dfn class="dfn-paneled" data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-entryindex">entryIndex</dfn>[<a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> - firstMappedGlyph]
+      <td> The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - <a data-link-type="dfn" href="#glyph-map-firstmappedglyph" id="ref-for-glyph-map-firstmappedglyph">firstMappedGlyph</a>]. Array members
       are uint8 if <a data-link-type="dfn" href="#format-1-patch-map-entrycount" id="ref-for-format-1-patch-map-entrycount">entryCount</a> is less than 256, otherwise they are uint16. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="feature-map">Feature Map</dfn> encoding:</p>
@@ -945,7 +953,7 @@ is typically less compact than format 1.</p>
       <th>Description
      <tr>
       <td>uint16
-      <td><dfn data-dfn-for="Feature Map" data-dfn-type="dfn" data-noexport id="feature-map-featurecount">featureCount<a class="self-link" href="#feature-map-featurecount"></a></dfn>
+      <td>featureCount
       <td>Number of featureRecords.
      <tr>
       <td><a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord">FeatureRecord</a>
@@ -953,7 +961,7 @@ is typically less compact than format 1.</p>
       <td> Provides mappings for a specific <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tag</a>. Must be sorted by <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag">featureTag</a> with any feature tag occurring at most once. 
      <tr>
       <td><a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord">EntryMapRecord</a>
-      <td><dfn data-dfn-for="Feature Map" data-dfn-type="dfn" data-noexport id="feature-map-entrymaprecords">entryMapRecords<a class="self-link" href="#feature-map-entrymaprecords"></a></dfn>[variable]
+      <td><dfn class="dfn-paneled" data-dfn-for="Feature Map" data-dfn-type="dfn" data-noexport id="feature-map-entrymaprecords">entryMapRecords</dfn>[variable]
       <td> Provides the key (entry index) for each feature mapping. The entryMapRecords array contains as many entries as the sum of
       the <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount">entryMapCount</a> fields in the <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords">featureRecords</a> array, with entryMapRecords[0] corresponding
       to the first entry of featureRecords[0], entryMapRecords[featureRecord[0].entryMapCount] corresponding to the first entry of
@@ -1022,7 +1030,7 @@ is typically less compact than format 1.</p>
     <li data-md>
      <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 4.1.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
     <li data-md>
-     <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map①">Glyph Map</a>:</p>
+     <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex">entryIndex</a>:</p>
      <ul>
       <li data-md>
        <p>a. If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
@@ -1037,7 +1045,7 @@ is typically less compact than format 1.</p>
 maps to the generated URI and the patch encoding specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding">patchEncoding</a>.</p>
      </ul>
     <li data-md>
-     <p>For each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords①">featureRecords</a>:</p>
+     <p>For each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords①">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
      <ul>
       <li data-md>
        <p>For each <var>entry index</var> between <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">firstEntryIndex</a> (inclusive) and <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">lastEntryIndex</a> (inclusive), find the set of unicode codepoints associated with that entry index using the same process as in step 2b through
@@ -2125,14 +2133,8 @@ required too many patches.</p>
    <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 4.1.1</span>
    <li><a href="#feature-map-entrymaprecords">entryMapRecords</a><span>, in § 4.1.1</span>
    <li><a href="#abstract-opdef-extend-a-font-subset">Extend a Font Subset</a><span>, in § 6</span>
-   <li>
-    featureCount
-    <ul>
-     <li><a href="#feature-map-featurecount">dfn for Feature Map</a><span>, in § 4.1.1</span>
-     <li><a href="#mapping-entry-featurecount">dfn for Mapping Entry</a><span>, in § 4.1.2</span>
-    </ul>
+   <li><a href="#mapping-entry-featurecount">featureCount</a><span>, in § 4.1.2</span>
    <li><a href="#feature-map">Feature Map</a><span>, in § 4.1.1</span>
-   <li><a href="#format-1-patch-map-featuremapoffset">featureMapOffset</a><span>, in § 4.1.1</span>
    <li><a href="#featurerecord">FeatureRecord</a><span>, in § 4.1.1</span>
    <li><a href="#feature-map-featurerecords">featureRecords</a><span>, in § 4.1.1</span>
    <li><a href="#featurerecord-featuretag">featureTag</a><span>, in § 4.1.1</span>
@@ -2172,7 +2174,6 @@ required too many patches.</p>
    <li><a href="#glyphpatches-glyphids">glyphIds</a><span>, in § 5.5</span>
    <li><a href="#glyph-keyed-patch">Glyph keyed patch</a><span>, in § 5.5</span>
    <li><a href="#glyph-map">Glyph Map</a><span>, in § 4.1.1</span>
-   <li><a href="#format-1-patch-map-glyphmapoffset">glyphMapOffset</a><span>, in § 4.1.1</span>
    <li><a href="#glyphpatches">GlyphPatches</a><span>, in § 5.5</span>
    <li><a href="#abstract-opdef-handle-errors">Handle errors</a><span>, in § 6</span>
    <li>
@@ -2224,12 +2225,7 @@ required too many patches.</p>
      <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
      <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
     </ul>
-   <li>
-    uriTemplateLength
-    <ul>
-     <li><a href="#format-1-patch-map-uritemplatelength">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
-     <li><a href="#format-2-patch-map-uritemplatelength">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
-    </ul>
+   <li><a href="#format-2-patch-map-uritemplatelength">uriTemplateLength</a><span>, in § 4.1.2</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -2433,9 +2429,12 @@ window.dfnpanelData['format-1-patch-map-glyphcount'] = {"dfnID": "format-1-patch
 window.dfnpanelData['format-1-patch-map-appliedentriesbitmap'] = {"dfnID": "format-1-patch-map-appliedentriesbitmap", "url": "#format-1-patch-map-appliedentriesbitmap", "dfnText": "appliedEntriesBitMap", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-appliedentriesbitmap"}, {"id": "ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['format-1-patch-map-uritemplate'] = {"dfnID": "format-1-patch-map-uritemplate", "url": "#format-1-patch-map-uritemplate", "dfnText": "uriTemplate", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-uritemplate"}, {"id": "ref-for-format-1-patch-map-uritemplate\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['format-1-patch-map-patchencoding'] = {"dfnID": "format-1-patch-map-patchencoding", "url": "#format-1-patch-map-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-patchencoding"}, {"id": "ref-for-format-1-patch-map-patchencoding\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['glyph-map'] = {"dfnID": "glyph-map", "url": "#glyph-map", "dfnText": "Glyph Map", "refSections": [{"refs": [{"id": "ref-for-glyph-map"}], "title": "4.1.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-glyph-map\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['glyph-map'] = {"dfnID": "glyph-map", "url": "#glyph-map", "dfnText": "Glyph Map", "refSections": [{"refs": [{"id": "ref-for-glyph-map"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
+window.dfnpanelData['glyph-map-firstmappedglyph'] = {"dfnID": "glyph-map-firstmappedglyph", "url": "#glyph-map-firstmappedglyph", "dfnText": "firstMappedGlyph", "refSections": [{"refs": [{"id": "ref-for-glyph-map-firstmappedglyph"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
+window.dfnpanelData['glyph-map-entryindex'] = {"dfnID": "glyph-map-entryindex", "url": "#glyph-map-entryindex", "dfnText": "entryIndex", "refSections": [{"refs": [{"id": "ref-for-glyph-map-entryindex"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['feature-map'] = {"dfnID": "feature-map", "url": "#feature-map", "dfnText": "Feature Map", "refSections": [{"refs": [{"id": "ref-for-feature-map"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
 window.dfnpanelData['feature-map-featurerecords'] = {"dfnID": "feature-map-featurerecords", "url": "#feature-map-featurerecords", "dfnText": "featureRecords", "refSections": [{"refs": [{"id": "ref-for-feature-map-featurerecords"}], "title": "4.1.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-feature-map-featurerecords\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['feature-map-entrymaprecords'] = {"dfnID": "feature-map-entrymaprecords", "url": "#feature-map-entrymaprecords", "dfnText": "entryMapRecords", "refSections": [{"refs": [{"id": "ref-for-feature-map-entrymaprecords"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['featurerecord'] = {"dfnID": "featurerecord", "url": "#featurerecord", "dfnText": "FeatureRecord", "refSections": [{"refs": [{"id": "ref-for-featurerecord"}], "title": "4.1.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-featurerecord\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['featurerecord-featuretag'] = {"dfnID": "featurerecord-featuretag", "url": "#featurerecord-featuretag", "dfnText": "featureTag", "refSections": [{"refs": [{"id": "ref-for-featurerecord-featuretag"}], "title": "4.1.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-featurerecord-featuretag\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['featurerecord-firstentryindex'] = {"dfnID": "featurerecord-firstentryindex", "url": "#featurerecord-firstentryindex", "dfnText": "firstEntryIndex", "refSections": [{"refs": [{"id": "ref-for-featurerecord-firstentryindex"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="9fb1a980a90ea075f6e2c8e234b1bb829dfa65b9" name="document-revision">
+  <meta content="899a2d6f5158e34644a4948f9be7a73afe964738" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -578,19 +578,20 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
     <li>
      <a href="#font-format-extensions"><span class="secno">4</span> <span class="content">Extensions to the Font Format</span></a>
      <ol class="toc">
+      <li><a href="#ift-and-woff2"><span class="secno">4.1</span> <span class="content">Incremental Font Transfer and WOFF2</span></a>
       <li>
-       <a href="#patch-map"><span class="secno">4.1</span> <span class="content">Patch Map Table</span></a>
+       <a href="#patch-map"><span class="secno">4.2</span> <span class="content">Patch Map Table</span></a>
        <ol class="toc">
         <li>
-         <a href="#patch-map-format-1"><span class="secno">4.1.1</span> <span class="content">Patch Map Table: Format 1</span></a>
+         <a href="#patch-map-format-1"><span class="secno">4.2.1</span> <span class="content">Patch Map Table: Format 1</span></a>
          <ol class="toc">
-          <li><a href="#interpreting-patch-map-format-1"><span class="secno">4.1.1.1</span> <span class="content">Interpreting Format 1</span></a>
+          <li><a href="#interpreting-patch-map-format-1"><span class="secno">4.2.1.1</span> <span class="content">Interpreting Format 1</span></a>
          </ol>
         <li>
-         <a href="#patch-map-format-2"><span class="secno">4.1.2</span> <span class="content">Patch Map Table: Format 2</span></a>
+         <a href="#patch-map-format-2"><span class="secno">4.2.2</span> <span class="content">Patch Map Table: Format 2</span></a>
          <ol class="toc">
-          <li><a href="#interpreting-patch-map-format-2"><span class="secno">4.1.2.1</span> <span class="content">Interpreting Format 2</span></a>
-          <li><a href="#sparse-bit-set-decoding"><span class="secno">4.1.2.2</span> <span class="content">Sparse Bit Set</span></a>
+          <li><a href="#interpreting-patch-map-format-2"><span class="secno">4.2.2.1</span> <span class="content">Interpreting Format 2</span></a>
+          <li><a href="#sparse-bit-set-decoding"><span class="secno">4.2.2.2</span> <span class="content">Sparse Bit Set</span></a>
          </ol>
        </ol>
      </ol>
@@ -850,9 +851,24 @@ the two tables. The two new tables are used only in this specification and are n
    <p class="note" role="note"><span class="marker">Note:</span> allowing the mapping to be split between two distinct tables allows an incremental font to more easily make use of multiple
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
 'IFTX' table. Those patches can make updates only to one of the mapping tables and avoid making conflicting updates.</p>
-   <p class="note" role="note"><span class="marker">Note:</span> <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font">incremental fonts</a> can be converted to <a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a> and still be utilized as an incremental fonts. In this
-case the user agent would first decode the woff2, and patches are relative to the decoded bytes.</p>
-   <h3 class="heading settled" data-level="4.1" id="patch-map"><span class="secno">4.1. </span><span class="content">Patch Map Table</span><a class="self-link" href="#patch-map"></a></h3>
+   <h3 class="heading settled" data-level="4.1" id="ift-and-woff2"><span class="secno">4.1. </span><span class="content">Incremental Font Transfer and WOFF2</span><a class="self-link" href="#ift-and-woff2"></a></h3>
+   <p><a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a> is a commonly used to encode fonts for transfer on the web. Incremental fonts can encoded with WOFF2 as long as special care is
+taken. If an incremental font will be encoded by WOFF2 for transfer:</p>
+   <ol>
+    <li data-md>
+     <p>The incremental font should not make use of <a href="#brotli">§ 5.3 Brotli Patch</a> patches. The WOFF2 format does not guarantee the ordering of tables in
+ the decoded font. <a href="#brotli">§ 5.3 Brotli Patch</a> patches are relative to a specific fixed set of bytes and thus cannot be used if the decoded font
+ has unpredictable decoded bytes. <a href="#per-table-brotli">§ 5.4 Per Table Brotli</a> patches do not depend on a specific table ordering and may be used.</p>
+    <li data-md>
+     <p>If the WOFF2 encoding will include a transformed glyf and loca table (<a href="https://w3c.github.io/woff/woff2/#glyf_table_format"><cite>WOFF 2.0</cite> § 5.1 Transformed glyf table format</a>) then, the incremental
+ font should not contain <a href="#per-table-brotli">§ 5.4 Per Table Brotli</a> patches which modify either the glyf or loca table. The WOFF2 format does not
+ guarantee the specific bytes that result from decoding a transformed glyf and loca table, so as with #1 brotli patches cannot
+ be used. <a href="#glyph-keyed">§ 5.5 Glyph Keyed</a> patches may be used in conjunction with a transformed glyf and loca table.</p>
+    <li data-md>
+     <p>When utilizing a WOFF2 encoded IFT font, the client must first fully decode the WOFF2 font before <a href="#extending-font-subset">§ 6 Extending a Font Subset</a>.</p>
+   </ol>
+   <p>The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in <a href="https://w3c.github.io/woff/woff2/#table_format"><cite>WOFF 2.0</cite> § 5 Compressed data format</a>.</p>
+   <h3 class="heading settled" data-level="4.2" id="patch-map"><span class="secno">4.2. </span><span class="content">Patch Map Table</span><a class="self-link" href="#patch-map"></a></h3>
    <p>A patch map table encodes a list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map-entries">patch map entries</dfn>, where each entry has a key and value. The key is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a> and the value is a URI and the <a href="#font-patch-formats">§ 5 Font Patch Formats</a> used by the data at the URI. A map is
 encoded in one of two formats:</p>
    <ul>
@@ -863,7 +879,7 @@ not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-f
      <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
 is typically less compact than format 1.</p>
    </ul>
-   <h4 class="heading settled" data-level="4.1.1" id="patch-map-format-1"><span class="secno">4.1.1. </span><span class="content">Patch Map Table: Format 1</span><a class="self-link" href="#patch-map-format-1"></a></h4>
+   <h4 class="heading settled" data-level="4.2.1" id="patch-map-format-1"><span class="secno">4.2.1. </span><span class="content">Patch Map Table: Format 1</span><a class="self-link" href="#patch-map-format-1"></a></h4>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="format-1-patch-map">Format 1 Patch Map</dfn> encoding:</p>
    <table>
     <tbody>
@@ -1000,7 +1016,7 @@ is typically less compact than format 1.</p>
       Must be greater than or equal to firstEntryIndex. 
    </table>
    <p>An entry map record matches any entry indices that are greater than or equal to firstEntryIndex and less than or equal to  lastEntryIndex.</p>
-   <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 1" data-level="4.1.1.1" id="interpreting-patch-map-format-1"><span class="secno">4.1.1.1. </span><span class="content">Interpreting Format 1</span><a class="self-link" href="#interpreting-patch-map-format-1"></a></h5>
+   <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 1" data-level="4.2.1.1" id="interpreting-patch-map-format-1"><span class="secno">4.2.1.1. </span><span class="content">Interpreting Format 1</span><a class="self-link" href="#interpreting-patch-map-format-1"></a></h5>
    <p>This algorithm is used to convert a format 1 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries">patch map entries</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
@@ -1020,7 +1036,7 @@ is typically less compact than format 1.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 4.1.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 4.2.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
     <li data-md>
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex">entryIndex</a>:</p>
      <ul>
@@ -1058,7 +1074,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
     <li data-md>
      <p>Return <var>entry list</var> and <a data-link-type="dfn" href="#format-1-patch-map-id" id="ref-for-format-1-patch-map-id">id</a> as <var>id</var>.</p>
    </ol>
-   <h4 class="heading settled" data-level="4.1.2" id="patch-map-format-2"><span class="secno">4.1.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
+   <h4 class="heading settled" data-level="4.2.2" id="patch-map-format-2"><span class="secno">4.2.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="format-2-patch-map">Format 2 Patch Map</dfn> encoding:</p>
    <table>
     <tbody>
@@ -1172,7 +1188,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codepoints</dfn>[variable]
       <td> Set of codepoints for this mapping. Encoded as a <a data-link-type="dfn" href="#sparse-bit-set" id="ref-for-sparse-bit-set">Sparse Bit Set</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 4 and/or 5 is set. The length is
-      determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. 
+      determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 4.2.2.2 Sparse Bit Set</a>. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="design-space-segment">Design Space Segment</dfn> encoding:</p>
    <table>
@@ -1194,7 +1210,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td><dfn class="dfn-paneled" data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-end">end</dfn>
       <td> End (inclusive) of the segment. Must be greater than or equal to start. This value uses the user axis scale: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
    </table>
-   <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="4.1.2.1" id="interpreting-patch-map-format-2"><span class="secno">4.1.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
+   <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="4.2.2.1" id="interpreting-patch-map-format-2"><span class="secno">4.2.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
    <p>This algorithm is used to convert a format 2 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
@@ -1212,7 +1228,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 4.1.2 Patch Map Table: Format 2</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 4.2.2 Patch Map Table: Format 2</a>. If it is not return an error.</p>
     <li data-md>
      <p>Initialize <var>last entry id</var> to 0, and <var>current byte</var> to 0.</p>
     <li data-md>
@@ -1300,7 +1316,7 @@ from <var>entry bytes</var>.</p>
       <li data-md>
        <p>Otherwise the bias is 0.</p>
       <li data-md>
-       <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codepoints</a> from <var>entry bytes</var> following <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. For each
+       <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codepoints</a> from <var>entry bytes</var> following <a href="#sparse-bit-set-decoding">§ 4.2.2.2 Sparse Bit Set</a>. For each
 codepoint add the bias value to it and then add the result to the codepoint set in <var>entry</var>.</p>
      </ul>
     <li data-md>
@@ -1310,7 +1326,7 @@ codepoint add the bias value to it and then add the result to the codepoint set 
     <li data-md>
      <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, and <var>ignored</var>.</p>
    </ol>
-   <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.1.2.2" id="sparse-bit-set-decoding"><span class="secno">4.1.2.2. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
+   <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.2.2.2" id="sparse-bit-set-decoding"><span class="secno">4.2.2.2. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
    <p>A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
 each node has a fixed number of children that recursively sub-divides an interval into equal partitions. A tree of height <i>H</i> with
 branching factor <i>B</i> can store set membership for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree
@@ -1779,13 +1795,13 @@ the entries processed in step 4, add a copy of that table to <var>extended font 
 that map to this patch.</p>
    </ol>
    <h2 class="heading settled algorithm" data-algorithm="Extending a Font Subset" data-level="6" id="extending-font-subset"><span class="secno">6. </span><span class="content">Extending a Font Subset</span><a class="self-link" href="#extending-font-subset"></a></h2>
-   <p>This sections defines the algorithm that a client uses to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑦">font subset</a> to cover additional
+   <p>This sections defines the algorithm that a client uses to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑦">font subset</a> to cover additional
 codepoints, layout features and/or design space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-extend-a-font-subset">Extend a Font Subset</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a>.</p>
+     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a>.</p>
     <li data-md>
      <p><var>font subset URI</var>: an <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the location of <var>font subset</var>.</p>
     <li data-md>
@@ -1794,7 +1810,7 @@ codepoints, layout features and/or design space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: an extended version of <var>font subset</var>. May or may not be an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font③">incremental font</a>.</p>
+     <p><var>extended font subset</var>: an extended version of <var>font subset</var>. May or may not be an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②">incremental font</a>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1802,8 +1818,8 @@ codepoints, layout features and/or design space.</p>
      <p>Set <var>extended font subset</var> to <var>font subset</var>.</p>
     <li data-md>
      <p>Load the 'IFT ' and 'IFTX' (if present) mapping <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> from <var>extended font subset</var>. Both
-tables are formatted as a <a href="#patch-map">§ 4.1 Patch Map Table</a>. Check that they are valid according to the requirements in <a href="#patch-map">§ 4.1 Patch Map Table</a>. If either table
-is not valid, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors">Handle errors</a>. If <var>extended font subset</var> does not have an 'IFT ' table, then it is not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font④">incremental font</a> and cannot be extended, return <var>extended font subset</var>.</p>
+tables are formatted as a <a href="#patch-map">§ 4.2 Patch Map Table</a>. Check that they are valid according to the requirements in <a href="#patch-map">§ 4.2 Patch Map Table</a>. If either table
+is not valid, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors">Handle errors</a>. If <var>extended font subset</var> does not have an 'IFT ' table, then it is not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font③">incremental font</a> and cannot be extended, return <var>extended font subset</var>.</p>
     <li data-md>
      <p>For each of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
 invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a> or <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a>. Concatenate the returned entry lists into a single list, <var>entry list</var>, and the returned IDs into a single list <var>ids</var>.</p>
@@ -1892,7 +1908,7 @@ patches to be applied.</p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑤">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑨">font subset</a>.</p>
+     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font④">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑨">font subset</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1907,25 +1923,25 @@ is considered to intersect all entries in the <a data-link-type="abstract-op" hr
 the <var>expanded font</var>.</p>
    </ol>
    <h2 class="heading settled" data-level="7" id="encoder"><span class="secno">7. </span><span class="content">Encoder</span><a class="self-link" href="#encoder"></a></h2>
-   <p>An encoder is a tool which produces an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑥">incremental font</a> and set of associated <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch③">patches</a>.
-The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑦">incremental font</a> and associated patches produced by a compliant encoder:</p>
+   <p>An encoder is a tool which produces an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑤">incremental font</a> and set of associated <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch③">patches</a>.
+The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑥">incremental font</a> and associated patches produced by a compliant encoder:</p>
    <ol>
     <li data-md>
      <p>Must meet all of the requirements in <a href="#font-format-extensions">§ 4 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 5 Font Patch Formats</a>.</p>
     <li data-md>
-     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset①">Extend a Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> must always be the same regardless of the particular order
+     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset①">Extend a Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑦">incremental font</a> must always be the same regardless of the particular order
 of dependent patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset②">Extend a Font Subset</a>.</p>
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font, that is:
- given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑨">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset③">Extend a Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⓪">incremental font</a> and the minimal subset definition covering that content should
+ given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset③">Extend a Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑨">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
     <li data-md>
-     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
+     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⓪">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
  should have all of the same <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> as the existing font (excluding the incremental IFT/IFTX
  tables) and each of those tables should be functionally equivalent to the corresponding table in the existing font. Note: the fully
  expanded may not always be an exact binary match with the existing font.</p>
    </ol>
-   <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> and a client is implemented according to the
+   <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> and a client is implemented according to the
 other sections of this document, the intent of the IFT specification is that appearance and behavior of the font in the client will be the
 same as if the entire file were transferred to the client. A primary goal of the IFT specification is that the IFT format and protocol can
 serve as a neutral medium for font transfer, comparable to WOFF2. If an encoder produces an encoding from a source font which meets all of
@@ -2083,12 +2099,12 @@ required too many patches.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a><span>, in § 4.1.1</span>
+   <li><a href="#format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a><span>, in § 4.2.1</span>
    <li><a href="#abstract-opdef-apply-brotli-patch">Apply brotli patch</a><span>, in § 5.3.1</span>
    <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 5.5.1</span>
    <li><a href="#abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</a><span>, in § 5.4.1</span>
-   <li><a href="#mapping-entry-bias">bias</a><span>, in § 4.1.2</span>
-   <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 4.1.2.2</span>
+   <li><a href="#mapping-entry-bias">bias</a><span>, in § 4.2.2</span>
+   <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 4.2.2.2</span>
    <li><a href="#brotli-patch">Brotli patch</a><span>, in § 5.3</span>
    <li>
     brotliStream
@@ -2098,47 +2114,47 @@ required too many patches.</p>
      <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 5.4</span>
     </ul>
    <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 6</span>
-   <li><a href="#mapping-entry-codepoints">codepoints</a><span>, in § 4.1.2</span>
-   <li><a href="#mapping-entry-copycount">copyCount</a><span>, in § 4.1.2</span>
-   <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 4.1.2</span>
-   <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 4.1.2.2</span>
-   <li><a href="#format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a><span>, in § 4.1.2</span>
+   <li><a href="#mapping-entry-codepoints">codepoints</a><span>, in § 4.2.2</span>
+   <li><a href="#mapping-entry-copycount">copyCount</a><span>, in § 4.2.2</span>
+   <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 4.2.2</span>
+   <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 4.2.2.2</span>
+   <li><a href="#format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a><span>, in § 4.2.2</span>
    <li><a href="#dependent">dependent</a><span>, in § 5.1</span>
-   <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 4.1.2</span>
-   <li><a href="#design-space-segment">Design Space Segment</a><span>, in § 4.1.2</span>
-   <li><a href="#mapping-entry-designspacesegments">designSpaceSegments</a><span>, in § 4.1.2</span>
-   <li><a href="#design-space-segment-end">end</a><span>, in § 4.1.2</span>
+   <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 4.2.2</span>
+   <li><a href="#design-space-segment">Design Space Segment</a><span>, in § 4.2.2</span>
+   <li><a href="#mapping-entry-designspacesegments">designSpaceSegments</a><span>, in § 4.2.2</span>
+   <li><a href="#design-space-segment-end">end</a><span>, in § 4.2.2</span>
    <li>
     entries
     <ul>
-     <li><a href="#format-2-patch-map-entries">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
-     <li><a href="#mapping-entries-entries">dfn for Mapping Entries</a><span>, in § 4.1.2</span>
+     <li><a href="#format-2-patch-map-entries">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
+     <li><a href="#mapping-entries-entries">dfn for Mapping Entries</a><span>, in § 4.2.2</span>
     </ul>
    <li>
     entryCount
     <ul>
-     <li><a href="#format-1-patch-map-entrycount">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
-     <li><a href="#format-2-patch-map-entrycount">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
+     <li><a href="#format-1-patch-map-entrycount">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
+     <li><a href="#format-2-patch-map-entrycount">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
     </ul>
-   <li><a href="#mapping-entry-entryiddelta">entryIdDelta</a><span>, in § 4.1.2</span>
-   <li><a href="#glyph-map-entryindex">entryIndex</a><span>, in § 4.1.1</span>
-   <li><a href="#featurerecord-entrymapcount">entryMapCount</a><span>, in § 4.1.1</span>
-   <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 4.1.1</span>
-   <li><a href="#feature-map-entrymaprecords">entryMapRecords</a><span>, in § 4.1.1</span>
+   <li><a href="#mapping-entry-entryiddelta">entryIdDelta</a><span>, in § 4.2.2</span>
+   <li><a href="#glyph-map-entryindex">entryIndex</a><span>, in § 4.2.1</span>
+   <li><a href="#featurerecord-entrymapcount">entryMapCount</a><span>, in § 4.2.1</span>
+   <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 4.2.1</span>
+   <li><a href="#feature-map-entrymaprecords">entryMapRecords</a><span>, in § 4.2.1</span>
    <li><a href="#abstract-opdef-extend-a-font-subset">Extend a Font Subset</a><span>, in § 6</span>
-   <li><a href="#mapping-entry-featurecount">featureCount</a><span>, in § 4.1.2</span>
-   <li><a href="#feature-map">Feature Map</a><span>, in § 4.1.1</span>
-   <li><a href="#featurerecord">FeatureRecord</a><span>, in § 4.1.1</span>
-   <li><a href="#feature-map-featurerecords">featureRecords</a><span>, in § 4.1.1</span>
-   <li><a href="#featurerecord-featuretag">featureTag</a><span>, in § 4.1.1</span>
-   <li><a href="#mapping-entry-featuretags">featureTags</a><span>, in § 4.1.2</span>
+   <li><a href="#mapping-entry-featurecount">featureCount</a><span>, in § 4.2.2</span>
+   <li><a href="#feature-map">Feature Map</a><span>, in § 4.2.1</span>
+   <li><a href="#featurerecord">FeatureRecord</a><span>, in § 4.2.1</span>
+   <li><a href="#feature-map-featurerecords">featureRecords</a><span>, in § 4.2.1</span>
+   <li><a href="#featurerecord-featuretag">featureTag</a><span>, in § 4.2.1</span>
+   <li><a href="#mapping-entry-featuretags">featureTags</a><span>, in § 4.2.2</span>
    <li>
     firstEntryIndex
     <ul>
-     <li><a href="#entrymaprecord-firstentryindex">dfn for EntryMapRecord</a><span>, in § 4.1.1</span>
-     <li><a href="#featurerecord-firstentryindex">dfn for FeatureRecord</a><span>, in § 4.1.1</span>
+     <li><a href="#entrymaprecord-firstentryindex">dfn for EntryMapRecord</a><span>, in § 4.2.1</span>
+     <li><a href="#featurerecord-firstentryindex">dfn for FeatureRecord</a><span>, in § 4.2.1</span>
     </ul>
-   <li><a href="#glyph-map-firstmappedglyph">firstMappedGlyph</a><span>, in § 4.1.1</span>
+   <li><a href="#glyph-map-firstmappedglyph">firstMappedGlyph</a><span>, in § 4.2.1</span>
    <li><a href="#tablepatch-flags">flags</a><span>, in § 5.4</span>
    <li><a href="#font-patch">font patch</a><span>, in § 5.1</span>
    <li><a href="#font-subset">font subset</a><span>, in § 3.1</span>
@@ -2147,72 +2163,72 @@ required too many patches.</p>
     format
     <ul>
      <li><a href="#brotli-patch-format">dfn for Brotli patch</a><span>, in § 5.3</span>
-     <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
-     <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
+     <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
+     <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
      <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 5.5</span>
      <li><a href="#per-table-brotli-patch-format">dfn for Per table brotli patch</a><span>, in § 5.4</span>
     </ul>
-   <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 4.1.1</span>
-   <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 4.1.2</span>
-   <li><a href="#mapping-entry-formatflags">formatFlags</a><span>, in § 4.1.2</span>
+   <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 4.2.1</span>
+   <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 4.2.2</span>
+   <li><a href="#mapping-entry-formatflags">formatFlags</a><span>, in § 4.2.2</span>
    <li><a href="#abstract-opdef-fully-expand-a-font-subset">Fully Expand a Font Subset</a><span>, in § 6.1</span>
    <li>
     glyphCount
     <ul>
-     <li><a href="#format-1-patch-map-glyphcount">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
+     <li><a href="#format-1-patch-map-glyphcount">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
      <li><a href="#glyphpatches-glyphcount">dfn for GlyphPatches</a><span>, in § 5.5</span>
     </ul>
    <li><a href="#glyphpatches-glyphdata">glyphData</a><span>, in § 5.5</span>
    <li><a href="#glyphpatches-glyphdataoffsets">glyphDataOffsets</a><span>, in § 5.5</span>
    <li><a href="#glyphpatches-glyphids">glyphIds</a><span>, in § 5.5</span>
    <li><a href="#glyph-keyed-patch">Glyph keyed patch</a><span>, in § 5.5</span>
-   <li><a href="#glyph-map">Glyph Map</a><span>, in § 4.1.1</span>
+   <li><a href="#glyph-map">Glyph Map</a><span>, in § 4.2.1</span>
    <li><a href="#glyphpatches">GlyphPatches</a><span>, in § 5.5</span>
    <li><a href="#abstract-opdef-handle-errors">Handle errors</a><span>, in § 6</span>
    <li>
     id
     <ul>
      <li><a href="#brotli-patch-id">dfn for Brotli patch</a><span>, in § 5.3</span>
-     <li><a href="#format-1-patch-map-id">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
-     <li><a href="#format-2-patch-map-id">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
+     <li><a href="#format-1-patch-map-id">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
+     <li><a href="#format-2-patch-map-id">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
      <li><a href="#glyph-keyed-patch-id">dfn for Glyph keyed patch</a><span>, in § 5.5</span>
      <li><a href="#per-table-brotli-patch-id">dfn for Per table brotli patch</a><span>, in § 5.4</span>
     </ul>
    <li><a href="#incremental-font">incremental font</a><span>, in § 4</span>
    <li><a href="#independent">independent</a><span>, in § 5.1</span>
-   <li><a href="#abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a><span>, in § 4.1.1.1</span>
-   <li><a href="#abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a><span>, in § 4.1.2.1</span>
-   <li><a href="#abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a><span>, in § 4.1.2.1</span>
-   <li><a href="#entrymaprecord-lastentryindex">lastEntryIndex</a><span>, in § 4.1.1</span>
+   <li><a href="#abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a><span>, in § 4.2.1.1</span>
+   <li><a href="#abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a><span>, in § 4.2.2.1</span>
+   <li><a href="#abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a><span>, in § 4.2.2.1</span>
+   <li><a href="#entrymaprecord-lastentryindex">lastEntryIndex</a><span>, in § 4.2.1</span>
    <li><a href="#abstract-opdef-load-patch-file">Load patch file</a><span>, in § 6</span>
-   <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 4.1.2</span>
-   <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 4.1.2</span>
+   <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 4.2.2</span>
+   <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 4.2.2</span>
    <li><a href="#patch-application-algorithm">patch application algorithm</a><span>, in § 5.1</span>
    <li>
     patchEncoding
     <ul>
-     <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
-     <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 4.1.2</span>
+     <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
+     <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 4.2.2</span>
     </ul>
    <li><a href="#per-table-brotli-patch-patches">patches</a><span>, in § 5.4</span>
    <li><a href="#patch-format">patch format</a><span>, in § 5.1</span>
-   <li><a href="#patch-map-entries">patch map entries</a><span>, in § 4.1</span>
+   <li><a href="#patch-map-entries">patch map entries</a><span>, in § 4.2</span>
    <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 5.4</span>
-   <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.1.2.2</span>
-   <li><a href="#design-space-segment-start">start</a><span>, in § 4.1.2</span>
+   <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.2.2.2</span>
+   <li><a href="#design-space-segment-start">start</a><span>, in § 4.2.2</span>
    <li><a href="#tablepatch">TablePatch</a><span>, in § 5.4</span>
    <li><a href="#glyphpatches-tables">tables</a><span>, in § 5.5</span>
    <li>
     tag
     <ul>
-     <li><a href="#design-space-segment-tag">dfn for Design Space Segment</a><span>, in § 4.1.2</span>
+     <li><a href="#design-space-segment-tag">dfn for Design Space Segment</a><span>, in § 4.2.2</span>
      <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 5.4</span>
     </ul>
    <li>
     uriTemplate
     <ul>
-     <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
-     <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
+     <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
+     <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -2238,6 +2254,8 @@ required too many patches.</p>
    <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09"><cite>Shared Brotli Compressed Data Format</cite></a>. 27 Jul 2021. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09</a>
    <dt id="biblio-utf-8">[UTF-8]
    <dd>F. Yergeau. <a href="https://www.rfc-editor.org/rfc/rfc3629"><cite>UTF-8, a transformation format of ISO 10646</cite></a>. November 2003. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3629">https://www.rfc-editor.org/rfc/rfc3629</a>
+   <dt id="biblio-woff2">[WOFF2]
+   <dd>Vladimir Levantovsky; Raph Levien. <a href="https://w3c.github.io/woff/woff2/"><cite>WOFF File Format 2.0</cite></a>. URL: <a href="https://w3c.github.io/woff/woff2/">https://w3c.github.io/woff/woff2/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -2247,8 +2265,6 @@ required too many patches.</p>
    <dd>M. Thomson, Ed.; C. Benfield, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9113"><cite>HTTP/2</cite></a>. June 2022. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9113">https://www.rfc-editor.org/rfc/rfc9113</a>
    <dt id="biblio-rfc9114">[RFC9114]
    <dd>M. Bishop, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9114"><cite>HTTP/3</cite></a>. June 2022. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9114">https://www.rfc-editor.org/rfc/rfc9114</a>
-   <dt id="biblio-woff2">[WOFF2]
-   <dd>Vladimir Levantovsky; Raph Levien. <a href="https://w3c.github.io/woff/woff2/"><cite>WOFF File Format 2.0</cite></a>. URL: <a href="https://w3c.github.io/woff/woff2/">https://w3c.github.io/woff/woff2/</a>
   </dl>
 <script>/* Boilerplate: script-dfn-panel */
 "use strict";
@@ -2405,61 +2421,61 @@ required too many patches.</p>
 </script>
 <script>/* Boilerplate: script-dfn-panel-json */
 window.dfnpanelData = {};
-window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subset", "dfnText": "font subset", "refSections": [{"refs": [{"id": "ref-for-font-subset"}], "title": "3.1. Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-font-subset\u2461"}], "title": "5. Font Patch Formats"}, {"refs": [{"id": "ref-for-font-subset\u2462"}, {"id": "ref-for-font-subset\u2463"}, {"id": "ref-for-font-subset\u2464"}, {"id": "ref-for-font-subset\u2465"}, {"id": "ref-for-font-subset\u2466"}, {"id": "ref-for-font-subset\u2467"}, {"id": "ref-for-font-subset\u2468"}, {"id": "ref-for-font-subset\u2460\u24ea"}, {"id": "ref-for-font-subset\u2460\u2460"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2461"}, {"id": "ref-for-font-subset\u2460\u2462"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2463"}], "title": "5.3. Brotli Patch"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2464"}, {"id": "ref-for-font-subset\u2460\u2465"}, {"id": "ref-for-font-subset\u2460\u2466"}], "title": "5.3.1. Applying Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2467"}, {"id": "ref-for-font-subset\u2460\u2468"}], "title": "5.4. Per Table Brotli"}, {"refs": [{"id": "ref-for-font-subset\u2461\u24ea"}, {"id": "ref-for-font-subset\u2461\u2460"}, {"id": "ref-for-font-subset\u2461\u2461"}], "title": "5.4.1. Applying Per Table Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2462"}], "title": "5.5. Glyph Keyed"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2463"}, {"id": "ref-for-font-subset\u2461\u2464"}, {"id": "ref-for-font-subset\u2461\u2465"}], "title": "5.5.1. Applying Glyph Keyed Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2466"}, {"id": "ref-for-font-subset\u2461\u2467"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2468"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-font-subset\u2462\u24ea"}], "title": "7. Encoder"}, {"refs": [{"id": "ref-for-font-subset\u2462\u2460"}], "title": "7.1. Encoder Considerations"}], "external": false};
-window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.1. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}, {"id": "ref-for-font-subset-definition\u2464"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-font-subset-definition\u2465"}, {"id": "ref-for-font-subset-definition\u2466"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2467"}], "title": "7. Encoder"}, {"refs": [{"id": "ref-for-font-subset-definition\u2468"}], "title": "7.1. Encoder Considerations"}], "external": false};
-window.dfnpanelData['incremental-font'] = {"dfnID": "incremental-font", "url": "#incremental-font", "dfnText": "incremental font", "refSections": [{"refs": [{"id": "ref-for-incremental-font"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-incremental-font\u2460"}, {"id": "ref-for-incremental-font\u2461"}, {"id": "ref-for-incremental-font\u2462"}, {"id": "ref-for-incremental-font\u2463"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-incremental-font\u2464"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-incremental-font\u2465"}, {"id": "ref-for-incremental-font\u2466"}, {"id": "ref-for-incremental-font\u2467"}, {"id": "ref-for-incremental-font\u2468"}, {"id": "ref-for-incremental-font\u2460\u24ea"}, {"id": "ref-for-incremental-font\u2460\u2460"}, {"id": "ref-for-incremental-font\u2460\u2461"}], "title": "7. Encoder"}], "external": false};
-window.dfnpanelData['patch-map-entries'] = {"dfnID": "patch-map-entries", "url": "#patch-map-entries", "dfnText": "patch map entries", "refSections": [{"refs": [{"id": "ref-for-patch-map-entries"}, {"id": "ref-for-patch-map-entries\u2460"}, {"id": "ref-for-patch-map-entries\u2461"}, {"id": "ref-for-patch-map-entries\u2462"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-patch-map-entries\u2463"}, {"id": "ref-for-patch-map-entries\u2464"}, {"id": "ref-for-patch-map-entries\u2465"}], "title": "4.1.2.1. Interpreting Format 2"}, {"refs": [{"id": "ref-for-patch-map-entries\u2466"}, {"id": "ref-for-patch-map-entries\u2467"}], "title": "6. Extending a Font Subset"}], "external": false};
-window.dfnpanelData['format-1-patch-map'] = {"dfnID": "format-1-patch-map", "url": "#format-1-patch-map", "dfnText": "Format 1 Patch Map", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['format-1-patch-map-format'] = {"dfnID": "format-1-patch-map-format", "url": "#format-1-patch-map-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-format"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['format-1-patch-map-id'] = {"dfnID": "format-1-patch-map-id", "url": "#format-1-patch-map-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-id"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['format-1-patch-map-entrycount'] = {"dfnID": "format-1-patch-map-entrycount", "url": "#format-1-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-entrycount"}, {"id": "ref-for-format-1-patch-map-entrycount\u2460"}, {"id": "ref-for-format-1-patch-map-entrycount\u2461"}, {"id": "ref-for-format-1-patch-map-entrycount\u2462"}, {"id": "ref-for-format-1-patch-map-entrycount\u2463"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
-window.dfnpanelData['format-1-patch-map-glyphcount'] = {"dfnID": "format-1-patch-map-glyphcount", "url": "#format-1-patch-map-glyphcount", "dfnText": "glyphCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-glyphcount"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
-window.dfnpanelData['format-1-patch-map-appliedentriesbitmap'] = {"dfnID": "format-1-patch-map-appliedentriesbitmap", "url": "#format-1-patch-map-appliedentriesbitmap", "dfnText": "appliedEntriesBitMap", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-appliedentriesbitmap"}, {"id": "ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['format-1-patch-map-uritemplate'] = {"dfnID": "format-1-patch-map-uritemplate", "url": "#format-1-patch-map-uritemplate", "dfnText": "uriTemplate", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-uritemplate"}, {"id": "ref-for-format-1-patch-map-uritemplate\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['format-1-patch-map-patchencoding'] = {"dfnID": "format-1-patch-map-patchencoding", "url": "#format-1-patch-map-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-patchencoding"}, {"id": "ref-for-format-1-patch-map-patchencoding\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['glyph-map'] = {"dfnID": "glyph-map", "url": "#glyph-map", "dfnText": "Glyph Map", "refSections": [{"refs": [{"id": "ref-for-glyph-map"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
-window.dfnpanelData['glyph-map-firstmappedglyph'] = {"dfnID": "glyph-map-firstmappedglyph", "url": "#glyph-map-firstmappedglyph", "dfnText": "firstMappedGlyph", "refSections": [{"refs": [{"id": "ref-for-glyph-map-firstmappedglyph"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
-window.dfnpanelData['glyph-map-entryindex'] = {"dfnID": "glyph-map-entryindex", "url": "#glyph-map-entryindex", "dfnText": "entryIndex", "refSections": [{"refs": [{"id": "ref-for-glyph-map-entryindex"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['feature-map'] = {"dfnID": "feature-map", "url": "#feature-map", "dfnText": "Feature Map", "refSections": [{"refs": [{"id": "ref-for-feature-map"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
-window.dfnpanelData['feature-map-featurerecords'] = {"dfnID": "feature-map-featurerecords", "url": "#feature-map-featurerecords", "dfnText": "featureRecords", "refSections": [{"refs": [{"id": "ref-for-feature-map-featurerecords"}], "title": "4.1.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-feature-map-featurerecords\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['feature-map-entrymaprecords'] = {"dfnID": "feature-map-entrymaprecords", "url": "#feature-map-entrymaprecords", "dfnText": "entryMapRecords", "refSections": [{"refs": [{"id": "ref-for-feature-map-entrymaprecords"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['featurerecord'] = {"dfnID": "featurerecord", "url": "#featurerecord", "dfnText": "FeatureRecord", "refSections": [{"refs": [{"id": "ref-for-featurerecord"}], "title": "4.1.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-featurerecord\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['featurerecord-featuretag'] = {"dfnID": "featurerecord-featuretag", "url": "#featurerecord-featuretag", "dfnText": "featureTag", "refSections": [{"refs": [{"id": "ref-for-featurerecord-featuretag"}], "title": "4.1.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-featurerecord-featuretag\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['featurerecord-firstentryindex'] = {"dfnID": "featurerecord-firstentryindex", "url": "#featurerecord-firstentryindex", "dfnText": "firstEntryIndex", "refSections": [{"refs": [{"id": "ref-for-featurerecord-firstentryindex"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['featurerecord-entrymapcount'] = {"dfnID": "featurerecord-entrymapcount", "url": "#featurerecord-entrymapcount", "dfnText": "entryMapCount", "refSections": [{"refs": [{"id": "ref-for-featurerecord-entrymapcount"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
-window.dfnpanelData['entrymaprecord'] = {"dfnID": "entrymaprecord", "url": "#entrymaprecord", "dfnText": "EntryMapRecord", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord"}, {"id": "ref-for-entrymaprecord\u2460"}], "title": "4.1.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-entrymaprecord\u2461"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['entrymaprecord-firstentryindex'] = {"dfnID": "entrymaprecord-firstentryindex", "url": "#entrymaprecord-firstentryindex", "dfnText": "firstEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-firstentryindex"}, {"id": "ref-for-entrymaprecord-firstentryindex\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
-window.dfnpanelData['entrymaprecord-lastentryindex'] = {"dfnID": "entrymaprecord-lastentryindex", "url": "#entrymaprecord-lastentryindex", "dfnText": "lastEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-lastentryindex"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subset", "dfnText": "font subset", "refSections": [{"refs": [{"id": "ref-for-font-subset"}], "title": "3.1. Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2460"}], "title": "4.2.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-font-subset\u2461"}], "title": "5. Font Patch Formats"}, {"refs": [{"id": "ref-for-font-subset\u2462"}, {"id": "ref-for-font-subset\u2463"}, {"id": "ref-for-font-subset\u2464"}, {"id": "ref-for-font-subset\u2465"}, {"id": "ref-for-font-subset\u2466"}, {"id": "ref-for-font-subset\u2467"}, {"id": "ref-for-font-subset\u2468"}, {"id": "ref-for-font-subset\u2460\u24ea"}, {"id": "ref-for-font-subset\u2460\u2460"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2461"}, {"id": "ref-for-font-subset\u2460\u2462"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2463"}], "title": "5.3. Brotli Patch"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2464"}, {"id": "ref-for-font-subset\u2460\u2465"}, {"id": "ref-for-font-subset\u2460\u2466"}], "title": "5.3.1. Applying Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2467"}, {"id": "ref-for-font-subset\u2460\u2468"}], "title": "5.4. Per Table Brotli"}, {"refs": [{"id": "ref-for-font-subset\u2461\u24ea"}, {"id": "ref-for-font-subset\u2461\u2460"}, {"id": "ref-for-font-subset\u2461\u2461"}], "title": "5.4.1. Applying Per Table Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2462"}], "title": "5.5. Glyph Keyed"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2463"}, {"id": "ref-for-font-subset\u2461\u2464"}, {"id": "ref-for-font-subset\u2461\u2465"}], "title": "5.5.1. Applying Glyph Keyed Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2466"}, {"id": "ref-for-font-subset\u2461\u2467"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2468"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-font-subset\u2462\u24ea"}], "title": "7. Encoder"}, {"refs": [{"id": "ref-for-font-subset\u2462\u2460"}], "title": "7.1. Encoder Considerations"}], "external": false};
+window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.2. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}, {"id": "ref-for-font-subset-definition\u2464"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-font-subset-definition\u2465"}, {"id": "ref-for-font-subset-definition\u2466"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2467"}], "title": "7. Encoder"}, {"refs": [{"id": "ref-for-font-subset-definition\u2468"}], "title": "7.1. Encoder Considerations"}], "external": false};
+window.dfnpanelData['incremental-font'] = {"dfnID": "incremental-font", "url": "#incremental-font", "dfnText": "incremental font", "refSections": [{"refs": [{"id": "ref-for-incremental-font"}, {"id": "ref-for-incremental-font\u2460"}, {"id": "ref-for-incremental-font\u2461"}, {"id": "ref-for-incremental-font\u2462"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-incremental-font\u2463"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-incremental-font\u2464"}, {"id": "ref-for-incremental-font\u2465"}, {"id": "ref-for-incremental-font\u2466"}, {"id": "ref-for-incremental-font\u2467"}, {"id": "ref-for-incremental-font\u2468"}, {"id": "ref-for-incremental-font\u2460\u24ea"}, {"id": "ref-for-incremental-font\u2460\u2460"}], "title": "7. Encoder"}], "external": false};
+window.dfnpanelData['patch-map-entries'] = {"dfnID": "patch-map-entries", "url": "#patch-map-entries", "dfnText": "patch map entries", "refSections": [{"refs": [{"id": "ref-for-patch-map-entries"}, {"id": "ref-for-patch-map-entries\u2460"}, {"id": "ref-for-patch-map-entries\u2461"}, {"id": "ref-for-patch-map-entries\u2462"}], "title": "4.2.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-patch-map-entries\u2463"}, {"id": "ref-for-patch-map-entries\u2464"}, {"id": "ref-for-patch-map-entries\u2465"}], "title": "4.2.2.1. Interpreting Format 2"}, {"refs": [{"id": "ref-for-patch-map-entries\u2466"}, {"id": "ref-for-patch-map-entries\u2467"}], "title": "6. Extending a Font Subset"}], "external": false};
+window.dfnpanelData['format-1-patch-map'] = {"dfnID": "format-1-patch-map", "url": "#format-1-patch-map", "dfnText": "Format 1 Patch Map", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['format-1-patch-map-format'] = {"dfnID": "format-1-patch-map-format", "url": "#format-1-patch-map-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-format"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['format-1-patch-map-id'] = {"dfnID": "format-1-patch-map-id", "url": "#format-1-patch-map-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-id"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['format-1-patch-map-entrycount'] = {"dfnID": "format-1-patch-map-entrycount", "url": "#format-1-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-entrycount"}, {"id": "ref-for-format-1-patch-map-entrycount\u2460"}, {"id": "ref-for-format-1-patch-map-entrycount\u2461"}, {"id": "ref-for-format-1-patch-map-entrycount\u2462"}, {"id": "ref-for-format-1-patch-map-entrycount\u2463"}], "title": "4.2.1. Patch Map Table: Format 1"}], "external": false};
+window.dfnpanelData['format-1-patch-map-glyphcount'] = {"dfnID": "format-1-patch-map-glyphcount", "url": "#format-1-patch-map-glyphcount", "dfnText": "glyphCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-glyphcount"}], "title": "4.2.1. Patch Map Table: Format 1"}], "external": false};
+window.dfnpanelData['format-1-patch-map-appliedentriesbitmap'] = {"dfnID": "format-1-patch-map-appliedentriesbitmap", "url": "#format-1-patch-map-appliedentriesbitmap", "dfnText": "appliedEntriesBitMap", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-appliedentriesbitmap"}, {"id": "ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['format-1-patch-map-uritemplate'] = {"dfnID": "format-1-patch-map-uritemplate", "url": "#format-1-patch-map-uritemplate", "dfnText": "uriTemplate", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-uritemplate"}, {"id": "ref-for-format-1-patch-map-uritemplate\u2460"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['format-1-patch-map-patchencoding'] = {"dfnID": "format-1-patch-map-patchencoding", "url": "#format-1-patch-map-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-patchencoding"}, {"id": "ref-for-format-1-patch-map-patchencoding\u2460"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['glyph-map'] = {"dfnID": "glyph-map", "url": "#glyph-map", "dfnText": "Glyph Map", "refSections": [{"refs": [{"id": "ref-for-glyph-map"}], "title": "4.2.1. Patch Map Table: Format 1"}], "external": false};
+window.dfnpanelData['glyph-map-firstmappedglyph'] = {"dfnID": "glyph-map-firstmappedglyph", "url": "#glyph-map-firstmappedglyph", "dfnText": "firstMappedGlyph", "refSections": [{"refs": [{"id": "ref-for-glyph-map-firstmappedglyph"}], "title": "4.2.1. Patch Map Table: Format 1"}], "external": false};
+window.dfnpanelData['glyph-map-entryindex'] = {"dfnID": "glyph-map-entryindex", "url": "#glyph-map-entryindex", "dfnText": "entryIndex", "refSections": [{"refs": [{"id": "ref-for-glyph-map-entryindex"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['feature-map'] = {"dfnID": "feature-map", "url": "#feature-map", "dfnText": "Feature Map", "refSections": [{"refs": [{"id": "ref-for-feature-map"}], "title": "4.2.1. Patch Map Table: Format 1"}], "external": false};
+window.dfnpanelData['feature-map-featurerecords'] = {"dfnID": "feature-map-featurerecords", "url": "#feature-map-featurerecords", "dfnText": "featureRecords", "refSections": [{"refs": [{"id": "ref-for-feature-map-featurerecords"}], "title": "4.2.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-feature-map-featurerecords\u2460"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['feature-map-entrymaprecords'] = {"dfnID": "feature-map-entrymaprecords", "url": "#feature-map-entrymaprecords", "dfnText": "entryMapRecords", "refSections": [{"refs": [{"id": "ref-for-feature-map-entrymaprecords"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['featurerecord'] = {"dfnID": "featurerecord", "url": "#featurerecord", "dfnText": "FeatureRecord", "refSections": [{"refs": [{"id": "ref-for-featurerecord"}], "title": "4.2.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-featurerecord\u2460"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['featurerecord-featuretag'] = {"dfnID": "featurerecord-featuretag", "url": "#featurerecord-featuretag", "dfnText": "featureTag", "refSections": [{"refs": [{"id": "ref-for-featurerecord-featuretag"}], "title": "4.2.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-featurerecord-featuretag\u2460"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['featurerecord-firstentryindex'] = {"dfnID": "featurerecord-firstentryindex", "url": "#featurerecord-firstentryindex", "dfnText": "firstEntryIndex", "refSections": [{"refs": [{"id": "ref-for-featurerecord-firstentryindex"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['featurerecord-entrymapcount'] = {"dfnID": "featurerecord-entrymapcount", "url": "#featurerecord-entrymapcount", "dfnText": "entryMapCount", "refSections": [{"refs": [{"id": "ref-for-featurerecord-entrymapcount"}], "title": "4.2.1. Patch Map Table: Format 1"}], "external": false};
+window.dfnpanelData['entrymaprecord'] = {"dfnID": "entrymaprecord", "url": "#entrymaprecord", "dfnText": "EntryMapRecord", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord"}, {"id": "ref-for-entrymaprecord\u2460"}], "title": "4.2.1. Patch Map Table: Format 1"}, {"refs": [{"id": "ref-for-entrymaprecord\u2461"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['entrymaprecord-firstentryindex'] = {"dfnID": "entrymaprecord-firstentryindex", "url": "#entrymaprecord-firstentryindex", "dfnText": "firstEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-firstentryindex"}, {"id": "ref-for-entrymaprecord-firstentryindex\u2460"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['entrymaprecord-lastentryindex'] = {"dfnID": "entrymaprecord-lastentryindex", "url": "#entrymaprecord-lastentryindex", "dfnText": "lastEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-lastentryindex"}], "title": "4.2.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-1-patch-map'] = {"dfnID": "abstract-opdef-interpret-format-1-patch-map", "url": "#abstract-opdef-interpret-format-1-patch-map", "dfnText": "Interpret Format 1 Patch Map", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-1-patch-map"}], "title": "6. Extending a Font Subset"}], "external": false};
-window.dfnpanelData['format-2-patch-map'] = {"dfnID": "format-2-patch-map", "url": "#format-2-patch-map", "dfnText": "Format 2 Patch Map", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['format-2-patch-map-format'] = {"dfnID": "format-2-patch-map-format", "url": "#format-2-patch-map-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-format"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['format-2-patch-map-id'] = {"dfnID": "format-2-patch-map-id", "url": "#format-2-patch-map-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-id"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['format-2-patch-map-defaultpatchencoding'] = {"dfnID": "format-2-patch-map-defaultpatchencoding", "url": "#format-2-patch-map-defaultpatchencoding", "dfnText": "defaultPatchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch-map-entrycount", "url": "#format-2-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entrycount"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entrycount\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['format-2-patch-map-entries'] = {"dfnID": "format-2-patch-map-entries", "url": "#format-2-patch-map-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entries"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['format-2-patch-map-uritemplate'] = {"dfnID": "format-2-patch-map-uritemplate", "url": "#format-2-patch-map-uritemplate", "dfnText": "uriTemplate", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-uritemplate"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entries'] = {"dfnID": "mapping-entries", "url": "#mapping-entries", "dfnText": "Mapping Entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
-window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}, {"id": "ref-for-mapping-entries-entries\u2460"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entries-entries\u2461"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry'] = {"dfnID": "mapping-entry", "url": "#mapping-entry", "dfnText": "Mapping Entry", "refSections": [{"refs": [{"id": "ref-for-mapping-entry"}, {"id": "ref-for-mapping-entry\u2460"}, {"id": "ref-for-mapping-entry\u2461"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry\u2462"}, {"id": "ref-for-mapping-entry\u2463"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-formatflags'] = {"dfnID": "mapping-entry-formatflags", "url": "#mapping-entry-formatflags", "dfnText": "formatFlags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-formatflags"}, {"id": "ref-for-mapping-entry-formatflags\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2466"}, {"id": "ref-for-mapping-entry-formatflags\u2467"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-formatflags\u2468"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u24ea"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2466"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-featurecount'] = {"dfnID": "mapping-entry-featurecount", "url": "#mapping-entry-featurecount", "dfnText": "featureCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featurecount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-featuretags'] = {"dfnID": "mapping-entry-featuretags", "url": "#mapping-entry-featuretags", "dfnText": "featureTags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featuretags"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-designspacecount'] = {"dfnID": "mapping-entry-designspacecount", "url": "#mapping-entry-designspacecount", "dfnText": "designSpaceCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacecount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-designspacesegments'] = {"dfnID": "mapping-entry-designspacesegments", "url": "#mapping-entry-designspacesegments", "dfnText": "designSpaceSegments", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacesegments"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-copycount'] = {"dfnID": "mapping-entry-copycount", "url": "#mapping-entry-copycount", "dfnText": "copyCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copycount"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-copyindices'] = {"dfnID": "mapping-entry-copyindices", "url": "#mapping-entry-copyindices", "dfnText": "copyIndices", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copyindices"}, {"id": "ref-for-mapping-entry-copyindices\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-entryiddelta'] = {"dfnID": "mapping-entry-entryiddelta", "url": "#mapping-entry-entryiddelta", "dfnText": "entryIdDelta", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryiddelta"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-patchencoding'] = {"dfnID": "mapping-entry-patchencoding", "url": "#mapping-entry-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-patchencoding"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-bias'] = {"dfnID": "mapping-entry-bias", "url": "#mapping-entry-bias", "dfnText": "bias", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-bias"}, {"id": "ref-for-mapping-entry-bias\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-codepoints'] = {"dfnID": "mapping-entry-codepoints", "url": "#mapping-entry-codepoints", "dfnText": "codepoints", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-codepoints"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['design-space-segment'] = {"dfnID": "design-space-segment", "url": "#design-space-segment", "dfnText": "Design Space Segment", "refSections": [{"refs": [{"id": "ref-for-design-space-segment"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
-window.dfnpanelData['design-space-segment-tag'] = {"dfnID": "design-space-segment-tag", "url": "#design-space-segment-tag", "dfnText": "tag", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-tag"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['design-space-segment-start'] = {"dfnID": "design-space-segment-start", "url": "#design-space-segment-start", "dfnText": "start", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-start"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['design-space-segment-end'] = {"dfnID": "design-space-segment-end", "url": "#design-space-segment-end", "dfnText": "end", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-end"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map'] = {"dfnID": "format-2-patch-map", "url": "#format-2-patch-map", "dfnText": "Format 2 Patch Map", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-format'] = {"dfnID": "format-2-patch-map-format", "url": "#format-2-patch-map-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-format"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-id'] = {"dfnID": "format-2-patch-map-id", "url": "#format-2-patch-map-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-id"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-defaultpatchencoding'] = {"dfnID": "format-2-patch-map-defaultpatchencoding", "url": "#format-2-patch-map-defaultpatchencoding", "dfnText": "defaultPatchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch-map-entrycount", "url": "#format-2-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entrycount"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entrycount\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-entries'] = {"dfnID": "format-2-patch-map-entries", "url": "#format-2-patch-map-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entries"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-uritemplate'] = {"dfnID": "format-2-patch-map-uritemplate", "url": "#format-2-patch-map-uritemplate", "dfnText": "uriTemplate", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-uritemplate"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entries'] = {"dfnID": "mapping-entries", "url": "#mapping-entries", "dfnText": "Mapping Entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries"}], "title": "4.2.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}, {"id": "ref-for-mapping-entries-entries\u2460"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entries-entries\u2461"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry'] = {"dfnID": "mapping-entry", "url": "#mapping-entry", "dfnText": "Mapping Entry", "refSections": [{"refs": [{"id": "ref-for-mapping-entry"}, {"id": "ref-for-mapping-entry\u2460"}, {"id": "ref-for-mapping-entry\u2461"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry\u2462"}, {"id": "ref-for-mapping-entry\u2463"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-formatflags'] = {"dfnID": "mapping-entry-formatflags", "url": "#mapping-entry-formatflags", "dfnText": "formatFlags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-formatflags"}, {"id": "ref-for-mapping-entry-formatflags\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2466"}, {"id": "ref-for-mapping-entry-formatflags\u2467"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-formatflags\u2468"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u24ea"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2466"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-featurecount'] = {"dfnID": "mapping-entry-featurecount", "url": "#mapping-entry-featurecount", "dfnText": "featureCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featurecount"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-featuretags'] = {"dfnID": "mapping-entry-featuretags", "url": "#mapping-entry-featuretags", "dfnText": "featureTags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featuretags"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-designspacecount'] = {"dfnID": "mapping-entry-designspacecount", "url": "#mapping-entry-designspacecount", "dfnText": "designSpaceCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacecount"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-designspacesegments'] = {"dfnID": "mapping-entry-designspacesegments", "url": "#mapping-entry-designspacesegments", "dfnText": "designSpaceSegments", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacesegments"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-copycount'] = {"dfnID": "mapping-entry-copycount", "url": "#mapping-entry-copycount", "dfnText": "copyCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copycount"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-copyindices'] = {"dfnID": "mapping-entry-copyindices", "url": "#mapping-entry-copyindices", "dfnText": "copyIndices", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copyindices"}, {"id": "ref-for-mapping-entry-copyindices\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-entryiddelta'] = {"dfnID": "mapping-entry-entryiddelta", "url": "#mapping-entry-entryiddelta", "dfnText": "entryIdDelta", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryiddelta"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-patchencoding'] = {"dfnID": "mapping-entry-patchencoding", "url": "#mapping-entry-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-patchencoding"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-bias'] = {"dfnID": "mapping-entry-bias", "url": "#mapping-entry-bias", "dfnText": "bias", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-bias"}, {"id": "ref-for-mapping-entry-bias\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-codepoints'] = {"dfnID": "mapping-entry-codepoints", "url": "#mapping-entry-codepoints", "dfnText": "codepoints", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-codepoints"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['design-space-segment'] = {"dfnID": "design-space-segment", "url": "#design-space-segment", "dfnText": "Design Space Segment", "refSections": [{"refs": [{"id": "ref-for-design-space-segment"}], "title": "4.2.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['design-space-segment-tag'] = {"dfnID": "design-space-segment-tag", "url": "#design-space-segment-tag", "dfnText": "tag", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-tag"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['design-space-segment-start'] = {"dfnID": "design-space-segment-start", "url": "#design-space-segment-start", "dfnText": "start", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-start"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['design-space-segment-end'] = {"dfnID": "design-space-segment-end", "url": "#design-space-segment-end", "dfnText": "end", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-end"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map", "url": "#abstract-opdef-interpret-format-2-patch-map", "dfnText": "Interpret Format 2 Patch Map", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map"}], "title": "6. Extending a Font Subset"}], "external": false};
-window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map-entry'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map-entry", "url": "#abstract-opdef-interpret-format-2-patch-map-entry", "dfnText": "Interpret Format 2 Patch Map Entry", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['sparse-bit-set'] = {"dfnID": "sparse-bit-set", "url": "#sparse-bit-set", "dfnText": "Sparse Bit Set", "refSections": [{"refs": [{"id": "ref-for-sparse-bit-set"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
-window.dfnpanelData['branch-factor-encoding'] = {"dfnID": "branch-factor-encoding", "url": "#branch-factor-encoding", "dfnText": "Branch Factor Encoding", "refSections": [{"refs": [{"id": "ref-for-branch-factor-encoding"}], "title": "4.1.2.2. Sparse Bit Set"}], "external": false};
+window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map-entry'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map-entry", "url": "#abstract-opdef-interpret-format-2-patch-map-entry", "dfnText": "Interpret Format 2 Patch Map Entry", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['sparse-bit-set'] = {"dfnID": "sparse-bit-set", "url": "#sparse-bit-set", "dfnText": "Sparse Bit Set", "refSections": [{"refs": [{"id": "ref-for-sparse-bit-set"}], "title": "4.2.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['branch-factor-encoding'] = {"dfnID": "branch-factor-encoding", "url": "#branch-factor-encoding", "dfnText": "Branch Factor Encoding", "refSections": [{"refs": [{"id": "ref-for-branch-factor-encoding"}], "title": "4.2.2.2. Sparse Bit Set"}], "external": false};
 window.dfnpanelData['font-patch'] = {"dfnID": "font-patch", "url": "#font-patch", "dfnText": "font patch", "refSections": [{"refs": [{"id": "ref-for-font-patch"}, {"id": "ref-for-font-patch\u2460"}, {"id": "ref-for-font-patch\u2461"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-patch\u2462"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-format'] = {"dfnID": "patch-format", "url": "#patch-format", "dfnText": "patch format", "refSections": [{"refs": [{"id": "ref-for-patch-format"}, {"id": "ref-for-patch-format\u2460"}], "title": "5.1. Definitions"}], "external": false};
 window.dfnpanelData['patch-application-algorithm'] = {"dfnID": "patch-application-algorithm", "url": "#patch-application-algorithm", "dfnText": "patch application algorithm", "refSections": [{"refs": [{"id": "ref-for-patch-application-algorithm"}], "title": "5.1. Definitions"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="48ab68d74d660e40e74c6cfbae7c6393676b0342" name="document-revision">
+  <meta content="545a4a162e383a75b849eb172560f0d9ccfbe236" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-09">9 April 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-12">12 April 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -600,14 +600,14 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
       <li><a href="#font-patch-definitions"><span class="secno">5.1</span> <span class="content">Definitions</span></a>
       <li><a href="#font-patch-formats-summary"><span class="secno">5.2</span> <span class="content">Formats Summary</span></a>
       <li>
-       <a href="#shared-brotli"><span class="secno">5.3</span> <span class="content">Shared Brotli Patch</span></a>
+       <a href="#shared-brotli"><span class="secno">5.3</span> <span class="content">Brotli Patch</span></a>
        <ol class="toc">
-        <li><a href="#apply-shared-brotli"><span class="secno">5.3.1</span> <span class="content">Applying Shared Brotli Patches</span></a>
+        <li><a href="#apply-shared-brotli"><span class="secno">5.3.1</span> <span class="content">Applying Brotli Patches</span></a>
        </ol>
       <li>
-       <a href="#per-table-shared-brotli"><span class="secno">5.4</span> <span class="content">Per Table Shared Brotli</span></a>
+       <a href="#per-table-shared-brotli"><span class="secno">5.4</span> <span class="content">Per Table Brotli</span></a>
        <ol class="toc">
-        <li><a href="#apply-per-table-shared-brotli"><span class="secno">5.4.1</span> <span class="content">Applying Per Table Shared Brotli Patches</span></a>
+        <li><a href="#apply-per-table-shared-brotli"><span class="secno">5.4.1</span> <span class="content">Applying Per Table Brotli Patches</span></a>
        </ol>
       <li>
        <a href="#glyph-keyed"><span class="secno">5.5</span> <span class="content">Glyph Keyed</span></a>
@@ -841,7 +841,7 @@ several variables are defined which are used to produce the expansion of the tem
     </table>
    </div>
    <h2 class="heading settled" data-level="4" id="font-format-extensions"><span class="secno">4. </span><span class="content">Extensions to the Font Format</span><a class="self-link" href="#font-format-extensions"></a></h2>
-   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="incremental-font">incremental font</dfn> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but include two new <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both <a href="#patch-map">patch maps</a>, which encode a collection of mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="incremental-font">incremental font</dfn> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but includes two new <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both <a href="#patch-map">patch maps</a>, which encode a collection of mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which
 host <a href="#font-patch-formats">patches</a> that extend the incremental font. All incremental fonts must contain the 'IFT ' table.
 The 'IFTX' table is optional. When both tables are present, the mapping of the font as a whole is the union of the mappings of
 the two tables.</p>
@@ -1473,15 +1473,15 @@ from F by the application of one or more independent patches from <code>P</code>
       <th>ID
       <th>Description
      <tr>
-      <td><a href="#shared-brotli">§ 5.3 Shared Brotli Patch</a>
+      <td><a href="#shared-brotli">§ 5.3 Brotli Patch</a>
       <td><a data-link-type="dfn" href="#dependent" id="ref-for-dependent">dependent</a>
       <td>1
-      <td>A shared brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> as a base.
+      <td>A brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> as a base.
      <tr>
-      <td><a href="#per-table-shared-brotli">§ 5.4 Per Table Shared Brotli</a>
+      <td><a href="#per-table-shared-brotli">§ 5.4 Per Table Brotli</a>
       <td><a data-link-type="dfn" href="#dependent" id="ref-for-dependent①">dependent</a>
       <td>2
-      <td>A collection of shared brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as bases.
+      <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as bases.
      <tr>
       <td><a href="#glyph-keyed">§ 5.5 Glyph Keyed</a>
       <td><a data-link-type="dfn" href="#independent" id="ref-for-independent">independent</a>
@@ -1489,11 +1489,11 @@ from F by the application of one or more independent patches from <code>P</code>
       <td>Contains a collection of opaque binary blobs, each associated with a glyph id and table.
    </table>
    <p>More detailed descriptions of each algorithm can be found in the following sections.</p>
-   <h3 class="heading settled" data-level="5.3" id="shared-brotli"><span class="secno">5.3. </span><span class="content">Shared Brotli Patch</span><a class="self-link" href="#shared-brotli"></a></h3>
-   <p>In a shared brotli patch the target file is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the
-source file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A shared brotli encoded patch consists
+   <h3 class="heading settled" data-level="5.3" id="shared-brotli"><span class="secno">5.3. </span><span class="content">Brotli Patch</span><a class="self-link" href="#shared-brotli"></a></h3>
+   <p>In a brotli patch the target file is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the
+source file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A brotli encoded patch consists
 of a short header followed by brotli encoded data.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shared-brotli-patch">Shared brotli patch</dfn> encoding:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="brotli-patch">Brotli patch</dfn> encoding:</p>
    <table>
     <tbody>
      <tr>
@@ -1502,27 +1502,27 @@ of a short header followed by brotli encoded data.</p>
       <th>Description
      <tr>
       <td>Tag
-      <td><dfn class="dfn-paneled" data-dfn-for="Shared brotli patch" data-dfn-type="dfn" data-noexport id="shared-brotli-patch-format">format</dfn>
-      <td>Identifies the encoding as shared brotli, set to 'ifbr'
+      <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-format">format</dfn>
+      <td>Identifies the encoding as brotli, set to 'ifbr'
      <tr>
       <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Shared brotli patch" data-dfn-type="dfn" data-noexport id="shared-brotli-patch-id">id</dfn>[4]
+      <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-id">id</dfn>[4]
       <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> which this patch can be applied too.
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Shared brotli patch" data-dfn-type="dfn" data-noexport id="shared-brotli-patch-brotlistream">brotliStream</dfn>[variable]
+      <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-brotlistream">brotliStream</dfn>[variable]
       <td>Brotli encoded byte stream.
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Shared Brotli Patches" data-level="5.3.1" id="apply-shared-brotli"><span class="secno">5.3.1. </span><span class="content">Applying Shared Brotli Patches</span><a class="self-link" href="#apply-shared-brotli"></a></h4>
-   <p>This algorithm is used to apply a shared brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> to cover additional codepoints,
+   <h4 class="heading settled algorithm" data-algorithm="Applying Brotli Patches" data-level="5.3.1" id="apply-shared-brotli"><span class="secno">5.3.1. </span><span class="content">Applying Brotli Patches</span><a class="self-link" href="#apply-shared-brotli"></a></h4>
+   <p>This algorithm is used to apply a brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
-   <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-shared-brotli-patch">Apply shared brotli patch<a class="self-link" href="#abstract-opdef-apply-shared-brotli-patch"></a></dfn></p>
+   <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-brotli-patch">Apply brotli patch<a class="self-link" href="#abstract-opdef-apply-brotli-patch"></a></dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
      <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> which is to be extended.</p>
     <li data-md>
-     <p><var>patch</var>: a <a data-link-type="dfn" href="#shared-brotli-patch" id="ref-for-shared-brotli-patch">shared brotli patch</a> to be applied to <var>base font subset</var>.</p>
+     <p><var>patch</var>: a <a data-link-type="dfn" href="#brotli-patch" id="ref-for-brotli-patch">brotli patch</a> to be applied to <var>base font subset</var>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1532,23 +1532,23 @@ features, and/or design-variation space.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#shared-brotli-patch-format" id="ref-for-shared-brotli-patch-format">format</a> field in <var>patch</var> is equal to 'ifbr', if it is
+     <p>Check that the <a data-link-type="dfn" href="#brotli-patch-format" id="ref-for-brotli-patch-format">format</a> field in <var>patch</var> is equal to 'ifbr', if it is
 not equal, then <var>patch</var> is not correctly formatted. Patch application has failed, return
 an error.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#shared-brotli-patch-id" id="ref-for-shared-brotli-patch-id">id</a> field in <var>patch</var> is equal to the at least one of the ids
+     <p>Check that the <a data-link-type="dfn" href="#brotli-patch-id" id="ref-for-brotli-patch-id">id</a> field in <var>patch</var> is equal to the at least one of the ids
 found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
 return an error.</p>
     <li data-md>
-     <p>Decode the brotli encoded data in <a data-link-type="dfn" href="#shared-brotli-patch-brotlistream" id="ref-for-shared-brotli-patch-brotlistream">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a> and
+     <p>Decode the brotli encoded data in <a data-link-type="dfn" href="#brotli-patch-brotlistream" id="ref-for-brotli-patch-brotlistream">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a> and
 using the <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. Return the decoded
 result as the <var>extended font subset</var></p>
    </ol>
-   <h3 class="heading settled" data-level="5.4" id="per-table-shared-brotli"><span class="secno">5.4. </span><span class="content">Per Table Shared Brotli</span><a class="self-link" href="#per-table-shared-brotli"></a></h3>
-   <p>A per table shared brotli patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A per table shared brotli encoded patch consists of a short header followed
+   <h3 class="heading settled" data-level="5.4" id="per-table-shared-brotli"><span class="secno">5.4. </span><span class="content">Per Table Brotli</span><a class="self-link" href="#per-table-shared-brotli"></a></h3>
+   <p>A per table brotli patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A per table brotli encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
 or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="per-table-shared-brotli-patch">Per table shared brotli patch</dfn> encoding:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch">Per table brotli patch</dfn> encoding:</p>
    <table>
     <tbody>
      <tr>
@@ -1557,22 +1557,22 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
       <th>Description
      <tr>
       <td>Tag
-      <td><dfn class="dfn-paneled" data-dfn-for="Per table shared brotli patch" data-dfn-type="dfn" data-noexport id="per-table-shared-brotli-patch-format">format</dfn>
-      <td>Identifies the encoding as shared brotli, set to 'ifbt'
+      <td><dfn class="dfn-paneled" data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-format">format</dfn>
+      <td>Identifies the encoding as per table brotli, set to 'ifbt'
      <tr>
       <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Per table shared brotli patch" data-dfn-type="dfn" data-noexport id="per-table-shared-brotli-patch-id">id</dfn>[4]
+      <td><dfn class="dfn-paneled" data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-id">id</dfn>[4]
       <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> which this patch can be applied too.
      <tr>
       <td>uint16
-      <td><dfn data-dfn-for="Per table shared brotli patch" data-dfn-type="dfn" data-noexport id="per-table-shared-brotli-patch-patchescount">patchesCount<a class="self-link" href="#per-table-shared-brotli-patch-patchescount"></a></dfn>
+      <td><dfn data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-patchescount">patchesCount<a class="self-link" href="#per-table-brotli-patch-patchescount"></a></dfn>
       <td>The number of entries in the patches array.
      <tr>
       <td>Offset32
-      <td><dfn class="dfn-paneled" data-dfn-for="Per table shared brotli patch" data-dfn-type="dfn" data-noexport id="per-table-shared-brotli-patch-patches">patches</dfn>[patchesCount+1]
+      <td><dfn class="dfn-paneled" data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-patches">patches</dfn>[patchesCount+1]
       <td>Each entry is an offset from the start of this table to a <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch">TablePatch</a>. Offsets must be sorted in ascending order.
    </table>
-   <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#per-table-shared-brotli-patch-patches" id="ref-for-per-table-shared-brotli-patch-patches">patches</a> array gives the size
+   <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches">patches</a> array gives the size
 of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">TablePatch</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="tablepatch">TablePatch</dfn> encoding:</p>
    <table>
@@ -1594,16 +1594,16 @@ of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">Ta
       <td><dfn class="dfn-paneled" data-dfn-for="TablePatch" data-dfn-type="dfn" data-noexport id="tablepatch-brotlistream">brotliStream</dfn>[variable]
       <td>Brotli encoded byte stream.
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Shared Brotli Patches" data-level="5.4.1" id="apply-per-table-shared-brotli"><span class="secno">5.4.1. </span><span class="content">Applying Per Table Shared Brotli Patches</span><a class="self-link" href="#apply-per-table-shared-brotli"></a></h4>
-   <p>This algorithm is used to apply a per table shared brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> to cover additional codepoints,
+   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Brotli Patches" data-level="5.4.1" id="apply-per-table-shared-brotli"><span class="secno">5.4.1. </span><span class="content">Applying Per Table Brotli Patches</span><a class="self-link" href="#apply-per-table-shared-brotli"></a></h4>
+   <p>This algorithm is used to apply a per table brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
-   <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-per-table-shared-brotli-patch">Apply per table shared brotli patch<a class="self-link" href="#abstract-opdef-apply-per-table-shared-brotli-patch"></a></dfn></p>
+   <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch<a class="self-link" href="#abstract-opdef-apply-per-table-brotli-patch"></a></dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
      <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a> which is to be extended.</p>
     <li data-md>
-     <p><var>patch</var>: a <a data-link-type="dfn" href="#per-table-shared-brotli-patch" id="ref-for-per-table-shared-brotli-patch">per table shared brotli patch</a> to be applied to <var>base font subset</var>.</p>
+     <p><var>patch</var>: a <a data-link-type="dfn" href="#per-table-brotli-patch" id="ref-for-per-table-brotli-patch">per table brotli patch</a> to be applied to <var>base font subset</var>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1613,23 +1613,23 @@ features, and/or design-variation space.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#per-table-shared-brotli-patch-format" id="ref-for-per-table-shared-brotli-patch-format">format</a> field in <var>patch</var> is equal to 'ifbt', if it is
+     <p>Check that the <a data-link-type="dfn" href="#per-table-brotli-patch-format" id="ref-for-per-table-brotli-patch-format">format</a> field in <var>patch</var> is equal to 'ifbt', if it is
 not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
 an error.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#per-table-shared-brotli-patch-id" id="ref-for-per-table-shared-brotli-patch-id">id</a> field in <var>patch</var> is equal to the at least one of the ids
+     <p>Check that the <a data-link-type="dfn" href="#per-table-brotli-patch-id" id="ref-for-per-table-brotli-patch-id">id</a> field in <var>patch</var> is equal to the at least one of the ids
 found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
 return an error.</p>
     <li data-md>
-     <p>For each entry in <a data-link-type="dfn" href="#per-table-shared-brotli-patch-patches" id="ref-for-per-table-shared-brotli-patch-patches①">patches</a>, with index <var>i</var>:</p>
+     <p>For each entry in <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches①">patches</a>, with index <var>i</var>:</p>
      <ul>
       <li data-md>
-       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch②">TablePatch</a> associated with index <var>i</var>. The object starts at the offset <a data-link-type="dfn" href="#per-table-shared-brotli-patch-patches" id="ref-for-per-table-shared-brotli-patch-patches②">patches[i]</a> (inclusive) and ends at the offset <a data-link-type="dfn" href="#per-table-shared-brotli-patch-patches" id="ref-for-per-table-shared-brotli-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
+       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch②">TablePatch</a> associated with index <var>i</var>. The object starts at the offset <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches②">patches[i]</a> (inclusive) and ends at the offset <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
 the <var>patch</var>.</p>
       <li data-md>
-       <p>If an entry in <a data-link-type="dfn" href="#per-table-shared-brotli-patch-patches" id="ref-for-per-table-shared-brotli-patch-patches④">patches</a> was previously applied that has the same <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag">tag</a> as
+       <p>If an entry in <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches④">patches</a> was previously applied that has the same <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag">tag</a> as
 this entry, then ignore this entry and continue the iteration to the next one. Entries are processed in same order as they
-are listed in the <a data-link-type="dfn" href="#per-table-shared-brotli-patch-patches" id="ref-for-per-table-shared-brotli-patch-patches⑤">patches</a> array.</p>
+are listed in the <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches⑤">patches</a> array.</p>
       <li data-md>
        <p>If bit 0 (least significant bit) of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags">flags</a> is set, then decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a>. No shared dictionary is used. Add a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag①">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream①">brotliStream</a>.</p>
       <li data-md>
@@ -1950,7 +1950,7 @@ incremental font. This can be accomplished by:</p>
     <li data-md>
      <p>Keep all dependent patch entries in one mapping table and all independent entries in the other mapping table.</p>
     <li data-md>
-     <p>Use per-table shared brotli patches to update all tables except for the tables touched by the independent patches (outline,
+     <p>Use per-table brotli patches to update all tables except for the tables touched by the independent patches (outline,
 variation deltas, and the independent patch mapping table). These patches should use a small number of large segments to keep
 the patch count reasonable.</p>
     <li data-md>
@@ -2018,16 +2018,17 @@ required too many patches.</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a><span>, in § 4.1.1</span>
+   <li><a href="#abstract-opdef-apply-brotli-patch">Apply brotli patch</a><span>, in § 5.3.1</span>
    <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 5.5.1</span>
-   <li><a href="#abstract-opdef-apply-per-table-shared-brotli-patch">Apply per table shared brotli patch</a><span>, in § 5.4.1</span>
-   <li><a href="#abstract-opdef-apply-shared-brotli-patch">Apply shared brotli patch</a><span>, in § 5.3.1</span>
+   <li><a href="#abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</a><span>, in § 5.4.1</span>
    <li><a href="#mapping-entry-bias">bias</a><span>, in § 4.1.2</span>
    <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 4.1.2.2</span>
+   <li><a href="#brotli-patch">Brotli patch</a><span>, in § 5.3</span>
    <li>
     brotliStream
     <ul>
+     <li><a href="#brotli-patch-brotlistream">dfn for Brotli patch</a><span>, in § 5.3</span>
      <li><a href="#glyph-keyed-patch-brotlistream">dfn for Glyph keyed patch</a><span>, in § 5.5</span>
-     <li><a href="#shared-brotli-patch-brotlistream">dfn for Shared brotli patch</a><span>, in § 5.3</span>
      <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 5.4</span>
     </ul>
    <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 6</span>
@@ -2085,11 +2086,11 @@ required too many patches.</p>
    <li>
     format
     <ul>
+     <li><a href="#brotli-patch-format">dfn for Brotli patch</a><span>, in § 5.3</span>
      <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
      <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
      <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 5.5</span>
-     <li><a href="#per-table-shared-brotli-patch-format">dfn for Per table shared brotli patch</a><span>, in § 5.4</span>
-     <li><a href="#shared-brotli-patch-format">dfn for Shared brotli patch</a><span>, in § 5.3</span>
+     <li><a href="#per-table-brotli-patch-format">dfn for Per table brotli patch</a><span>, in § 5.4</span>
     </ul>
    <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 4.1.1</span>
    <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 4.1.2</span>
@@ -2112,11 +2113,11 @@ required too many patches.</p>
    <li>
     id
     <ul>
+     <li><a href="#brotli-patch-id">dfn for Brotli patch</a><span>, in § 5.3</span>
      <li><a href="#format-1-patch-map-id">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
      <li><a href="#format-2-patch-map-id">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
      <li><a href="#glyph-keyed-patch-id">dfn for Glyph keyed patch</a><span>, in § 5.5</span>
-     <li><a href="#per-table-shared-brotli-patch-id">dfn for Per table shared brotli patch</a><span>, in § 5.4</span>
-     <li><a href="#shared-brotli-patch-id">dfn for Shared brotli patch</a><span>, in § 5.3</span>
+     <li><a href="#per-table-brotli-patch-id">dfn for Per table brotli patch</a><span>, in § 5.4</span>
     </ul>
    <li><a href="#incremental-font">incremental font</a><span>, in § 4</span>
    <li><a href="#independent">independent</a><span>, in § 5.1</span>
@@ -2135,18 +2136,17 @@ required too many patches.</p>
      <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
      <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 4.1.2</span>
     </ul>
-   <li><a href="#per-table-shared-brotli-patch-patches">patches</a><span>, in § 5.4</span>
-   <li><a href="#per-table-shared-brotli-patch-patchescount">patchesCount</a><span>, in § 5.4</span>
+   <li><a href="#per-table-brotli-patch-patches">patches</a><span>, in § 5.4</span>
+   <li><a href="#per-table-brotli-patch-patchescount">patchesCount</a><span>, in § 5.4</span>
    <li><a href="#patch-format">patch format</a><span>, in § 5.1</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 4.1</span>
-   <li><a href="#per-table-shared-brotli-patch">Per table shared brotli patch</a><span>, in § 5.4</span>
+   <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 5.4</span>
    <li>
     reserved
     <ul>
      <li><a href="#format-1-patch-map-reserved">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
      <li><a href="#format-2-patch-map-reserved">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
     </ul>
-   <li><a href="#shared-brotli-patch">Shared brotli patch</a><span>, in § 5.3</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.1.2.2</span>
    <li><a href="#design-space-segment-start">start</a><span>, in § 4.1.2</span>
    <li><a href="#glyphpatches-tablecount">tableCount</a><span>, in § 5.5</span>
@@ -2357,7 +2357,7 @@ required too many patches.</p>
 </script>
 <script>/* Boilerplate: script-dfn-panel-json */
 window.dfnpanelData = {};
-window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subset", "dfnText": "font subset", "refSections": [{"refs": [{"id": "ref-for-font-subset"}], "title": "3.1. Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-font-subset\u2461"}], "title": "5. Font Patch Formats"}, {"refs": [{"id": "ref-for-font-subset\u2462"}, {"id": "ref-for-font-subset\u2463"}, {"id": "ref-for-font-subset\u2464"}, {"id": "ref-for-font-subset\u2465"}, {"id": "ref-for-font-subset\u2466"}, {"id": "ref-for-font-subset\u2467"}, {"id": "ref-for-font-subset\u2468"}, {"id": "ref-for-font-subset\u2460\u24ea"}, {"id": "ref-for-font-subset\u2460\u2460"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2461"}, {"id": "ref-for-font-subset\u2460\u2462"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2463"}], "title": "5.3. Shared Brotli Patch"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2464"}, {"id": "ref-for-font-subset\u2460\u2465"}, {"id": "ref-for-font-subset\u2460\u2466"}], "title": "5.3.1. Applying Shared Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2467"}, {"id": "ref-for-font-subset\u2460\u2468"}], "title": "5.4. Per Table Shared Brotli"}, {"refs": [{"id": "ref-for-font-subset\u2461\u24ea"}, {"id": "ref-for-font-subset\u2461\u2460"}, {"id": "ref-for-font-subset\u2461\u2461"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2462"}], "title": "5.5. Glyph Keyed"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2463"}, {"id": "ref-for-font-subset\u2461\u2464"}, {"id": "ref-for-font-subset\u2461\u2465"}], "title": "5.5.1. Applying Glyph Keyed Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2466"}, {"id": "ref-for-font-subset\u2461\u2467"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2468"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-font-subset\u2462\u24ea"}], "title": "7. Encoder"}], "external": false};
+window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subset", "dfnText": "font subset", "refSections": [{"refs": [{"id": "ref-for-font-subset"}], "title": "3.1. Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-font-subset\u2461"}], "title": "5. Font Patch Formats"}, {"refs": [{"id": "ref-for-font-subset\u2462"}, {"id": "ref-for-font-subset\u2463"}, {"id": "ref-for-font-subset\u2464"}, {"id": "ref-for-font-subset\u2465"}, {"id": "ref-for-font-subset\u2466"}, {"id": "ref-for-font-subset\u2467"}, {"id": "ref-for-font-subset\u2468"}, {"id": "ref-for-font-subset\u2460\u24ea"}, {"id": "ref-for-font-subset\u2460\u2460"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2461"}, {"id": "ref-for-font-subset\u2460\u2462"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2463"}], "title": "5.3. Brotli Patch"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2464"}, {"id": "ref-for-font-subset\u2460\u2465"}, {"id": "ref-for-font-subset\u2460\u2466"}], "title": "5.3.1. Applying Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2467"}, {"id": "ref-for-font-subset\u2460\u2468"}], "title": "5.4. Per Table Brotli"}, {"refs": [{"id": "ref-for-font-subset\u2461\u24ea"}, {"id": "ref-for-font-subset\u2461\u2460"}, {"id": "ref-for-font-subset\u2461\u2461"}], "title": "5.4.1. Applying Per Table Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2462"}], "title": "5.5. Glyph Keyed"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2463"}, {"id": "ref-for-font-subset\u2461\u2464"}, {"id": "ref-for-font-subset\u2461\u2465"}], "title": "5.5.1. Applying Glyph Keyed Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2466"}, {"id": "ref-for-font-subset\u2461\u2467"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2468"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-font-subset\u2462\u24ea"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.1. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}, {"id": "ref-for-font-subset-definition\u2464"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-font-subset-definition\u2465"}, {"id": "ref-for-font-subset-definition\u2466"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2467"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['incremental-font'] = {"dfnID": "incremental-font", "url": "#incremental-font", "dfnText": "incremental font", "refSections": [{"refs": [{"id": "ref-for-incremental-font"}, {"id": "ref-for-incremental-font\u2460"}, {"id": "ref-for-incremental-font\u2461"}, {"id": "ref-for-incremental-font\u2462"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-incremental-font\u2463"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-incremental-font\u2464"}, {"id": "ref-for-incremental-font\u2465"}, {"id": "ref-for-incremental-font\u2466"}, {"id": "ref-for-incremental-font\u2467"}, {"id": "ref-for-incremental-font\u2468"}, {"id": "ref-for-incremental-font\u2460\u24ea"}, {"id": "ref-for-incremental-font\u2460\u2460"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-map-entries'] = {"dfnID": "patch-map-entries", "url": "#patch-map-entries", "dfnText": "patch map entries", "refSections": [{"refs": [{"id": "ref-for-patch-map-entries"}, {"id": "ref-for-patch-map-entries\u2460"}, {"id": "ref-for-patch-map-entries\u2461"}, {"id": "ref-for-patch-map-entries\u2462"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-patch-map-entries\u2463"}, {"id": "ref-for-patch-map-entries\u2464"}, {"id": "ref-for-patch-map-entries\u2465"}], "title": "4.1.2.1. Interpreting Format 2"}, {"refs": [{"id": "ref-for-patch-map-entries\u2466"}, {"id": "ref-for-patch-map-entries\u2467"}], "title": "6. Extending a Font Subset"}], "external": false};
@@ -2402,18 +2402,18 @@ window.dfnpanelData['patch-format'] = {"dfnID": "patch-format", "url": "#patch-f
 window.dfnpanelData['patch-application-algorithm'] = {"dfnID": "patch-application-algorithm", "url": "#patch-application-algorithm", "dfnText": "patch application algorithm", "refSections": [{"refs": [{"id": "ref-for-patch-application-algorithm"}], "title": "5.1. Definitions"}], "external": false};
 window.dfnpanelData['dependent'] = {"dfnID": "dependent", "url": "#dependent", "dfnText": "dependent", "refSections": [{"refs": [{"id": "ref-for-dependent"}, {"id": "ref-for-dependent\u2460"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-dependent\u2461"}, {"id": "ref-for-dependent\u2462"}, {"id": "ref-for-dependent\u2463"}], "title": "6. Extending a Font Subset"}], "external": false};
 window.dfnpanelData['independent'] = {"dfnID": "independent", "url": "#independent", "dfnText": "independent", "refSections": [{"refs": [{"id": "ref-for-independent"}], "title": "5.2. Formats Summary"}], "external": false};
-window.dfnpanelData['shared-brotli-patch'] = {"dfnID": "shared-brotli-patch", "url": "#shared-brotli-patch", "dfnText": "Shared brotli patch", "refSections": [{"refs": [{"id": "ref-for-shared-brotli-patch"}], "title": "5.3.1. Applying Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['shared-brotli-patch-format'] = {"dfnID": "shared-brotli-patch-format", "url": "#shared-brotli-patch-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-shared-brotli-patch-format"}], "title": "5.3.1. Applying Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['shared-brotli-patch-id'] = {"dfnID": "shared-brotli-patch-id", "url": "#shared-brotli-patch-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-shared-brotli-patch-id"}], "title": "5.3.1. Applying Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['shared-brotli-patch-brotlistream'] = {"dfnID": "shared-brotli-patch-brotlistream", "url": "#shared-brotli-patch-brotlistream", "dfnText": "brotliStream", "refSections": [{"refs": [{"id": "ref-for-shared-brotli-patch-brotlistream"}], "title": "5.3.1. Applying Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['per-table-shared-brotli-patch'] = {"dfnID": "per-table-shared-brotli-patch", "url": "#per-table-shared-brotli-patch", "dfnText": "Per table shared brotli patch", "refSections": [{"refs": [{"id": "ref-for-per-table-shared-brotli-patch"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['per-table-shared-brotli-patch-format'] = {"dfnID": "per-table-shared-brotli-patch-format", "url": "#per-table-shared-brotli-patch-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-per-table-shared-brotli-patch-format"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['per-table-shared-brotli-patch-id'] = {"dfnID": "per-table-shared-brotli-patch-id", "url": "#per-table-shared-brotli-patch-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-per-table-shared-brotli-patch-id"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['per-table-shared-brotli-patch-patches'] = {"dfnID": "per-table-shared-brotli-patch-patches", "url": "#per-table-shared-brotli-patch-patches", "dfnText": "patches", "refSections": [{"refs": [{"id": "ref-for-per-table-shared-brotli-patch-patches"}], "title": "5.4. Per Table Shared Brotli"}, {"refs": [{"id": "ref-for-per-table-shared-brotli-patch-patches\u2460"}, {"id": "ref-for-per-table-shared-brotli-patch-patches\u2461"}, {"id": "ref-for-per-table-shared-brotli-patch-patches\u2462"}, {"id": "ref-for-per-table-shared-brotli-patch-patches\u2463"}, {"id": "ref-for-per-table-shared-brotli-patch-patches\u2464"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['tablepatch'] = {"dfnID": "tablepatch", "url": "#tablepatch", "dfnText": "TablePatch", "refSections": [{"refs": [{"id": "ref-for-tablepatch"}, {"id": "ref-for-tablepatch\u2460"}], "title": "5.4. Per Table Shared Brotli"}, {"refs": [{"id": "ref-for-tablepatch\u2461"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['tablepatch-tag'] = {"dfnID": "tablepatch-tag", "url": "#tablepatch-tag", "dfnText": "tag", "refSections": [{"refs": [{"id": "ref-for-tablepatch-tag"}, {"id": "ref-for-tablepatch-tag\u2460"}, {"id": "ref-for-tablepatch-tag\u2461"}, {"id": "ref-for-tablepatch-tag\u2462"}, {"id": "ref-for-tablepatch-tag\u2463"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['tablepatch-flags'] = {"dfnID": "tablepatch-flags", "url": "#tablepatch-flags", "dfnText": "flags", "refSections": [{"refs": [{"id": "ref-for-tablepatch-flags"}, {"id": "ref-for-tablepatch-flags\u2460"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}], "external": false};
-window.dfnpanelData['tablepatch-brotlistream'] = {"dfnID": "tablepatch-brotlistream", "url": "#tablepatch-brotlistream", "dfnText": "brotliStream", "refSections": [{"refs": [{"id": "ref-for-tablepatch-brotlistream"}, {"id": "ref-for-tablepatch-brotlistream\u2460"}, {"id": "ref-for-tablepatch-brotlistream\u2461"}, {"id": "ref-for-tablepatch-brotlistream\u2462"}], "title": "5.4.1. Applying Per Table Shared Brotli Patches"}], "external": false};
+window.dfnpanelData['brotli-patch'] = {"dfnID": "brotli-patch", "url": "#brotli-patch", "dfnText": "Brotli patch", "refSections": [{"refs": [{"id": "ref-for-brotli-patch"}], "title": "5.3.1. Applying Brotli Patches"}], "external": false};
+window.dfnpanelData['brotli-patch-format'] = {"dfnID": "brotli-patch-format", "url": "#brotli-patch-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-brotli-patch-format"}], "title": "5.3.1. Applying Brotli Patches"}], "external": false};
+window.dfnpanelData['brotli-patch-id'] = {"dfnID": "brotli-patch-id", "url": "#brotli-patch-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-brotli-patch-id"}], "title": "5.3.1. Applying Brotli Patches"}], "external": false};
+window.dfnpanelData['brotli-patch-brotlistream'] = {"dfnID": "brotli-patch-brotlistream", "url": "#brotli-patch-brotlistream", "dfnText": "brotliStream", "refSections": [{"refs": [{"id": "ref-for-brotli-patch-brotlistream"}], "title": "5.3.1. Applying Brotli Patches"}], "external": false};
+window.dfnpanelData['per-table-brotli-patch'] = {"dfnID": "per-table-brotli-patch", "url": "#per-table-brotli-patch", "dfnText": "Per table brotli patch", "refSections": [{"refs": [{"id": "ref-for-per-table-brotli-patch"}], "title": "5.4.1. Applying Per Table Brotli Patches"}], "external": false};
+window.dfnpanelData['per-table-brotli-patch-format'] = {"dfnID": "per-table-brotli-patch-format", "url": "#per-table-brotli-patch-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-per-table-brotli-patch-format"}], "title": "5.4.1. Applying Per Table Brotli Patches"}], "external": false};
+window.dfnpanelData['per-table-brotli-patch-id'] = {"dfnID": "per-table-brotli-patch-id", "url": "#per-table-brotli-patch-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-per-table-brotli-patch-id"}], "title": "5.4.1. Applying Per Table Brotli Patches"}], "external": false};
+window.dfnpanelData['per-table-brotli-patch-patches'] = {"dfnID": "per-table-brotli-patch-patches", "url": "#per-table-brotli-patch-patches", "dfnText": "patches", "refSections": [{"refs": [{"id": "ref-for-per-table-brotli-patch-patches"}], "title": "5.4. Per Table Brotli"}, {"refs": [{"id": "ref-for-per-table-brotli-patch-patches\u2460"}, {"id": "ref-for-per-table-brotli-patch-patches\u2461"}, {"id": "ref-for-per-table-brotli-patch-patches\u2462"}, {"id": "ref-for-per-table-brotli-patch-patches\u2463"}, {"id": "ref-for-per-table-brotli-patch-patches\u2464"}], "title": "5.4.1. Applying Per Table Brotli Patches"}], "external": false};
+window.dfnpanelData['tablepatch'] = {"dfnID": "tablepatch", "url": "#tablepatch", "dfnText": "TablePatch", "refSections": [{"refs": [{"id": "ref-for-tablepatch"}, {"id": "ref-for-tablepatch\u2460"}], "title": "5.4. Per Table Brotli"}, {"refs": [{"id": "ref-for-tablepatch\u2461"}], "title": "5.4.1. Applying Per Table Brotli Patches"}], "external": false};
+window.dfnpanelData['tablepatch-tag'] = {"dfnID": "tablepatch-tag", "url": "#tablepatch-tag", "dfnText": "tag", "refSections": [{"refs": [{"id": "ref-for-tablepatch-tag"}, {"id": "ref-for-tablepatch-tag\u2460"}, {"id": "ref-for-tablepatch-tag\u2461"}, {"id": "ref-for-tablepatch-tag\u2462"}, {"id": "ref-for-tablepatch-tag\u2463"}], "title": "5.4.1. Applying Per Table Brotli Patches"}], "external": false};
+window.dfnpanelData['tablepatch-flags'] = {"dfnID": "tablepatch-flags", "url": "#tablepatch-flags", "dfnText": "flags", "refSections": [{"refs": [{"id": "ref-for-tablepatch-flags"}, {"id": "ref-for-tablepatch-flags\u2460"}], "title": "5.4.1. Applying Per Table Brotli Patches"}], "external": false};
+window.dfnpanelData['tablepatch-brotlistream'] = {"dfnID": "tablepatch-brotlistream", "url": "#tablepatch-brotlistream", "dfnText": "brotliStream", "refSections": [{"refs": [{"id": "ref-for-tablepatch-brotlistream"}, {"id": "ref-for-tablepatch-brotlistream\u2460"}, {"id": "ref-for-tablepatch-brotlistream\u2461"}, {"id": "ref-for-tablepatch-brotlistream\u2462"}], "title": "5.4.1. Applying Per Table Brotli Patches"}], "external": false};
 window.dfnpanelData['glyph-keyed-patch'] = {"dfnID": "glyph-keyed-patch", "url": "#glyph-keyed-patch", "dfnText": "Glyph keyed patch", "refSections": [{"refs": [{"id": "ref-for-glyph-keyed-patch"}], "title": "5.5.1. Applying Glyph Keyed Patches"}], "external": false};
 window.dfnpanelData['glyph-keyed-patch-format'] = {"dfnID": "glyph-keyed-patch-format", "url": "#glyph-keyed-patch-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-glyph-keyed-patch-format"}], "title": "5.5.1. Applying Glyph Keyed Patches"}], "external": false};
 window.dfnpanelData['glyph-keyed-patch-id'] = {"dfnID": "glyph-keyed-patch-id", "url": "#glyph-keyed-patch-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-glyph-keyed-patch-id"}], "title": "5.5.1. Applying Glyph Keyed Patches"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,11 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-<<<<<<< HEAD
-  <meta content="27d662b865c94d64b35015c955f6abe490cbe810" name="document-revision">
-=======
-  <meta content="db12e20a3b706a51eb62e3cc7d62920a504c85cc" name="document-revision">
->>>>>>> b1da24c (Cleanup unused definitions in the format 1 patch map section.)
+  <meta content="be0c90d3cca3ed1fcdec7b6e1365c54d2b804e66" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -507,11 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-<<<<<<< HEAD
    <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-12">12 April 2024</time></p>
-=======
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-04">4 April 2024</time></p>
->>>>>>> b1da24c (Cleanup unused definitions in the format 1 patch map section.)
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1067,7 +1059,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <p>Return <var>entry list</var> and <a data-link-type="dfn" href="#format-1-patch-map-id" id="ref-for-format-1-patch-map-id">id</a> as <var>id</var>.</p>
    </ol>
    <h4 class="heading settled" data-level="4.1.2" id="patch-map-format-2"><span class="secno">4.1.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
-   <p><dfn data-dfn-type="dfn" data-noexport id="format-2-patch-map">Format 2 Patch Map<a class="self-link" href="#format-2-patch-map"></a></dfn> encoding:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="format-2-patch-map">Format 2 Patch Map</dfn> encoding:</p>
    <table>
     <tbody>
      <tr>
@@ -1076,11 +1068,11 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <th>Description
      <tr>
       <td>uint8
-      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-format">format<a class="self-link" href="#format-2-patch-map-format"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-format">format</dfn>
       <td>Set to 2, identifies this as format 2.
      <tr>
       <td>uint32
-      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-reserved">reserved<a class="self-link" href="#format-2-patch-map-reserved"></a></dfn>
+      <td>reserved
       <td>Not used, set to 0.
      <tr>
       <td>uint32
@@ -1100,7 +1092,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td>Offset to a <a data-link-type="dfn" href="#mapping-entries" id="ref-for-mapping-entries">Mapping Entries</a> sub table. Offset is from the start of this table.
      <tr>
       <td>uint16
-      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplatelength">uriTemplateLength<a class="self-link" href="#format-2-patch-map-uritemplatelength"></a></dfn>
+      <td>uriTemplateLength
       <td> Length of the uriTemplate string. 
      <tr>
       <td>uint8
@@ -1191,15 +1183,15 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <th>Description
      <tr>
       <td>Tag
-      <td><dfn data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-tag">tag<a class="self-link" href="#design-space-segment-tag"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-tag">tag</dfn>
       <td> Axis tag value. 
      <tr>
       <td>Fixed
-      <td><dfn data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-start">start<a class="self-link" href="#design-space-segment-start"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-start">start</dfn>
       <td> Start (inclusive) of the segment. This value uses the user axis scale: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
      <tr>
       <td>Fixed
-      <td><dfn data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-end">end<a class="self-link" href="#design-space-segment-end"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-end">end</dfn>
       <td> End (inclusive) of the segment. Must be greater than or equal to start. This value uses the user axis scale: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
    </table>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="4.1.2.1" id="interpreting-patch-map-format-2"><span class="secno">4.1.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
@@ -1208,7 +1200,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>patch map</var>: a <a href="#patch-map-format-2">§ 4.1.2 Patch Map Table: Format 2</a> encoded patch map.</p>
+     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map">Format 2 Patch Map</a> encoded patch map.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1220,7 +1212,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> is valid according to the requirements in <a href="#patch-map-format-2">§ 4.1.2 Patch Map Table: Format 2</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 4.1.2 Patch Map Table: Format 2</a>. If it is not return an error.</p>
     <li data-md>
      <p>Initialize <var>last entry id</var> to 0, and <var>current byte</var> to 0.</p>
     <li data-md>
@@ -1279,7 +1271,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <li data-md>
        <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to <var>entry</var>.</p>
       <li data-md>
-       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to <var>entry</var>.</p>
+       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to <var>entry</var>. Each segment defines an interval from <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start">start</a> to <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end">end</a> inclusive for the axis identified by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-space-segment-tag">tag</a>.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①①">formatFlags</a> bit 1 is set, then the copy indices list is present:</p>
@@ -2207,7 +2199,6 @@ required too many patches.</p>
    <li><a href="#patch-format">patch format</a><span>, in § 5.1</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 4.1</span>
    <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 5.4</span>
-   <li><a href="#format-2-patch-map-reserved">reserved</a><span>, in § 4.1.2</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.1.2.2</span>
    <li><a href="#design-space-segment-start">start</a><span>, in § 4.1.2</span>
    <li><a href="#glyphpatches-tablecount">tableCount</a><span>, in § 5.5</span>
@@ -2225,7 +2216,6 @@ required too many patches.</p>
      <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
      <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
     </ul>
-   <li><a href="#format-2-patch-map-uritemplatelength">uriTemplateLength</a><span>, in § 4.1.2</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -2443,6 +2433,8 @@ window.dfnpanelData['entrymaprecord'] = {"dfnID": "entrymaprecord", "url": "#ent
 window.dfnpanelData['entrymaprecord-firstentryindex'] = {"dfnID": "entrymaprecord-firstentryindex", "url": "#entrymaprecord-firstentryindex", "dfnText": "firstEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-firstentryindex"}, {"id": "ref-for-entrymaprecord-firstentryindex\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['entrymaprecord-lastentryindex'] = {"dfnID": "entrymaprecord-lastentryindex", "url": "#entrymaprecord-lastentryindex", "dfnText": "lastEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-lastentryindex"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-1-patch-map'] = {"dfnID": "abstract-opdef-interpret-format-1-patch-map", "url": "#abstract-opdef-interpret-format-1-patch-map", "dfnText": "Interpret Format 1 Patch Map", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-1-patch-map"}], "title": "6. Extending a Font Subset"}], "external": false};
+window.dfnpanelData['format-2-patch-map'] = {"dfnID": "format-2-patch-map", "url": "#format-2-patch-map", "dfnText": "Format 2 Patch Map", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-format'] = {"dfnID": "format-2-patch-map-format", "url": "#format-2-patch-map-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-format"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-id'] = {"dfnID": "format-2-patch-map-id", "url": "#format-2-patch-map-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-id"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-defaultpatchencoding'] = {"dfnID": "format-2-patch-map-defaultpatchencoding", "url": "#format-2-patch-map-defaultpatchencoding", "dfnText": "defaultPatchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch-map-entrycount", "url": "#format-2-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entrycount"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entrycount\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
@@ -2463,6 +2455,9 @@ window.dfnpanelData['mapping-entry-patchencoding'] = {"dfnID": "mapping-entry-pa
 window.dfnpanelData['mapping-entry-bias'] = {"dfnID": "mapping-entry-bias", "url": "#mapping-entry-bias", "dfnText": "bias", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-bias"}, {"id": "ref-for-mapping-entry-bias\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-codepoints'] = {"dfnID": "mapping-entry-codepoints", "url": "#mapping-entry-codepoints", "dfnText": "codepoints", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-codepoints"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['design-space-segment'] = {"dfnID": "design-space-segment", "url": "#design-space-segment", "dfnText": "Design Space Segment", "refSections": [{"refs": [{"id": "ref-for-design-space-segment"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['design-space-segment-tag'] = {"dfnID": "design-space-segment-tag", "url": "#design-space-segment-tag", "dfnText": "tag", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-tag"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['design-space-segment-start'] = {"dfnID": "design-space-segment-start", "url": "#design-space-segment-start", "dfnText": "start", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-start"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['design-space-segment-end'] = {"dfnID": "design-space-segment-end", "url": "#design-space-segment-end", "dfnText": "end", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-end"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map", "url": "#abstract-opdef-interpret-format-2-patch-map", "dfnText": "Interpret Format 2 Patch Map", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map"}], "title": "6. Extending a Font Subset"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map-entry'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map-entry", "url": "#abstract-opdef-interpret-format-2-patch-map-entry", "dfnText": "Interpret Format 2 Patch Map Entry", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['font-patch'] = {"dfnID": "font-patch", "url": "#font-patch", "dfnText": "font patch", "refSections": [{"refs": [{"id": "ref-for-font-patch"}, {"id": "ref-for-font-patch\u2460"}, {"id": "ref-for-font-patch\u2461"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-patch\u2462"}], "title": "7. Encoder"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="761cefaf3b71762ee05e517452843ee124c2bd48" name="document-revision">
+  <meta content="6809a70f82fd03910c3f636dc040a0ca8082c76f" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -1577,7 +1577,7 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
       <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> which this patch can be applied too.
      <tr>
       <td>uint16
-      <td><dfn data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-patchescount">patchesCount<a class="self-link" href="#per-table-brotli-patch-patchescount"></a></dfn>
+      <td>patchesCount
       <td>The number of entries in the patches array.
      <tr>
       <td>Offset32
@@ -1678,7 +1678,7 @@ the entries processed in step 3, add a copy of that table to <var>extended font 
       <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> which this patch can be applied too.
      <tr>
       <td>uint32
-      <td><dfn data-dfn-for="Glyph keyed patch" data-dfn-type="dfn" data-noexport id="glyph-keyed-patch-length">length<a class="self-link" href="#glyph-keyed-patch-length"></a></dfn>
+      <td>length
       <td>The uncompressed length of <a data-link-type="dfn" href="#glyph-keyed-patch-brotlistream" id="ref-for-glyph-keyed-patch-brotlistream">brotliStream</a>.
      <tr>
       <td>uint8
@@ -1698,7 +1698,7 @@ the entries processed in step 3, add a copy of that table to <var>extended font 
       <td>The number of glyphs encoded in the patch.
      <tr>
       <td>uint8
-      <td><dfn data-dfn-for="GlyphPatches" data-dfn-type="dfn" data-noexport id="glyphpatches-tablecount">tableCount<a class="self-link" href="#glyphpatches-tablecount"></a></dfn>
+      <td>tableCount
       <td>The number of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> the patch has data for.
      <tr>
       <td>uint16
@@ -2183,7 +2183,6 @@ required too many patches.</p>
    <li><a href="#abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a><span>, in § 4.1.2.1</span>
    <li><a href="#abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a><span>, in § 4.1.2.1</span>
    <li><a href="#entrymaprecord-lastentryindex">lastEntryIndex</a><span>, in § 4.1.1</span>
-   <li><a href="#glyph-keyed-patch-length">length</a><span>, in § 5.5</span>
    <li><a href="#abstract-opdef-load-patch-file">Load patch file</a><span>, in § 6</span>
    <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 4.1.2</span>
    <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 4.1.2</span>
@@ -2195,13 +2194,11 @@ required too many patches.</p>
      <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 4.1.2</span>
     </ul>
    <li><a href="#per-table-brotli-patch-patches">patches</a><span>, in § 5.4</span>
-   <li><a href="#per-table-brotli-patch-patchescount">patchesCount</a><span>, in § 5.4</span>
    <li><a href="#patch-format">patch format</a><span>, in § 5.1</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 4.1</span>
    <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 5.4</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.1.2.2</span>
    <li><a href="#design-space-segment-start">start</a><span>, in § 4.1.2</span>
-   <li><a href="#glyphpatches-tablecount">tableCount</a><span>, in § 5.5</span>
    <li><a href="#tablepatch">TablePatch</a><span>, in § 5.4</span>
    <li><a href="#glyphpatches-tables">tables</a><span>, in § 5.5</span>
    <li>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="545a4a162e383a75b849eb172560f0d9ccfbe236" name="document-revision">
+  <meta content="32e5b91c30707f9be12ca1473e06f3f9fd96d4df" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -600,14 +600,14 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
       <li><a href="#font-patch-definitions"><span class="secno">5.1</span> <span class="content">Definitions</span></a>
       <li><a href="#font-patch-formats-summary"><span class="secno">5.2</span> <span class="content">Formats Summary</span></a>
       <li>
-       <a href="#shared-brotli"><span class="secno">5.3</span> <span class="content">Brotli Patch</span></a>
+       <a href="#brotli"><span class="secno">5.3</span> <span class="content">Brotli Patch</span></a>
        <ol class="toc">
-        <li><a href="#apply-shared-brotli"><span class="secno">5.3.1</span> <span class="content">Applying Brotli Patches</span></a>
+        <li><a href="#apply-brotli"><span class="secno">5.3.1</span> <span class="content">Applying Brotli Patches</span></a>
        </ol>
       <li>
-       <a href="#per-table-shared-brotli"><span class="secno">5.4</span> <span class="content">Per Table Brotli</span></a>
+       <a href="#per-table-brotli"><span class="secno">5.4</span> <span class="content">Per Table Brotli</span></a>
        <ol class="toc">
-        <li><a href="#apply-per-table-shared-brotli"><span class="secno">5.4.1</span> <span class="content">Applying Per Table Brotli Patches</span></a>
+        <li><a href="#apply-per-table-brotli"><span class="secno">5.4.1</span> <span class="content">Applying Per Table Brotli Patches</span></a>
        </ol>
       <li>
        <a href="#glyph-keyed"><span class="secno">5.5</span> <span class="content">Glyph Keyed</span></a>
@@ -1473,12 +1473,12 @@ from F by the application of one or more independent patches from <code>P</code>
       <th>ID
       <th>Description
      <tr>
-      <td><a href="#shared-brotli">§ 5.3 Brotli Patch</a>
+      <td><a href="#brotli">§ 5.3 Brotli Patch</a>
       <td><a data-link-type="dfn" href="#dependent" id="ref-for-dependent">dependent</a>
       <td>1
       <td>A brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> as a base.
      <tr>
-      <td><a href="#per-table-shared-brotli">§ 5.4 Per Table Brotli</a>
+      <td><a href="#per-table-brotli">§ 5.4 Per Table Brotli</a>
       <td><a data-link-type="dfn" href="#dependent" id="ref-for-dependent①">dependent</a>
       <td>2
       <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as bases.
@@ -1489,7 +1489,7 @@ from F by the application of one or more independent patches from <code>P</code>
       <td>Contains a collection of opaque binary blobs, each associated with a glyph id and table.
    </table>
    <p>More detailed descriptions of each algorithm can be found in the following sections.</p>
-   <h3 class="heading settled" data-level="5.3" id="shared-brotli"><span class="secno">5.3. </span><span class="content">Brotli Patch</span><a class="self-link" href="#shared-brotli"></a></h3>
+   <h3 class="heading settled" data-level="5.3" id="brotli"><span class="secno">5.3. </span><span class="content">Brotli Patch</span><a class="self-link" href="#brotli"></a></h3>
    <p>In a brotli patch the target file is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the
 source file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A brotli encoded patch consists
 of a short header followed by brotli encoded data.</p>
@@ -1513,7 +1513,7 @@ of a short header followed by brotli encoded data.</p>
       <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-brotlistream">brotliStream</dfn>[variable]
       <td>Brotli encoded byte stream.
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Brotli Patches" data-level="5.3.1" id="apply-shared-brotli"><span class="secno">5.3.1. </span><span class="content">Applying Brotli Patches</span><a class="self-link" href="#apply-shared-brotli"></a></h4>
+   <h4 class="heading settled algorithm" data-algorithm="Applying Brotli Patches" data-level="5.3.1" id="apply-brotli"><span class="secno">5.3.1. </span><span class="content">Applying Brotli Patches</span><a class="self-link" href="#apply-brotli"></a></h4>
    <p>This algorithm is used to apply a brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
    <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-brotli-patch">Apply brotli patch<a class="self-link" href="#abstract-opdef-apply-brotli-patch"></a></dfn></p>
@@ -1544,7 +1544,7 @@ return an error.</p>
 using the <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. Return the decoded
 result as the <var>extended font subset</var></p>
    </ol>
-   <h3 class="heading settled" data-level="5.4" id="per-table-shared-brotli"><span class="secno">5.4. </span><span class="content">Per Table Brotli</span><a class="self-link" href="#per-table-shared-brotli"></a></h3>
+   <h3 class="heading settled" data-level="5.4" id="per-table-brotli"><span class="secno">5.4. </span><span class="content">Per Table Brotli</span><a class="self-link" href="#per-table-brotli"></a></h3>
    <p>A per table brotli patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A per table brotli encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
 or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>.</p>
@@ -1594,7 +1594,7 @@ of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">Ta
       <td><dfn class="dfn-paneled" data-dfn-for="TablePatch" data-dfn-type="dfn" data-noexport id="tablepatch-brotlistream">brotliStream</dfn>[variable]
       <td>Brotli encoded byte stream.
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Brotli Patches" data-level="5.4.1" id="apply-per-table-shared-brotli"><span class="secno">5.4.1. </span><span class="content">Applying Per Table Brotli Patches</span><a class="self-link" href="#apply-per-table-shared-brotli"></a></h4>
+   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Brotli Patches" data-level="5.4.1" id="apply-per-table-brotli"><span class="secno">5.4.1. </span><span class="content">Applying Per Table Brotli Patches</span><a class="self-link" href="#apply-per-table-brotli"></a></h4>
    <p>This algorithm is used to apply a per table brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
    <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch<a class="self-link" href="#abstract-opdef-apply-per-table-brotli-patch"></a></dfn></p>
@@ -1905,7 +1905,10 @@ of dependent patch selection chosen in step 6 of <a data-link-type="abstract-op"
  given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset③">Extend a Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑨">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
     <li data-md>
-     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⓪">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> should be equal to the existing font.</p>
+     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⓪">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
+ should have all of the same <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> as the existing font (excluding the incremental IFT/IFTX
+ tables) and each of those tables should be functionally equivalent to the corresponding table in the existing font. Note: the fully
+ expanded may not always be an exact binary match with the existing font.</p>
    </ol>
    <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> and a client is implemented according to the
 other sections of this document, the intent of the IFT specification is that appearance and behavior of the font in the client will be the
@@ -1926,6 +1929,50 @@ directly encoded into the IFT format from font authoring source files.</p>
    <p>The details of the encoding process may differ by encoder and are beyond the scope of this document. However, this section provides
 guidance that encoder implementations may want to consider.</p>
    <p><b>Utilize an existing font subsetter implementation</b></p>
+   <p>As discussed in <a href="#encoder">§ 7 Encoder</a> a high quality encoder should preserve the functionality of the original font. One way to
+achieve this is to leverage an existing font subsetter implementation to produce font subsets that retain the functionality
+of the original font. The IFT patches can then be derived from these subsets.</p>
+   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③①">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a>. The practice of reliably
+subsetting a font is well understood and has multiple open-source implementations (a full formal description is
+beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
+relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
+Any reachable data is retained in the generated font subset, while any unreachable data may be removed.</p>
+   <p>Example pseudo code for a very basic encoder implementation using a font subsetter:</p>
+<pre># Encodes a font (full_font) into an incremental font that starts at base_subset_def
+# and can incrementally add any of subset_definitions. Returns the IFT encoded font
+# and set of associated patches.
+encode_as_ift(full_font, base_subset_def, subset_definitions):
+  base_font = subset(full_font, base_subset_def)
+  patches = encode_node(full_font, base_font, base_subset_def, subset_definitions)
+  return base_font, patches
+
+# Update base_font to add all of the ift patch mappings to reach any of
+# subset_definitions and produces the associated patches.
+encode_node(full_font, base_font, cur_def, subset_definitions):
+  patches = []
+  next_fonts = []
+  
+  for each subset_def in subset_definitions not fully covered by cur_def:
+    next_def = subset_def union cur_def
+    next_font = subset(full_font, next_def)
+    let patch_url be a new unique url
+    
+    add patch map entry into base_font from (subset_def - cur_def) to patch_url
+    patches += encode(full_font, next_font, next_def, subset_definitions)
+
+    next_fonts += (next_font, next_def, patch_url)
+
+  for each (next_font, next_def, patch_url):
+    patch = dependent_patch_diff(base_font, next_font)
+    patches += (patch, patch_url)
+  
+  return patches
+</pre>
+   <p>In this example implementation if the union of the input base subset definition and the list of subset definitions fully covers the input
+full font, and the subsetter implementation used correctly retains all functionality then the above implementation should meet the
+requirements in <a href="#encoder">§ 7 Encoder</a> to be a neutral encoding. This basic encoder implementation is for demonstration purposes and not meant
+to be representative of all possible encoder implementations. Most encoders will likely be more complex and need to consider additional
+factors some of which are discussed in the remaining sections.</p>
    <p><b>Choosing segmentations</b></p>
    <p>One of the most important and complex decisions an encoder needs to make is how to segment the data in the encoded font. To maximize
 efficiency the encoder should try and group data (eg. codepoints) that are commonly used together into the same segments. This will
@@ -1936,7 +1983,10 @@ to guide segmentation.</p>
    <p>During segmentation an encoder should also consider how codepoints interact with each other in the font. Keeping interacting codepoints
 in the same segment can avoid having to duplicate data between patches, which may be necessary to preserve the functionality of the
 original font when interacting codepoints reside in different segments.</p>
-   <p><b>Dependent patches can form patch graphs</b></p>
+   <p><b>Dependent patches can form graphs</b></p>
+   <p><a data-link-type="dfn" href="#dependent" id="ref-for-dependent⑤">Dependent</a> patches can modify the mapping table in the current font subset, which allows a patch to update the mapping table
+to point to a different set of patches which are valid against the result of the patch application. This allows a graph to be formed
+where a font subset is the node and each patch is an edge.</p>
    <p><b>Choosing patch formats</b></p>
    <p>An encoder must choose the appropriate patch type to use. Dependent patches allow all types of data in the font to be patched, while
 independent patches are limited to updating outline and variation delta data. However, using dependent patches can cause the number of
@@ -2357,8 +2407,8 @@ required too many patches.</p>
 </script>
 <script>/* Boilerplate: script-dfn-panel-json */
 window.dfnpanelData = {};
-window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subset", "dfnText": "font subset", "refSections": [{"refs": [{"id": "ref-for-font-subset"}], "title": "3.1. Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-font-subset\u2461"}], "title": "5. Font Patch Formats"}, {"refs": [{"id": "ref-for-font-subset\u2462"}, {"id": "ref-for-font-subset\u2463"}, {"id": "ref-for-font-subset\u2464"}, {"id": "ref-for-font-subset\u2465"}, {"id": "ref-for-font-subset\u2466"}, {"id": "ref-for-font-subset\u2467"}, {"id": "ref-for-font-subset\u2468"}, {"id": "ref-for-font-subset\u2460\u24ea"}, {"id": "ref-for-font-subset\u2460\u2460"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2461"}, {"id": "ref-for-font-subset\u2460\u2462"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2463"}], "title": "5.3. Brotli Patch"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2464"}, {"id": "ref-for-font-subset\u2460\u2465"}, {"id": "ref-for-font-subset\u2460\u2466"}], "title": "5.3.1. Applying Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2467"}, {"id": "ref-for-font-subset\u2460\u2468"}], "title": "5.4. Per Table Brotli"}, {"refs": [{"id": "ref-for-font-subset\u2461\u24ea"}, {"id": "ref-for-font-subset\u2461\u2460"}, {"id": "ref-for-font-subset\u2461\u2461"}], "title": "5.4.1. Applying Per Table Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2462"}], "title": "5.5. Glyph Keyed"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2463"}, {"id": "ref-for-font-subset\u2461\u2464"}, {"id": "ref-for-font-subset\u2461\u2465"}], "title": "5.5.1. Applying Glyph Keyed Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2466"}, {"id": "ref-for-font-subset\u2461\u2467"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2468"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-font-subset\u2462\u24ea"}], "title": "7. Encoder"}], "external": false};
-window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.1. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}, {"id": "ref-for-font-subset-definition\u2464"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-font-subset-definition\u2465"}, {"id": "ref-for-font-subset-definition\u2466"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2467"}], "title": "7. Encoder"}], "external": false};
+window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subset", "dfnText": "font subset", "refSections": [{"refs": [{"id": "ref-for-font-subset"}], "title": "3.1. Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-font-subset\u2461"}], "title": "5. Font Patch Formats"}, {"refs": [{"id": "ref-for-font-subset\u2462"}, {"id": "ref-for-font-subset\u2463"}, {"id": "ref-for-font-subset\u2464"}, {"id": "ref-for-font-subset\u2465"}, {"id": "ref-for-font-subset\u2466"}, {"id": "ref-for-font-subset\u2467"}, {"id": "ref-for-font-subset\u2468"}, {"id": "ref-for-font-subset\u2460\u24ea"}, {"id": "ref-for-font-subset\u2460\u2460"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2461"}, {"id": "ref-for-font-subset\u2460\u2462"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2463"}], "title": "5.3. Brotli Patch"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2464"}, {"id": "ref-for-font-subset\u2460\u2465"}, {"id": "ref-for-font-subset\u2460\u2466"}], "title": "5.3.1. Applying Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2467"}, {"id": "ref-for-font-subset\u2460\u2468"}], "title": "5.4. Per Table Brotli"}, {"refs": [{"id": "ref-for-font-subset\u2461\u24ea"}, {"id": "ref-for-font-subset\u2461\u2460"}, {"id": "ref-for-font-subset\u2461\u2461"}], "title": "5.4.1. Applying Per Table Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2462"}], "title": "5.5. Glyph Keyed"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2463"}, {"id": "ref-for-font-subset\u2461\u2464"}, {"id": "ref-for-font-subset\u2461\u2465"}], "title": "5.5.1. Applying Glyph Keyed Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2466"}, {"id": "ref-for-font-subset\u2461\u2467"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2468"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-font-subset\u2462\u24ea"}], "title": "7. Encoder"}, {"refs": [{"id": "ref-for-font-subset\u2462\u2460"}], "title": "7.1. Encoder Considerations"}], "external": false};
+window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.1. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}, {"id": "ref-for-font-subset-definition\u2464"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-font-subset-definition\u2465"}, {"id": "ref-for-font-subset-definition\u2466"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2467"}], "title": "7. Encoder"}, {"refs": [{"id": "ref-for-font-subset-definition\u2468"}], "title": "7.1. Encoder Considerations"}], "external": false};
 window.dfnpanelData['incremental-font'] = {"dfnID": "incremental-font", "url": "#incremental-font", "dfnText": "incremental font", "refSections": [{"refs": [{"id": "ref-for-incremental-font"}, {"id": "ref-for-incremental-font\u2460"}, {"id": "ref-for-incremental-font\u2461"}, {"id": "ref-for-incremental-font\u2462"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-incremental-font\u2463"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-incremental-font\u2464"}, {"id": "ref-for-incremental-font\u2465"}, {"id": "ref-for-incremental-font\u2466"}, {"id": "ref-for-incremental-font\u2467"}, {"id": "ref-for-incremental-font\u2468"}, {"id": "ref-for-incremental-font\u2460\u24ea"}, {"id": "ref-for-incremental-font\u2460\u2460"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-map-entries'] = {"dfnID": "patch-map-entries", "url": "#patch-map-entries", "dfnText": "patch map entries", "refSections": [{"refs": [{"id": "ref-for-patch-map-entries"}, {"id": "ref-for-patch-map-entries\u2460"}, {"id": "ref-for-patch-map-entries\u2461"}, {"id": "ref-for-patch-map-entries\u2462"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-patch-map-entries\u2463"}, {"id": "ref-for-patch-map-entries\u2464"}, {"id": "ref-for-patch-map-entries\u2465"}], "title": "4.1.2.1. Interpreting Format 2"}, {"refs": [{"id": "ref-for-patch-map-entries\u2466"}, {"id": "ref-for-patch-map-entries\u2467"}], "title": "6. Extending a Font Subset"}], "external": false};
 window.dfnpanelData['format-1-patch-map-entrycount'] = {"dfnID": "format-1-patch-map-entrycount", "url": "#format-1-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-entrycount"}, {"id": "ref-for-format-1-patch-map-entrycount\u2460"}, {"id": "ref-for-format-1-patch-map-entrycount\u2461"}, {"id": "ref-for-format-1-patch-map-entrycount\u2462"}, {"id": "ref-for-format-1-patch-map-entrycount\u2463"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
@@ -2400,7 +2450,7 @@ window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map-entry'] = {"dfn
 window.dfnpanelData['font-patch'] = {"dfnID": "font-patch", "url": "#font-patch", "dfnText": "font patch", "refSections": [{"refs": [{"id": "ref-for-font-patch"}, {"id": "ref-for-font-patch\u2460"}, {"id": "ref-for-font-patch\u2461"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-patch\u2462"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-format'] = {"dfnID": "patch-format", "url": "#patch-format", "dfnText": "patch format", "refSections": [{"refs": [{"id": "ref-for-patch-format"}, {"id": "ref-for-patch-format\u2460"}], "title": "5.1. Definitions"}], "external": false};
 window.dfnpanelData['patch-application-algorithm'] = {"dfnID": "patch-application-algorithm", "url": "#patch-application-algorithm", "dfnText": "patch application algorithm", "refSections": [{"refs": [{"id": "ref-for-patch-application-algorithm"}], "title": "5.1. Definitions"}], "external": false};
-window.dfnpanelData['dependent'] = {"dfnID": "dependent", "url": "#dependent", "dfnText": "dependent", "refSections": [{"refs": [{"id": "ref-for-dependent"}, {"id": "ref-for-dependent\u2460"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-dependent\u2461"}, {"id": "ref-for-dependent\u2462"}, {"id": "ref-for-dependent\u2463"}], "title": "6. Extending a Font Subset"}], "external": false};
+window.dfnpanelData['dependent'] = {"dfnID": "dependent", "url": "#dependent", "dfnText": "dependent", "refSections": [{"refs": [{"id": "ref-for-dependent"}, {"id": "ref-for-dependent\u2460"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-dependent\u2461"}, {"id": "ref-for-dependent\u2462"}, {"id": "ref-for-dependent\u2463"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-dependent\u2464"}], "title": "7.1. Encoder Considerations"}], "external": false};
 window.dfnpanelData['independent'] = {"dfnID": "independent", "url": "#independent", "dfnText": "independent", "refSections": [{"refs": [{"id": "ref-for-independent"}], "title": "5.2. Formats Summary"}], "external": false};
 window.dfnpanelData['brotli-patch'] = {"dfnID": "brotli-patch", "url": "#brotli-patch", "dfnText": "Brotli patch", "refSections": [{"refs": [{"id": "ref-for-brotli-patch"}], "title": "5.3.1. Applying Brotli Patches"}], "external": false};
 window.dfnpanelData['brotli-patch-format'] = {"dfnID": "brotli-patch-format", "url": "#brotli-patch-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-brotli-patch-format"}], "title": "5.3.1. Applying Brotli Patches"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="32e5b91c30707f9be12ca1473e06f3f9fd96d4df" name="document-revision">
+  <meta content="ba124498bafdaee859840129c51e97650d577ebe" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -654,7 +654,8 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
 the web. Without this technology, a browser needs to download every last byte of a font before it can render
 any characters using that font. IFT allows the browser to download only some of the bytes in the file, thereby
 decreasing the perceived latency between the time when a browser realizes it needs a font and when the
-necessary text can be rendered with that font.</p>
+necessary text can be rendered with that font. Unlike traditional font subsetting approaches Incremental Font Transfer
+retains the encoding of layout rules between segments (<a href="https://www.w3.org/TR/PFE-evaluation/#fail-subset">Progressive Font Enrichment: Evaluation Report § fail-subset</a>).</p>
    <p>The success of WebFonts is unevenly distributed. This specification allows WebFonts to be used where
 slow networks, very large fonts, or complex subsetting requirements currently preclude their use. For
 example, even using WOFF 2 <a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a>, fonts for CJK languages can be too large to be practical.</p>
@@ -684,7 +685,8 @@ by loading and applying patches to it.</p>
 the font.</p>
     <li data-md>
      <p>Based on the content to be rendered, the client <a href="#extending-font-subset">selects, downloads, and applies</a> patches to extend
-the font to cover additional characters. This step is repeated each time there is new content.</p>
+the font to cover additional characters, layout features, and/or variation space. This step is repeated each time there is new
+content.</p>
    </ol>
    <h3 class="heading settled" data-level="1.3" id="making-incremental-fonts"><span class="secno">1.3. </span><span class="content">Creating an Incremental Font</span><a class="self-link" href="#making-incremental-fonts"></a></h3>
    <p>It is expected that the most common way to produce an incremental font will be to convert an existing font to use the incremental
@@ -709,6 +711,9 @@ requirements on the encoding can be found in the <a href="#encoder">§ 7 Encod
    <p>Using incremental transfer may not always be beneficial, depending on the characteristics of the font,
 the network, and the content being rendered. This section provides non-normative guidance to help decide
 when incremental transfer should be utilized.</p>
+   <p>It is common for an incremental font to trigger the loading of multiple patches in parallel. So to maximize performance, when
+serving an incremental font it is recommended that an HTTP server which is capable of multiplexing (such as <a data-link-type="biblio" href="#biblio-rfc9113" title="HTTP/2">[rfc9113]</a> or <a data-link-type="biblio" href="#biblio-rfc9114" title="HTTP/3">[rfc9114]</a>)
+is used.</p>
    <p>Incrementally loading a font has a fundamental performance trade off versus loading the whole font.
 Simplistically, under incremental transfer less bytes may be transferred at the potential cost of
 increasing the total number of network requests being made, and/or increased request processing
@@ -2249,6 +2254,10 @@ required too many patches.</p>
   <dl>
    <dt id="biblio-fetch">[FETCH]
    <dd><a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. 22 May 2023. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-rfc9113">[RFC9113]
+   <dd>M. Thomson, Ed.; C. Benfield, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9113"><cite>HTTP/2</cite></a>. June 2022. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9113">https://www.rfc-editor.org/rfc/rfc9113</a>
+   <dt id="biblio-rfc9114">[RFC9114]
+   <dd>M. Bishop, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc9114"><cite>HTTP/3</cite></a>. June 2022. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9114">https://www.rfc-editor.org/rfc/rfc9114</a>
    <dt id="biblio-woff2">[WOFF2]
    <dd>Vladimir Levantovsky; Raph Levien. <a href="https://w3c.github.io/woff/woff2/"><cite>WOFF File Format 2.0</cite></a>. URL: <a href="https://w3c.github.io/woff/woff2/">https://w3c.github.io/woff/woff2/</a>
   </dl>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="b1a98b06362c9a0973e7e10f6e525f01e5d428bc" name="document-revision">
+  <meta content="5a9cd7bdad82cd34c62bcb6a62502fb8c047498c" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -846,10 +846,12 @@ several variables are defined which are used to produce the expansion of the tem
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="incremental-font">incremental font</dfn> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but includes two new <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both <a href="#patch-map">patch maps</a>, which encode a collection of mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which
 host <a href="#font-patch-formats">patches</a> that extend the incremental font. All incremental fonts must contain the 'IFT ' table.
 The 'IFTX' table is optional. When both tables are present, the mapping of the font as a whole is the union of the mappings of
-the two tables.</p>
+the two tables. The two new tables are used only in this specification and are not being added to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">Open-Type</a> specification.</p>
    <p class="note" role="note"><span class="marker">Note:</span> allowing the mapping to be split between two distinct tables allows an incremental font to more easily make use of multiple
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
 'IFTX' table. Those patches can make updates only to one of the mapping tables and avoid making conflicting updates.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font">incremental fonts</a> can be converted to <a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a> and still be utilized as an incremental fonts. In this
+case the user agent would first decode the woff2, and patches are relative to the decoded bytes.</p>
    <h3 class="heading settled" data-level="4.1" id="patch-map"><span class="secno">4.1. </span><span class="content">Patch Map Table</span><a class="self-link" href="#patch-map"></a></h3>
    <p>A patch map table encodes a list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map-entries">patch map entries</dfn>, where each entry has a key and value. The key is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a> and the value is a URI and the <a href="#font-patch-formats">§ 5 Font Patch Formats</a> used by the data at the URI. A map is
 encoded in one of two formats:</p>
@@ -1765,13 +1767,13 @@ the entries processed in step 4, add a copy of that table to <var>extended font 
 that map to this patch.</p>
    </ol>
    <h2 class="heading settled algorithm" data-algorithm="Extending a Font Subset" data-level="6" id="extending-font-subset"><span class="secno">6. </span><span class="content">Extending a Font Subset</span><a class="self-link" href="#extending-font-subset"></a></h2>
-   <p>This sections defines the algorithm that a client uses to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑦">font subset</a> to cover additional
+   <p>This sections defines the algorithm that a client uses to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑦">font subset</a> to cover additional
 codepoints, layout features and/or design space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-extend-a-font-subset">Extend a Font Subset</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a>.</p>
+     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a>.</p>
     <li data-md>
      <p><var>font subset URI</var>: an <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the location of <var>font subset</var>.</p>
     <li data-md>
@@ -1780,7 +1782,7 @@ codepoints, layout features and/or design space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: an extended version of <var>font subset</var>. May or may not be an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②">incremental font</a>.</p>
+     <p><var>extended font subset</var>: an extended version of <var>font subset</var>. May or may not be an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font③">incremental font</a>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1789,7 +1791,7 @@ codepoints, layout features and/or design space.</p>
     <li data-md>
      <p>Load the 'IFT ' and 'IFTX' (if present) mapping <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> from <var>extended font subset</var>. Both
 tables are formatted as a <a href="#patch-map">§ 4.1 Patch Map Table</a>. Check that they are valid according to the requirements in <a href="#patch-map">§ 4.1 Patch Map Table</a>. If either table
-is not valid, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors">Handle errors</a>. If <var>extended font subset</var> does not have an 'IFT ' table, then it is not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font③">incremental font</a> and cannot be extended, return <var>extended font subset</var>.</p>
+is not valid, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors">Handle errors</a>. If <var>extended font subset</var> does not have an 'IFT ' table, then it is not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font④">incremental font</a> and cannot be extended, return <var>extended font subset</var>.</p>
     <li data-md>
      <p>For each of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
 invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a>. Concatenate the output entry lists into a single list, <var>entry list</var>.</p>
@@ -1879,7 +1881,7 @@ patches to be applied.</p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font④">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑨">font subset</a>.</p>
+     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑤">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑨">font subset</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1894,25 +1896,25 @@ is considered to intersect all entries in the <a data-link-type="abstract-op" hr
 the <var>expanded font</var>.</p>
    </ol>
    <h2 class="heading settled" data-level="7" id="encoder"><span class="secno">7. </span><span class="content">Encoder</span><a class="self-link" href="#encoder"></a></h2>
-   <p>An encoder is a tool which produces an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑤">incremental font</a> and set of associated <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch③">patches</a>.
-The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑥">incremental font</a> and associated patches produced by a compliant encoder:</p>
+   <p>An encoder is a tool which produces an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑥">incremental font</a> and set of associated <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch③">patches</a>.
+The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑦">incremental font</a> and associated patches produced by a compliant encoder:</p>
    <ol>
     <li data-md>
      <p>Must meet all of the requirements in <a href="#font-format-extensions">§ 4 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 5 Font Patch Formats</a>.</p>
     <li data-md>
-     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset①">Extend a Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑦">incremental font</a> must always be the same regardless of the particular order
+     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset①">Extend a Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> must always be the same regardless of the particular order
 of dependent patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset②">Extend a Font Subset</a>.</p>
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font, that is:
- given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset③">Extend a Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑨">incremental font</a> and the minimal subset definition covering that content should
+ given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑨">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset③">Extend a Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⓪">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
     <li data-md>
-     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⓪">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
+     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
  should have all of the same <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> as the existing font (excluding the incremental IFT/IFTX
  tables) and each of those tables should be functionally equivalent to the corresponding table in the existing font. Note: the fully
  expanded may not always be an exact binary match with the existing font.</p>
    </ol>
-   <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> and a client is implemented according to the
+   <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> and a client is implemented according to the
 other sections of this document, the intent of the IFT specification is that appearance and behavior of the font in the client will be the
 same as if the entire file were transferred to the client. A primary goal of the IFT specification is that the IFT format and protocol can
 serve as a neutral medium for font transfer, comparable to WOFF2. If an encoder produces an encoding from a source font which meets all of
@@ -2415,7 +2417,7 @@ required too many patches.</p>
 window.dfnpanelData = {};
 window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subset", "dfnText": "font subset", "refSections": [{"refs": [{"id": "ref-for-font-subset"}], "title": "3.1. Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-font-subset\u2461"}], "title": "5. Font Patch Formats"}, {"refs": [{"id": "ref-for-font-subset\u2462"}, {"id": "ref-for-font-subset\u2463"}, {"id": "ref-for-font-subset\u2464"}, {"id": "ref-for-font-subset\u2465"}, {"id": "ref-for-font-subset\u2466"}, {"id": "ref-for-font-subset\u2467"}, {"id": "ref-for-font-subset\u2468"}, {"id": "ref-for-font-subset\u2460\u24ea"}, {"id": "ref-for-font-subset\u2460\u2460"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2461"}, {"id": "ref-for-font-subset\u2460\u2462"}], "title": "5.2. Formats Summary"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2463"}], "title": "5.3. Brotli Patch"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2464"}, {"id": "ref-for-font-subset\u2460\u2465"}, {"id": "ref-for-font-subset\u2460\u2466"}], "title": "5.3.1. Applying Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2460\u2467"}, {"id": "ref-for-font-subset\u2460\u2468"}], "title": "5.4. Per Table Brotli"}, {"refs": [{"id": "ref-for-font-subset\u2461\u24ea"}, {"id": "ref-for-font-subset\u2461\u2460"}, {"id": "ref-for-font-subset\u2461\u2461"}], "title": "5.4.1. Applying Per Table Brotli Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2462"}], "title": "5.5. Glyph Keyed"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2463"}, {"id": "ref-for-font-subset\u2461\u2464"}, {"id": "ref-for-font-subset\u2461\u2465"}], "title": "5.5.1. Applying Glyph Keyed Patches"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2466"}, {"id": "ref-for-font-subset\u2461\u2467"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset\u2461\u2468"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-font-subset\u2462\u24ea"}], "title": "7. Encoder"}, {"refs": [{"id": "ref-for-font-subset\u2462\u2460"}], "title": "7.1. Encoder Considerations"}], "external": false};
 window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.1. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}, {"id": "ref-for-font-subset-definition\u2464"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-font-subset-definition\u2465"}, {"id": "ref-for-font-subset-definition\u2466"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2467"}], "title": "7. Encoder"}, {"refs": [{"id": "ref-for-font-subset-definition\u2468"}], "title": "7.1. Encoder Considerations"}], "external": false};
-window.dfnpanelData['incremental-font'] = {"dfnID": "incremental-font", "url": "#incremental-font", "dfnText": "incremental font", "refSections": [{"refs": [{"id": "ref-for-incremental-font"}, {"id": "ref-for-incremental-font\u2460"}, {"id": "ref-for-incremental-font\u2461"}, {"id": "ref-for-incremental-font\u2462"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-incremental-font\u2463"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-incremental-font\u2464"}, {"id": "ref-for-incremental-font\u2465"}, {"id": "ref-for-incremental-font\u2466"}, {"id": "ref-for-incremental-font\u2467"}, {"id": "ref-for-incremental-font\u2468"}, {"id": "ref-for-incremental-font\u2460\u24ea"}, {"id": "ref-for-incremental-font\u2460\u2460"}], "title": "7. Encoder"}], "external": false};
+window.dfnpanelData['incremental-font'] = {"dfnID": "incremental-font", "url": "#incremental-font", "dfnText": "incremental font", "refSections": [{"refs": [{"id": "ref-for-incremental-font"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-incremental-font\u2460"}, {"id": "ref-for-incremental-font\u2461"}, {"id": "ref-for-incremental-font\u2462"}, {"id": "ref-for-incremental-font\u2463"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-incremental-font\u2464"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-incremental-font\u2465"}, {"id": "ref-for-incremental-font\u2466"}, {"id": "ref-for-incremental-font\u2467"}, {"id": "ref-for-incremental-font\u2468"}, {"id": "ref-for-incremental-font\u2460\u24ea"}, {"id": "ref-for-incremental-font\u2460\u2460"}, {"id": "ref-for-incremental-font\u2460\u2461"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-map-entries'] = {"dfnID": "patch-map-entries", "url": "#patch-map-entries", "dfnText": "patch map entries", "refSections": [{"refs": [{"id": "ref-for-patch-map-entries"}, {"id": "ref-for-patch-map-entries\u2460"}, {"id": "ref-for-patch-map-entries\u2461"}, {"id": "ref-for-patch-map-entries\u2462"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-patch-map-entries\u2463"}, {"id": "ref-for-patch-map-entries\u2464"}, {"id": "ref-for-patch-map-entries\u2465"}], "title": "4.1.2.1. Interpreting Format 2"}, {"refs": [{"id": "ref-for-patch-map-entries\u2466"}, {"id": "ref-for-patch-map-entries\u2467"}], "title": "6. Extending a Font Subset"}], "external": false};
 window.dfnpanelData['format-1-patch-map-entrycount'] = {"dfnID": "format-1-patch-map-entrycount", "url": "#format-1-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-entrycount"}, {"id": "ref-for-format-1-patch-map-entrycount\u2460"}, {"id": "ref-for-format-1-patch-map-entrycount\u2461"}, {"id": "ref-for-format-1-patch-map-entrycount\u2462"}, {"id": "ref-for-format-1-patch-map-entrycount\u2463"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
 window.dfnpanelData['format-1-patch-map-glyphcount'] = {"dfnID": "format-1-patch-map-glyphcount", "url": "#format-1-patch-map-glyphcount", "dfnText": "glyphCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-glyphcount"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="5a9cd7bdad82cd34c62bcb6a62502fb8c047498c" name="document-revision">
+  <meta content="27d662b865c94d64b35015c955f6abe490cbe810" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -864,7 +864,7 @@ not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-f
 is typically less compact than format 1.</p>
    </ul>
    <h4 class="heading settled" data-level="4.1.1" id="patch-map-format-1"><span class="secno">4.1.1. </span><span class="content">Patch Map Table: Format 1</span><a class="self-link" href="#patch-map-format-1"></a></h4>
-   <p><dfn data-dfn-type="dfn" data-noexport id="format-1-patch-map">Format 1 Patch Map<a class="self-link" href="#format-1-patch-map"></a></dfn> encoding:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="format-1-patch-map">Format 1 Patch Map</dfn> encoding:</p>
    <table>
     <tbody>
      <tr>
@@ -873,15 +873,15 @@ is typically less compact than format 1.</p>
       <th>Description
      <tr>
       <td>uint8
-      <td><dfn data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-format">format<a class="self-link" href="#format-1-patch-map-format"></a></dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-format">format</dfn>
       <td>Set to 1, identifies this as format 1.
      <tr>
       <td>uint32
-      <td><dfn data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-reserved">reserved<a class="self-link" href="#format-1-patch-map-reserved"></a></dfn>
+      <td>reserved
       <td>Not used, set to 0.
      <tr>
       <td>uint32
-      <td><dfn data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-id">id<a class="self-link" href="#format-1-patch-map-id"></a></dfn>[4]
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-id">id</dfn>[4]
       <td>Unique ID used to identify patches that are compatible with this font.
      <tr>
       <td>uint32
@@ -1006,7 +1006,7 @@ is typically less compact than format 1.</p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>patch map</var>: a <a href="#patch-map-format-1">§ 4.1.1 Patch Map Table: Format 1</a> encoded patch map.</p>
+     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-1-patch-map" id="ref-for-format-1-patch-map">Format 1 Patch Map</a> encoded patch map.</p>
     <li data-md>
      <p><var>font subset</var>: the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①">font subset</a> which contains <var>patch map</var>.</p>
    </ul>
@@ -1014,11 +1014,13 @@ is typically less compact than format 1.</p>
    <ul>
     <li data-md>
      <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①">patch map entries</a>.</p>
+    <li data-md>
+     <p><var>id</var>: the ID associated with this table.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> is valid according to the requirements in <a href="#patch-map-format-1">§ 4.1.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 4.1.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
     <li data-md>
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map①">Glyph Map</a>:</p>
      <ul>
@@ -1053,6 +1055,8 @@ a feature tag set containing only <a data-link-type="dfn" href="#featurerecord-f
 specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding①">patchEncoding</a>.</p>
        </ul>
      </ul>
+    <li data-md>
+     <p>Return <var>entry list</var> and <a data-link-type="dfn" href="#format-1-patch-map-id" id="ref-for-format-1-patch-map-id">id</a> as <var>id</var>.</p>
    </ol>
    <h4 class="heading settled" data-level="4.1.2" id="patch-map-format-2"><span class="secno">4.1.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
    <p><dfn data-dfn-type="dfn" data-noexport id="format-2-patch-map">Format 2 Patch Map<a class="self-link" href="#format-2-patch-map"></a></dfn> encoding:</p>
@@ -1072,7 +1076,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td>Not used, set to 0.
      <tr>
       <td>uint32
-      <td><dfn data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-id">id<a class="self-link" href="#format-2-patch-map-id"></a></dfn>[4]
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-id">id</dfn>[4]
       <td>Unique ID used to identify patches that are compatible with this font.
      <tr>
       <td>uint8
@@ -1192,7 +1196,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
    </table>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="4.1.2.1" id="interpreting-patch-map-format-2"><span class="secno">4.1.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
    <p>This algorithm is used to convert a format 2 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a>.</p>
-   <p><dfn data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map<a class="self-link" href="#abstract-opdef-interpret-format-2-patch-map"></a></dfn></p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
@@ -1202,6 +1206,8 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
    <ul>
     <li data-md>
      <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">patch map entries</a>.</p>
+    <li data-md>
+     <p><var>id</var>: the ID associated with this table.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1223,7 +1229,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
        <p>If the returned value of ignored is false, then add the returned entry to <var>entry list</var>.</p>
      </ul>
     <li data-md>
-     <p>Return <var>entry list</var>.</p>
+     <p>Return <var>entry list</var> and <a data-link-type="dfn" href="#format-2-patch-map-id" id="ref-for-format-2-patch-map-id">id</a> as <var>id</var>.</p>
    </ol>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</dfn></p>
    <p>The inputs to this algorithm are:</p>
@@ -1527,6 +1533,8 @@ features, and/or design-variation space.</p>
      <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#brotli-patch" id="ref-for-brotli-patch">brotli patch</a> to be applied to <var>base font subset</var>.</p>
+    <li data-md>
+     <p><var>ids</var>: The ID numbers from the 'IFT ' and 'IFTX' tables of <var>base font subset</var>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1540,9 +1548,9 @@ features, and/or design-variation space.</p>
 not equal, then <var>patch</var> is not correctly formatted. Patch application has failed, return
 an error.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#brotli-patch-id" id="ref-for-brotli-patch-id">id</a> field in <var>patch</var> is equal to the at least one of the ids
-found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
-return an error.</p>
+     <p>Check that the <a data-link-type="dfn" href="#brotli-patch-id" id="ref-for-brotli-patch-id">id</a> field in <var>patch</var> is equal to at least one of <var>ids</var>.
+If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
+has failed, return an error.</p>
     <li data-md>
      <p>Decode the brotli encoded data in <a data-link-type="dfn" href="#brotli-patch-brotlistream" id="ref-for-brotli-patch-brotlistream">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a> and
 using the <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. Return the decoded
@@ -1608,6 +1616,8 @@ features, and/or design-variation space.</p>
      <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#per-table-brotli-patch" id="ref-for-per-table-brotli-patch">per table brotli patch</a> to be applied to <var>base font subset</var>.</p>
+    <li data-md>
+     <p><var>ids</var>: The ID numbers from the 'IFT ' and 'IFTX' tables of <var>base font subset</var>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1621,9 +1631,9 @@ features, and/or design-variation space.</p>
 not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
 an error.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#per-table-brotli-patch-id" id="ref-for-per-table-brotli-patch-id">id</a> field in <var>patch</var> is equal to the at least one of the ids
-found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
-return an error.</p>
+     <p>Check that the <a data-link-type="dfn" href="#per-table-brotli-patch-id" id="ref-for-per-table-brotli-patch-id">id</a> field in <var>patch</var> is equal to at least one of <var>ids</var>.
+If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
+has failed, return an error.</p>
     <li data-md>
      <p>For each entry in <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches①">patches</a>, with index <var>i</var>:</p>
      <ul>
@@ -1720,6 +1730,8 @@ features, and/or design-variation space.</p>
      <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑤">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#glyph-keyed-patch" id="ref-for-glyph-keyed-patch">glyph keyed patch</a> to be applied to <var>base font subset</var>.</p>
+    <li data-md>
+     <p><var>ids</var>: The ID numbers from the 'IFT ' and 'IFTX' tables of <var>base font subset</var>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1733,9 +1745,9 @@ features, and/or design-variation space.</p>
 not equal, then <var>patch</var> is not correctly formatted and patch application has failed, return
 an error.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#glyph-keyed-patch-id" id="ref-for-glyph-keyed-patch-id">id</a> field in <var>patch</var> is equal to the at least one of the ids
-found in the 'IFT ' or 'IFTX' table of <var>base font subset</var>. If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has failed,
-return an error.</p>
+     <p>Check that the <a data-link-type="dfn" href="#glyph-keyed-patch-id" id="ref-for-glyph-keyed-patch-id">id</a> field in <var>patch</var> is equal to at least one of <var>ids</var>.
+If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application has
+failed, return an error.</p>
     <li data-md>
      <p>Decode the brotli encoded data in <a data-link-type="dfn" href="#glyph-keyed-patch-brotlistream" id="ref-for-glyph-keyed-patch-brotlistream①">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a>. The
 decoded data is a <a data-link-type="dfn" href="#glyphpatches" id="ref-for-glyphpatches②">GlyphPatches</a> table.</p>
@@ -1794,7 +1806,7 @@ tables are formatted as a <a href="#patch-map">§ 4.1 Patch Map Table</a>. Che
 is not valid, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors">Handle errors</a>. If <var>extended font subset</var> does not have an 'IFT ' table, then it is not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font④">incremental font</a> and cannot be extended, return <var>extended font subset</var>.</p>
     <li data-md>
      <p>For each of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
-invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a>. Concatenate the output entry lists into a single list, <var>entry list</var>.</p>
+invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a> or <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a>. Concatenate the returned entry lists into a single list, <var>entry list</var>, and the returned IDs into a single list <var>ids</var>.</p>
     <li data-md>
      <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection">Check entry intersection</a> with <var>entry</var> and <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var> from <var>entry list</var>.</p>
     <li data-md>
@@ -1807,8 +1819,7 @@ exactly one of the <a data-link-type="dfn" href="#dependent" id="ref-for-depende
 incremental font URI and the entries URI as the patch URI. Collect the returned patch
 files into <var>patch list</var>.</p>
     <li data-md>
-     <p>For each <var>patch</var> in <var>patch list</var> use the appropriate application algorithm (matching the patches format) from <a href="#font-patch-formats">§ 5 Font Patch Formats</a> to apply the <var>patch</var> to <var>extended font subset</var>. The order of patch application is left up to
-the implementation.</p>
+     <p>For each <var>patch</var> in <var>patch list</var> use the appropriate application algorithm (matching the patches format) from <a href="#font-patch-formats">§ 5 Font Patch Formats</a> to apply the <var>patch</var> to <var>extended font subset</var>. Pass in <var>entry list</var> and <var>ids</var>. The order of patch application is left up to the implementation.</p>
     <li data-md>
      <p>Go to step 2.</p>
    </ol>
@@ -2195,12 +2206,7 @@ required too many patches.</p>
    <li><a href="#patch-format">patch format</a><span>, in § 5.1</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 4.1</span>
    <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 5.4</span>
-   <li>
-    reserved
-    <ul>
-     <li><a href="#format-1-patch-map-reserved">dfn for Format 1 Patch Map</a><span>, in § 4.1.1</span>
-     <li><a href="#format-2-patch-map-reserved">dfn for Format 2 Patch Map</a><span>, in § 4.1.2</span>
-    </ul>
+   <li><a href="#format-2-patch-map-reserved">reserved</a><span>, in § 4.1.2</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.1.2.2</span>
    <li><a href="#design-space-segment-start">start</a><span>, in § 4.1.2</span>
    <li><a href="#glyphpatches-tablecount">tableCount</a><span>, in § 5.5</span>
@@ -2419,6 +2425,9 @@ window.dfnpanelData['font-subset'] = {"dfnID": "font-subset", "url": "#font-subs
 window.dfnpanelData['font-subset-definition'] = {"dfnID": "font-subset-definition", "url": "#font-subset-definition", "dfnText": "font subset definition", "refSections": [{"refs": [{"id": "ref-for-font-subset-definition"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-font-subset-definition\u2460"}, {"id": "ref-for-font-subset-definition\u2461"}], "title": "4.1. Patch Map Table"}, {"refs": [{"id": "ref-for-font-subset-definition\u2462"}, {"id": "ref-for-font-subset-definition\u2463"}, {"id": "ref-for-font-subset-definition\u2464"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-font-subset-definition\u2465"}, {"id": "ref-for-font-subset-definition\u2466"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-font-subset-definition\u2467"}], "title": "7. Encoder"}, {"refs": [{"id": "ref-for-font-subset-definition\u2468"}], "title": "7.1. Encoder Considerations"}], "external": false};
 window.dfnpanelData['incremental-font'] = {"dfnID": "incremental-font", "url": "#incremental-font", "dfnText": "incremental font", "refSections": [{"refs": [{"id": "ref-for-incremental-font"}], "title": "4. Extensions to the Font Format"}, {"refs": [{"id": "ref-for-incremental-font\u2460"}, {"id": "ref-for-incremental-font\u2461"}, {"id": "ref-for-incremental-font\u2462"}, {"id": "ref-for-incremental-font\u2463"}], "title": "6. Extending a Font Subset"}, {"refs": [{"id": "ref-for-incremental-font\u2464"}], "title": "6.1. Fully Expanding a Font"}, {"refs": [{"id": "ref-for-incremental-font\u2465"}, {"id": "ref-for-incremental-font\u2466"}, {"id": "ref-for-incremental-font\u2467"}, {"id": "ref-for-incremental-font\u2468"}, {"id": "ref-for-incremental-font\u2460\u24ea"}, {"id": "ref-for-incremental-font\u2460\u2460"}, {"id": "ref-for-incremental-font\u2460\u2461"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-map-entries'] = {"dfnID": "patch-map-entries", "url": "#patch-map-entries", "dfnText": "patch map entries", "refSections": [{"refs": [{"id": "ref-for-patch-map-entries"}, {"id": "ref-for-patch-map-entries\u2460"}, {"id": "ref-for-patch-map-entries\u2461"}, {"id": "ref-for-patch-map-entries\u2462"}], "title": "4.1.1.1. Interpreting Format 1"}, {"refs": [{"id": "ref-for-patch-map-entries\u2463"}, {"id": "ref-for-patch-map-entries\u2464"}, {"id": "ref-for-patch-map-entries\u2465"}], "title": "4.1.2.1. Interpreting Format 2"}, {"refs": [{"id": "ref-for-patch-map-entries\u2466"}, {"id": "ref-for-patch-map-entries\u2467"}], "title": "6. Extending a Font Subset"}], "external": false};
+window.dfnpanelData['format-1-patch-map'] = {"dfnID": "format-1-patch-map", "url": "#format-1-patch-map", "dfnText": "Format 1 Patch Map", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['format-1-patch-map-format'] = {"dfnID": "format-1-patch-map-format", "url": "#format-1-patch-map-format", "dfnText": "format", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-format"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
+window.dfnpanelData['format-1-patch-map-id'] = {"dfnID": "format-1-patch-map-id", "url": "#format-1-patch-map-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-id"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['format-1-patch-map-entrycount'] = {"dfnID": "format-1-patch-map-entrycount", "url": "#format-1-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-entrycount"}, {"id": "ref-for-format-1-patch-map-entrycount\u2460"}, {"id": "ref-for-format-1-patch-map-entrycount\u2461"}, {"id": "ref-for-format-1-patch-map-entrycount\u2462"}, {"id": "ref-for-format-1-patch-map-entrycount\u2463"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
 window.dfnpanelData['format-1-patch-map-glyphcount'] = {"dfnID": "format-1-patch-map-glyphcount", "url": "#format-1-patch-map-glyphcount", "dfnText": "glyphCount", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-glyphcount"}], "title": "4.1.1. Patch Map Table: Format 1"}], "external": false};
 window.dfnpanelData['format-1-patch-map-appliedentriesbitmap'] = {"dfnID": "format-1-patch-map-appliedentriesbitmap", "url": "#format-1-patch-map-appliedentriesbitmap", "dfnText": "appliedEntriesBitMap", "refSections": [{"refs": [{"id": "ref-for-format-1-patch-map-appliedentriesbitmap"}, {"id": "ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
@@ -2435,6 +2444,7 @@ window.dfnpanelData['entrymaprecord'] = {"dfnID": "entrymaprecord", "url": "#ent
 window.dfnpanelData['entrymaprecord-firstentryindex'] = {"dfnID": "entrymaprecord-firstentryindex", "url": "#entrymaprecord-firstentryindex", "dfnText": "firstEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-firstentryindex"}, {"id": "ref-for-entrymaprecord-firstentryindex\u2460"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['entrymaprecord-lastentryindex'] = {"dfnID": "entrymaprecord-lastentryindex", "url": "#entrymaprecord-lastentryindex", "dfnText": "lastEntryIndex", "refSections": [{"refs": [{"id": "ref-for-entrymaprecord-lastentryindex"}], "title": "4.1.1.1. Interpreting Format 1"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-1-patch-map'] = {"dfnID": "abstract-opdef-interpret-format-1-patch-map", "url": "#abstract-opdef-interpret-format-1-patch-map", "dfnText": "Interpret Format 1 Patch Map", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-1-patch-map"}], "title": "6. Extending a Font Subset"}], "external": false};
+window.dfnpanelData['format-2-patch-map-id'] = {"dfnID": "format-2-patch-map-id", "url": "#format-2-patch-map-id", "dfnText": "id", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-id"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-defaultpatchencoding'] = {"dfnID": "format-2-patch-map-defaultpatchencoding", "url": "#format-2-patch-map-defaultpatchencoding", "dfnText": "defaultPatchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch-map-entrycount", "url": "#format-2-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entrycount"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entrycount\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-entries'] = {"dfnID": "format-2-patch-map-entries", "url": "#format-2-patch-map-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entries"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
@@ -2454,6 +2464,7 @@ window.dfnpanelData['mapping-entry-patchencoding'] = {"dfnID": "mapping-entry-pa
 window.dfnpanelData['mapping-entry-bias'] = {"dfnID": "mapping-entry-bias", "url": "#mapping-entry-bias", "dfnText": "bias", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-bias"}, {"id": "ref-for-mapping-entry-bias\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-codepoints'] = {"dfnID": "mapping-entry-codepoints", "url": "#mapping-entry-codepoints", "dfnText": "codepoints", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-codepoints"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['design-space-segment'] = {"dfnID": "design-space-segment", "url": "#design-space-segment", "dfnText": "Design Space Segment", "refSections": [{"refs": [{"id": "ref-for-design-space-segment"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map", "url": "#abstract-opdef-interpret-format-2-patch-map", "dfnText": "Interpret Format 2 Patch Map", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map"}], "title": "6. Extending a Font Subset"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map-entry'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map-entry", "url": "#abstract-opdef-interpret-format-2-patch-map-entry", "dfnText": "Interpret Format 2 Patch Map Entry", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['font-patch'] = {"dfnID": "font-patch", "url": "#font-patch", "dfnText": "font patch", "refSections": [{"refs": [{"id": "ref-for-font-patch"}, {"id": "ref-for-font-patch\u2460"}, {"id": "ref-for-font-patch\u2461"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-patch\u2462"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-format'] = {"dfnID": "patch-format", "url": "#patch-format", "dfnText": "patch format", "refSections": [{"refs": [{"id": "ref-for-patch-format"}, {"id": "ref-for-patch-format\u2460"}], "title": "5.1. Definitions"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="ba124498bafdaee859840129c51e97650d577ebe" name="document-revision">
+  <meta content="b1a98b06362c9a0973e7e10f6e525f01e5d428bc" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -762,9 +762,6 @@ only be loaded by a user agent which supports incremental font transfer.</p>
 }
 </pre>
    </div>
-   <p>@font-face’s that include the <code>incremental</code> tech keyword should also include a <a href="https://drafts.csswg.org/css-fonts-4/#unicode-range-desc">unicode-range descriptor</a>. This informs the client which codepoints
-are available in the font prior to making the first request, which can be used to avoid requesting
-the font unnecessarily.</p>
    <p class="note" role="note"><span class="marker">Note:</span> Each individual <code>@font-face</code> block may or may not opt-in to IFT. This is due to the
 variety of ways fonts are used on web pages. Authors have control over which fonts they want to use
 this technology with, and which they do not.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="5b984306400d9447e8181d6afafcd391dff21569" name="document-revision">
+  <meta content="9fb1a980a90ea075f6e2c8e234b1bb829dfa65b9" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -1973,7 +1973,7 @@ encode_node(full_font, base_font, cur_def, subset_definitions):
     let patch_url be a new unique url
 
     add a mapping from, (subset_def - cur_def) to patch_url, into base_font
-    next_font, patches += encode(full_font, next_font, next_def, subset_definitions)
+    next_font, patches += encode_node(full_font, next_font, next_def, subset_definitions)
 
     next_fonts += (next_font, next_def, patch_url)
 

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="899a2d6f5158e34644a4948f9be7a73afe964738" name="document-revision">
+  <meta content="d868067fb5c779321b4c240b08c9756087ab09fb" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -852,8 +852,8 @@ the two tables. The two new tables are used only in this specification and are n
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
 'IFTX' table. Those patches can make updates only to one of the mapping tables and avoid making conflicting updates.</p>
    <h3 class="heading settled" data-level="4.1" id="ift-and-woff2"><span class="secno">4.1. </span><span class="content">Incremental Font Transfer and WOFF2</span><a class="self-link" href="#ift-and-woff2"></a></h3>
-   <p><a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a> is a commonly used to encode fonts for transfer on the web. Incremental fonts can encoded with WOFF2 as long as special care is
-taken. If an incremental font will be encoded by WOFF2 for transfer:</p>
+   <p><a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a> is a commonly used to encode fonts for transfer on the web. Incremental fonts can be encoded with WOFF2 as long as special care
+is taken. If an incremental font will be encoded by WOFF2 for transfer:</p>
    <ol>
     <li data-md>
      <p>The incremental font should not make use of <a href="#brotli">§ 5.3 Brotli Patch</a> patches. The WOFF2 format does not guarantee the ordering of tables in

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="6809a70f82fd03910c3f636dc040a0ca8082c76f" name="document-revision">
+  <meta content="5b984306400d9447e8181d6afafcd391dff21569" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -1952,13 +1952,13 @@ subsetting a font is well understood and has multiple open-source implementation
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
 Any reachable data is retained in the generated font subset, while any unreachable data may be removed.</p>
-   <p>Example pseudo code for a very basic encoder implementation using a font subsetter:</p>
+   <p>In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only dependent patches:</p>
 <pre># Encodes a font (full_font) into an incremental font that starts at base_subset_def
 # and can incrementally add any of subset_definitions. Returns the IFT encoded font
 # and set of associated patches.
 encode_as_ift(full_font, base_subset_def, subset_definitions):
   base_font = subset(full_font, base_subset_def)
-  patches = encode_node(full_font, base_font, base_subset_def, subset_definitions)
+  base_font, patches  = encode_node(full_font, base_font, base_subset_def, subset_definitions)
   return base_font, patches
 
 # Update base_font to add all of the ift patch mappings to reach any of
@@ -1971,23 +1971,24 @@ encode_node(full_font, base_font, cur_def, subset_definitions):
     next_def = subset_def union cur_def
     next_font = subset(full_font, next_def)
     let patch_url be a new unique url
-    
-    add patch map entry into base_font from (subset_def - cur_def) to patch_url
-    patches += encode(full_font, next_font, next_def, subset_definitions)
+
+    add a mapping from, (subset_def - cur_def) to patch_url, into base_font
+    next_font, patches += encode(full_font, next_font, next_def, subset_definitions)
 
     next_fonts += (next_font, next_def, patch_url)
 
-  for each (next_font, next_def, patch_url):
+  for each (next_font, next_def, patch_url) in next_fonts:
     patch = dependent_patch_diff(base_font, next_font)
     patches += (patch, patch_url)
   
-  return patches
+  return base_font, patches
 </pre>
    <p>In this example implementation if the union of the input base subset definition and the list of subset definitions fully covers the input
-full font, and the subsetter implementation used correctly retains all functionality then the above implementation should meet the
+full font, and the subsetter implementation used correctly retains all functionality then, the above implementation should meet the
 requirements in <a href="#encoder">§ 7 Encoder</a> to be a neutral encoding. This basic encoder implementation is for demonstration purposes and not meant
-to be representative of all possible encoder implementations. Most encoders will likely be more complex and need to consider additional
-factors some of which are discussed in the remaining sections.</p>
+to be representative of all possible encoder implementations. Notably it does not make use of nor demonstrate utilizing independent
+patches. Most encoders will likely be more complex and need to consider additional factors some of which are discussed in the remaining
+sections.</p>
    <p><b>Choosing segmentations</b></p>
    <p>One of the most important and complex decisions an encoder needs to make is how to segment the data in the encoded font. To maximize
 efficiency the encoder should try and group data (eg. codepoints) that are commonly used together into the same segments. This will

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="be0c90d3cca3ed1fcdec7b6e1365c54d2b804e66" name="document-revision">
+  <meta content="761cefaf3b71762ee05e517452843ee124c2bd48" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -1170,7 +1170,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codepoints</dfn>[variable]
-      <td> Set of codepoints for this mapping. Encoded as a <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. 
+      <td> Set of codepoints for this mapping. Encoded as a <a data-link-type="dfn" href="#sparse-bit-set" id="ref-for-sparse-bit-set">Sparse Bit Set</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 4 and/or 5 is set. The length is
       determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 4.1.2.2 Sparse Bit Set</a>. 
    </table>
@@ -1315,7 +1315,7 @@ codepoint add the bias value to it and then add the result to the codepoint set 
 each node has a fixed number of children that recursively sub-divides an interval into equal partitions. A tree of height <i>H</i> with
 branching factor <i>B</i> can store set membership for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree
 is encoded into an array of bytes for transport.</p>
-   <p><dfn data-dfn-type="dfn" data-noexport id="sparse-bit-set">Sparse Bit Set<a class="self-link" href="#sparse-bit-set"></a></dfn> encoding:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sparse-bit-set">Sparse Bit Set</dfn> encoding:</p>
    <table>
     <tbody>
      <tr>
@@ -1325,8 +1325,8 @@ is encoded into an array of bytes for transport.</p>
      <tr>
       <td>uint8
       <td>header
-      <td>Bits 0 (least significant) and 1 encode the trees branch factor <i>B</i>. Bits 2 through 6 are a 5-bit unsigned integer which
-        encodes the value of <i>H</i>. Bit 7 is set to 0 and reserved for future use. 
+      <td>Bits 0 (least significant) and 1 encode the trees branch factor <i>B</i> via <a data-link-type="dfn" href="#branch-factor-encoding" id="ref-for-branch-factor-encoding">Branch Factor Encoding</a>. Bits 2 through 6 are a
+        5-bit unsigned integer which encodes the value of <i>H</i>. Bit 7 is set to 0 and reserved for future use. 
      <tr>
       <td>uint8
       <td>treeData[variable]
@@ -1335,7 +1335,7 @@ is encoded into an array of bytes for transport.</p>
    <p>The exact length of <var>treeData</var> is initially unknown, it’s length is determined by executing the decoding algorithm. When using
 branch factors of 2 or 4 the last node may only partially consume the bits in a byte. In that case all remaining bits are unused and
 ignored.</p>
-   <p><dfn data-dfn-type="dfn" data-noexport id="branch-factor-encoding">Branch Factor Encoding<a class="self-link" href="#branch-factor-encoding"></a></dfn>:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="branch-factor-encoding">Branch Factor Encoding</dfn>:</p>
    <table>
     <tbody>
      <tr>
@@ -2460,6 +2460,8 @@ window.dfnpanelData['design-space-segment-start'] = {"dfnID": "design-space-segm
 window.dfnpanelData['design-space-segment-end'] = {"dfnID": "design-space-segment-end", "url": "#design-space-segment-end", "dfnText": "end", "refSections": [{"refs": [{"id": "ref-for-design-space-segment-end"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map", "url": "#abstract-opdef-interpret-format-2-patch-map", "dfnText": "Interpret Format 2 Patch Map", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map"}], "title": "6. Extending a Font Subset"}], "external": false};
 window.dfnpanelData['abstract-opdef-interpret-format-2-patch-map-entry'] = {"dfnID": "abstract-opdef-interpret-format-2-patch-map-entry", "url": "#abstract-opdef-interpret-format-2-patch-map-entry", "dfnText": "Interpret Format 2 Patch Map Entry", "refSections": [{"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}], "title": "4.1.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}], "title": "4.1.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['sparse-bit-set'] = {"dfnID": "sparse-bit-set", "url": "#sparse-bit-set", "dfnText": "Sparse Bit Set", "refSections": [{"refs": [{"id": "ref-for-sparse-bit-set"}], "title": "4.1.2. Patch Map Table: Format 2"}], "external": false};
+window.dfnpanelData['branch-factor-encoding'] = {"dfnID": "branch-factor-encoding", "url": "#branch-factor-encoding", "dfnText": "Branch Factor Encoding", "refSections": [{"refs": [{"id": "ref-for-branch-factor-encoding"}], "title": "4.1.2.2. Sparse Bit Set"}], "external": false};
 window.dfnpanelData['font-patch'] = {"dfnID": "font-patch", "url": "#font-patch", "dfnText": "font patch", "refSections": [{"refs": [{"id": "ref-for-font-patch"}, {"id": "ref-for-font-patch\u2460"}, {"id": "ref-for-font-patch\u2461"}], "title": "5.1. Definitions"}, {"refs": [{"id": "ref-for-font-patch\u2462"}], "title": "7. Encoder"}], "external": false};
 window.dfnpanelData['patch-format'] = {"dfnID": "patch-format", "url": "#patch-format", "dfnText": "patch format", "refSections": [{"refs": [{"id": "ref-for-patch-format"}, {"id": "ref-for-patch-format\u2460"}], "title": "5.1. Definitions"}], "external": false};
 window.dfnpanelData['patch-application-algorithm'] = {"dfnID": "patch-application-algorithm", "url": "#patch-application-algorithm", "dfnText": "patch application algorithm", "refSections": [{"refs": [{"id": "ref-for-patch-application-algorithm"}], "title": "5.1. Definitions"}], "external": false};


### PR DESCRIPTION
- Further clarifies some of the text in the encoder section.
- Adds more of the text for encoder guidance.
- Cleans up a bunch of TODO's throughout.
- Change from "shared brotli" to "brotli"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/161.html" title="Last updated on Apr 12, 2024, 10:11 PM UTC (d90c786)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/161/545a4a1...d90c786.html" title="Last updated on Apr 12, 2024, 10:11 PM UTC (d90c786)">Diff</a>