### PR TITLE
Add text for the "Load a Patch File" algorithm.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1592,21 +1592,27 @@ The algorithm:
 
 <dfn abstract-op>Load patch file</dfn>
 
-<!-- TODO: when discussing how to load patches via URI's we need to define what they are relative too -->
-<!-- TODO: ref fetch spec like we did in the patch subset spec. -->
 <!-- TODO: consider requiring HTTPS (or disallowing HTTP specifically if we want to allow file:// and other url types) -->
 
 The inputs to this algorithm are:
 
-*   <var>URI</var>: a URI identifying the patch file to load.
+*   <var>Patch URI</var>: A [[rfc3986#section-4.1|URI Reference]] identifying the patch file to load. As a URI reference this may be a
+     relative path.
+
+*   <var>Incremental Font URI</var>: A [[rfc3986#section-4.3|Abslolute URI]] which identifies the incremental font which contains
+     the reference to <var>Patch URI</var>.
 
 The algorithm outputs:
 
-*   <var>patch file</var>: the patch file identified by <var>URI</var>.
+*   <var>patch file</var>: the content (bytes) identified by <var>Patch URI</var>.
 
 The algorithm:
 
-1.  TODO Coming soon.
+1.  Perform [[rfc3986#section-5|reference resolution]] on <var>Patch URI</var> using <var>Incremental Font URI</var> as the base URI to
+     produce the <var>target URI</var>.
+
+2.  Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers,
+     [[fetch]] should be used. Return the retrieved contents, or an error if the fetch resulted in an error.
 
 <dfn abstract-op>Handle errors</dfn>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1516,6 +1516,8 @@ The inputs to this algorithm are:
 
 * <var>font subset</var>: an [=incremental font|incremental=] [=font subset=].
 
+* <var>font subset URI</var>: an [[rfc3986#section-4.3|abslolute URI]] which identifies the location of <var>font subset</var>.
+
 * <var>target subset definition</var>: the [=font subset definition=] that the client wants to extend <var>font subset</var> to cover.
 
 The algorithm outputs:
@@ -1545,7 +1547,8 @@ The algorithm:
     exactly one of the [=dependent=] entries in <var>entry list</var> and remove all others. The criteria for selecting the single
     [=dependent=] entry is left up to the implementation to decide.
 
-7.  For each <var>entry</var> in <var>entry list</var> invoke [$Load patch file$] with the entries URI. Collect the returned patch
+7.  For each <var>entry</var> in <var>entry list</var> invoke [$Load patch file$] with the <var>font subset URI</var> as the
+    incremental font URI and the entries URI as the patch URI. Collect the returned patch
     files into <var>patch list</var>.
 
 8.  For each <var>patch</var> in <var>patch list</var> use the appropriate application algorithm (matching the patches format) from
@@ -1599,7 +1602,7 @@ The inputs to this algorithm are:
 *   <var>Patch URI</var>: A [[rfc3986#section-4.1|URI Reference]] identifying the patch file to load. As a URI reference this may be a
      relative path.
 
-*   <var>Incremental Font URI</var>: A [[rfc3986#section-4.3|Abslolute URI]] which identifies the incremental font which contains
+*   <var>Incremental Font URI</var>: An [[rfc3986#section-4.3|abslolute URI]] which identifies the incremental font which contains
      the reference to <var>Patch URI</var>.
 
 The algorithm outputs:

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="0793b5645769ed5afc324993e7c3a641cabe0fcb" name="document-revision">
+  <meta content="25b4515039af382dc06787ed8657942ee3305791" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-03-07">7 March 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-09">9 April 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1845,17 +1845,24 @@ the implementation.</p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>URI</var>: a URI identifying the patch file to load.</p>
+     <p><var>Patch URI</var>: A <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.1">URI Reference</a> identifying the patch file to load. As a URI reference this may be a
+ relative path.</p>
+    <li data-md>
+     <p><var>Incremental Font URI</var>: A <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">Abslolute URI</a> which identifies the incremental font which contains
+ the reference to <var>Patch URI</var>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>patch file</var>: the patch file identified by <var>URI</var>.</p>
+     <p><var>patch file</var>: the content (bytes) identified by <var>Patch URI</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>TODO Coming soon.</p>
+     <p>Perform <a href="https://www.rfc-editor.org/rfc/rfc3986#section-5">reference resolution</a> on <var>Patch URI</var> using <var>Incremental Font URI</var> as the base URI to
+ produce the <var>target URI</var>.</p>
+    <li data-md>
+     <p>Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers, <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[fetch]</a> should be used. Return the retrieved contents, or an error if the fetch resulted in an error.</p>
    </ol>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-errors">Handle errors</dfn></p>
    <p>Coming soon.</p>
@@ -2174,6 +2181,8 @@ required too many patches.</p>
    <dd>Chris Lilley. <a href="https://www.w3.org/TR/PFE-evaluation/"><cite>Progressive Font Enrichment: Evaluation Report</cite></a>. 15 October 2020. Note. URL: <a href="https://www.w3.org/TR/PFE-evaluation/">https://www.w3.org/TR/PFE-evaluation/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
+   <dt id="biblio-rfc3986">[RFC3986]
+   <dd>T. Berners-Lee; R. Fielding; L. Masinter. <a href="https://www.rfc-editor.org/rfc/rfc3986"><cite>Uniform Resource Identifier (URI): Generic Syntax</cite></a>. January 2005. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3986">https://www.rfc-editor.org/rfc/rfc3986</a>
    <dt id="biblio-rfc6570">[RFC6570]
    <dd>J. Gregorio; et al. <a href="https://www.rfc-editor.org/rfc/rfc6570"><cite>URI Template</cite></a>. March 2012. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc6570">https://www.rfc-editor.org/rfc/rfc6570</a>
    <dt id="biblio-rfc7932">[RFC7932]
@@ -2185,6 +2194,8 @@ required too many patches.</p>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
+   <dt id="biblio-fetch">[FETCH]
+   <dd><a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. 22 May 2023. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-woff2">[WOFF2]
    <dd>Vladimir Levantovsky; Raph Levien. <a href="https://w3c.github.io/woff/woff2/"><cite>WOFF File Format 2.0</cite></a>. URL: <a href="https://w3c.github.io/woff/woff2/">https://w3c.github.io/woff/woff2/</a>
   </dl>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="25b4515039af382dc06787ed8657942ee3305791" name="document-revision">
+  <meta content="48ab68d74d660e40e74c6cfbae7c6393676b0342" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -1771,6 +1771,8 @@ codepoints, layout features and/or design space.</p>
     <li data-md>
      <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a>.</p>
     <li data-md>
+     <p><var>font subset URI</var>: an <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the location of <var>font subset</var>.</p>
+    <li data-md>
      <p><var>target subset definition</var>: the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑥">font subset definition</a> that the client wants to extend <var>font subset</var> to cover.</p>
    </ul>
    <p>The algorithm outputs:</p>
@@ -1797,7 +1799,8 @@ invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-
      <p>If <var>entry list</var> contains one or more <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">patch map entries</a> which have a patch format that is <a data-link-type="dfn" href="#dependent" id="ref-for-dependent②">dependent</a>, then select
 exactly one of the <a data-link-type="dfn" href="#dependent" id="ref-for-dependent③">dependent</a> entries in <var>entry list</var> and remove all others. The criteria for selecting the single <a data-link-type="dfn" href="#dependent" id="ref-for-dependent④">dependent</a> entry is left up to the implementation to decide.</p>
     <li data-md>
-     <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the entries URI. Collect the returned patch
+     <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>font subset URI</var> as the
+incremental font URI and the entries URI as the patch URI. Collect the returned patch
 files into <var>patch list</var>.</p>
     <li data-md>
      <p>For each <var>patch</var> in <var>patch list</var> use the appropriate application algorithm (matching the patches format) from <a href="#font-patch-formats">§ 5 Font Patch Formats</a> to apply the <var>patch</var> to <var>extended font subset</var>. The order of patch application is left up to
@@ -1848,7 +1851,7 @@ the implementation.</p>
      <p><var>Patch URI</var>: A <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.1">URI Reference</a> identifying the patch file to load. As a URI reference this may be a
  relative path.</p>
     <li data-md>
-     <p><var>Incremental Font URI</var>: A <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">Abslolute URI</a> which identifies the incremental font which contains
+     <p><var>Incremental Font URI</var>: An <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the incremental font which contains
  the reference to <var>Patch URI</var>.</p>
    </ul>
    <p>The algorithm outputs:</p>


### PR DESCRIPTION
This defines patch URI's as URI references which may be relative. Relative references use the containing incremental font URI as the base URI.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/162.html" title="Last updated on Apr 9, 2024, 10:38 PM UTC (5ee2cea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/162/25b4515...5ee2cea.html" title="Last updated on Apr 9, 2024, 10:38 PM UTC (5ee2cea)">Diff</a>