### PR TITLE
Add optional ID string mapping to format 2.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -668,7 +668,7 @@ The algorithm:
     </td>
   </tr>
   <tr>
-    <td>uint16</td> <!-- TODO: uint32 to match format 1? -->
+    <td>uint24</td>
     <td><dfn for="Format 2 Patch Map">entryCount</dfn></td>
     <td>Number of entries encoded in this table.</td>
   </tr>
@@ -739,7 +739,7 @@ The algorithm:
   </tr>
 
   <tr>
-    <td>uint8</td>
+    <td>uint16</td>
     <td><dfn for="Mapping Entry">designSpaceCount</dfn></td>
     <td>
       Number of elements in the design space list. Only present if [=Mapping Entry/formatFlags=] bit 0 is set.
@@ -761,7 +761,7 @@ The algorithm:
     </td>
   </tr>
   <tr>
-    <td>uint16</td>
+    <td>uint24</td>
     <td><dfn for="Mapping Entry">copyIndices</dfn>[copyCount]</td>
     <td>
       List of indices from the [=Mapping Entries/entries=] array whose [=font subset definition=] should be copied into this entry. All
@@ -771,7 +771,7 @@ The algorithm:
   </tr>
 
   <tr>
-    <td>int16</td>
+    <td>int24</td>
     <td><dfn for="Mapping Entry">entryIdDelta</dfn></td>
     <td>
       Signed delta which is used to calculate the id for this entry. The id for this entry is the entry id of the previous

--- a/Overview.bs
+++ b/Overview.bs
@@ -285,29 +285,29 @@ in [[open-type/otff#data-types]]. As with the rest of OpenType, all fields use "
 URI Templates {#uri-templates}
 ------------------------------
 
-URI templates [[!rfc6570]] are used to convert numeric indices into URIs where patch files are located. Given a numeric index value,
-several variables are defined which are used to produce the expansion of the template:
+URI templates [[!rfc6570]] are used to convert numeric or string ids into URIs where patch files are located. Several variables are
+defined which are used to produce the expansion of the template:
 
 <table>
   <tr><th>Variable</th><th>Value</th></tr>
   <tr>
     <td>id</td>
     <td>
-      The numeric index value converted to a string in hexadecimal representation (using the digits 0-9, A-F). No padding with 0's is
-      used.
+      If the input id is numeric then this is the  numeric value converted to a string in hexadecimal representation
+      (using the digits 0-9, A-F). No padding with 0's is used. Otherwise, this is the string id value.
     </td>
   </tr>
   <tr>
-    <td>d1</td><td>The first digit (least significant digit) of the numeric index in hexadecimal.</td>
+    <td>d1</td><td>The last character of the string in the id variable.</td>
   </tr>
   <tr>
-    <td>d2</td><td>The second digit of the numeric index in hexadecimal, or 0 if the index does not have a second digit</td>
+    <td>d2</td><td>The second last character of the string in the id variable.</td>
   </tr>
   <tr>
-    <td>d3</td><td>The third digit of the numeric index in hexadecimal, or 0 if the index does not have a third digit</td>
+    <td>d3</td><td>The third last character of the string in the id variable.</td>
   </tr>
   <tr>
-    <td>d4</td><td>The fourth digit of the numeric index in hexadecimal, or 0 if the index does not have a fourth digit</td>
+    <td>d4</td><td>The fourth last character of the string in the id variable.</td>
   </tr>
 </table>
 
@@ -316,7 +316,7 @@ several variables are defined which are used to produce the expansion of the tem
 Some example inputs and the corresponding expansions:
 
 <table>
-  <tr><th>Template</th><th>Input Index</th><th>Expansion</th></tr>
+  <tr><th>Template</th><th>Input ID</th><th>Expansion</th></tr>
   <tr>
     <td>//foo.bar/{id}</td>
     <td>123</td>
@@ -331,6 +331,11 @@ Some example inputs and the corresponding expansions:
     <td>//foo.bar{/d1,d2,d3,id}</td>
     <td>123</td>
     <td>//foo.bar/B/7/0/7B</td>
+  </tr>
+    <tr>
+    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>baz</td>
+    <td>//foo.bar/z/a/b/baz</td>
   </tr>
 </table>
 
@@ -678,6 +683,14 @@ The algorithm:
     <td>Offset to a [=Mapping Entries=] sub table. Offset is from the start of this table.</td>
   </tr>
   <tr>
+    <td>Offset32</td>
+    <td><dfn for="Format 2 Patch Map">entryIdStringData</dfn></td>
+    <td>
+      Offset to a block of data containing the concatentation of all of the entry ID strings.
+      May be null (0). Offset is from the start of this table.
+    </td>
+  </tr>
+  <tr>
     <td>uint16</td>
     <td>uriTemplateLength</td>
     <td>
@@ -775,8 +788,17 @@ The algorithm:
     <td><dfn for="Mapping Entry">entryIdDelta</dfn></td>
     <td>
       Signed delta which is used to calculate the id for this entry. The id for this entry is the entry id of the previous
-      [=Mapping Entry=] + 1 + entryIdDelta. Only present if [=Mapping Entry/formatFlags=] bit 2 is set. If not present delta is assumed
-      to be 0.
+      [=Mapping Entry=] + 1 + entryIdDelta. Only present if [=Mapping Entry/formatFlags=] bit 2 is set and
+      [=Format 2 Patch Map/entryIdStringData=] is null (0). If not present delta is assumed to be 0.
+    </td>
+  </tr>
+  <tr>
+    <td>uint16</td>
+    <td><dfn for="Mapping Entry">entryIdStringLength</dfn></td>
+    <td>
+      The number of bytes that the id string for this entry occupies in the [=Format 2 Patch Map/entryIdStringData=] data block.
+      Strings are encoded in [[UTF-8]]. Only present if [=Mapping Entry/formatFlags=] bit 2 is set and
+      [=Format 2 Patch Map/entryIdStringData=] is not null (0). If not present the length is assumed to be 0.
     </td>
   </tr>
 
@@ -789,7 +811,6 @@ The algorithm:
       Only present if [=Mapping Entry/formatFlags=] bit 3 is set.
     </td>
   </tr>
-
 
   <tr>
     <td>uint16/uint24</td>
@@ -867,12 +888,14 @@ The algorithm:
 1.  Check that the <var>patch map</var> has [=Format 2 Patch Map/format=] equal to 2 and is valid according to the requirements in
      [[#patch-map-format-2]]. If it is not return an error.
 
-2.  Initialize <var>last entry id</var> to 0, and <var>current byte</var> to 0.
+2.  Initialize <var>last entry id</var> to 0, <var>current byte</var> to 0, and <var>current id string byte</var> to 0.
 
 3.  Invoke [$Interpret Format 2 Patch Map Entry$], [=Format 2 Patch Map/entryCount=] times. For each invocation:
 
      *  pass in the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entries=][<var>current byte</var>] to
          the end of <var>patch map</var>,
+         the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entryIdStringData=][<var>current id string byte</var>]
+         to the end of <var>patch map</var> if [=Format 2 Patch Map/entryIdStringData=] is non zero,
          <var>last entry id</var>,
          [=Format 2 Patch Map/defaultPatchEncoding=], and
          [=Format 2 Patch Map/uriTemplate=].
@@ -880,6 +903,8 @@ The algorithm:
      *  Set <var>last entry id</var> to the returned entry id.
 
      *  Add the returned consumed byte count to <var>current byte</var>.
+
+     *  Add the returned consumed id string byte count to <var>current id string byte</var>.
 
      *  If the returned value of ignored is false, then add the returned entry to <var>entry list</var>.
 
@@ -891,6 +916,8 @@ The inputs to this algorithm are:
 
 * <var>entry bytes</var>: a byte array that contains an encoded [=Mapping Entry=].
 
+* <var>id string bytes</var> (optional): a byte array the contains entry ID strings.
+
 * <var>last entry id</var>: the entry id of the entry preceding this one.
 
 * <var>default patch encoding</var>: the default patch encoding if one isn't specified.
@@ -899,11 +926,13 @@ The inputs to this algorithm are:
 
 The algorithm outputs:
 
-* <var>entry id</var>: the numeric id of this entry.
+* <var>entry id</var>: the numeric or string id of this entry.
 
 * <var>entry</var>: a single [=patch map entries|entry=].
 
 * <var>consumed bytes</var>: the number of bytes used to encode the entry.
+
+* <var>consumed id string bytes</var>: the number of bytes used to encode the entry id string.
 
 * <var>ignored</var>: if true, then this entry should be ignored.
 
@@ -912,7 +941,7 @@ The algorithm:
 1.  For the all steps whenever data is loaded from <var>entry bytes</var> increment <var>consumed bytes</var> with the
      number of bytes read.
 
-2.  Set <var>entry id</var> = <var>last entry id</var> + 1.
+2.  If <var>id string bytes</var> is not present then, set <var>entry id</var> = <var>last entry id</var> + 1.
 
 3.  Set the patch encoding of <var>entry</var> to <var>default patch encoding</var>.
 
@@ -935,9 +964,14 @@ The algorithm:
          and so on. For each index in [=Mapping Entry/copyIndices=] locate the previously loaded entry with a matching index and
          add all code points, feature tags, and design space segments from it to <var>entry</var>.
 
-7.  If [=Mapping Entry/formatFlags=] bit 2 is set, then an id delta is present. Read the id delta specified by [=Mapping Entry/entryIdDelta=]
-     from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
-     and the mapping is malformed.
+7.  If [=Mapping Entry/formatFlags=] bit 2 is set, then an id delta or id string length is present:
+
+    *  If <var>id string bytes</var> is not present then, read the id delta specified by [=Mapping Entry/entryIdDelta=]
+        from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
+        and the mapping is malformed.
+
+    *  Otherwise if <var>id string bytes</var> is present then, read [=Mapping Entry/entryIdStringLength=] bytes from
+        <var>id string bytes</var> and interpret the bytes as a [[UTF-8]] string. Set <var>entry id</var> to the result.
 
 8.  If [=Mapping Entry/formatFlags=] bit 3 is set, then a patch encoding is present. Read the encoding specified by
      [=Mapping Entry/patchEncoding=] from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.
@@ -960,7 +994,8 @@ The algorithm:
 11. Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]]. Set the patch uri of
      <var>entry</var> to the generated URI.
 
-12. Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, and <var>ignored</var>.
+12. Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, [=Mapping Entry/entryIdStringLength=] as
+     <var>consumed id string bytes</var>, and <var>ignored</var>.
 
 <h5 algorithm id="sparse-bit-set-decoding">Sparse Bit Set</h5>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -845,9 +845,16 @@ The algorithm:
   </tr>
 </table>
 
+If an encoder is producing patches that will be stored on a file system and then served it's recommended that only numeric entry IDs be
+used (via [=Mapping Entry/entryIdDelta=]) as these will generally produce the smallest encoding of the format 2 patch map. String IDs
+are useful in cases where patches are not being stored in advance and the ID strings can be then used to encode information about the patch
+being requested.
+
 If an encoder is using string IDs via [=Format 2 Patch Map/entryIdStringData=] and  [=Mapping Entry/entryIdStringLength=] then, the
-encoder should only use [[rfc3986#section-2.3|unreserved uri characters]] in the ID strings to prevent the need for percent encoding of
-the ID values when expanding the URI templates.
+encoder should only use [[rfc3986#section-2.3|unreserved uri characters]] in the ID strings. This will prevent the need for percent
+encoding of the ID values when expanding the URI templates and maximize compatibility of the URLs and associated file names. Particularly,
+if patch files are to be stored on a file system which does not support unicode encoded file names or is case insensitive then special care
+needs to be taken when choosing the set of characters to use in the file names.
 
 <dfn>Design Space Segment</dfn> encoding:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -285,8 +285,10 @@ in [[open-type/otff#data-types]]. As with the rest of OpenType, all fields use "
 URI Templates {#uri-templates}
 ------------------------------
 
-URI templates [[!rfc6570]] are used to convert numeric or string ids into URIs where patch files are located. Several variables are
-defined which are used to produce the expansion of the template:
+URI templates [[!rfc6570]] are used to convert numeric or string IDs into URIs where patch files are located.
+A string ID is a sequence of [[!unicode|Unicode]] code point values obtained from decoding a
+[[UTF-8]] string (see [[rfc6570#section-1.6]]). Several variables are defined which are used to produce the
+expansion of the template:
 
 <table>
   <tr><th>Variable</th><th>Value</th></tr>
@@ -310,6 +312,10 @@ defined which are used to produce the expansion of the template:
     <td>d4</td><td>The fourth last character of the string in the id variable.</td>
   </tr>
 </table>
+
+The variables d1 through d4 select a specific character of the id variable. In this context a character is a [[!unicode]] code point.
+If the code point is not an ASCII code point then during expansion it will need to be converted to
+[[UTF-8]] and percent encoded as required by [[rfc6570#section-1.6]].
 
 <div class="example">
 
@@ -336,6 +342,12 @@ Some example inputs and the corresponding expansions:
     <td>//foo.bar{/d1,d2,d3,id}</td>
     <td>baz</td>
     <td>//foo.bar/z/a/b/baz</td>
+  </tr>
+  </tr>
+    <tr>
+    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>àbc</td>
+    <td>//foo.bar/c/b/%C3%A0/%C3%A0bc</td>
   </tr>
 </table>
 
@@ -832,6 +844,10 @@ The algorithm:
     </td>
   </tr>
 </table>
+
+If an encoder is using string IDs via [=Format 2 Patch Map/entryIdStringData=] and  [=Mapping Entry/entryIdStringLength=] then, the
+encoder should only use [[rfc3986#section-2.3|unreserved uri characters]] in the ID strings to prevent the need for percent encoding of
+the ID values when expanding the URI templates.
 
 <dfn>Design Space Segment</dfn> encoding:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -300,16 +300,32 @@ expansion of the template:
     </td>
   </tr>
   <tr>
-    <td>d1</td><td>The last character of the string in the id variable.</td>
+    <td>d1</td>
+    <td>
+      The last character of the string in the id variable.
+      If id variable is empty then, the value is the character 0 (U+0030).
+    </td>
   </tr>
   <tr>
-    <td>d2</td><td>The second last character of the string in the id variable.</td>
+    <td>d2</td>
+    <td>
+      The second last character of the string in the id variable.
+      If the id variable has less than 2 characters then, the value is the character 0 (U+0030).
+    </td>
   </tr>
   <tr>
-    <td>d3</td><td>The third last character of the string in the id variable.</td>
+    <td>d3</td>
+    <td>
+      The third last character of the string in the id variable.
+      If the id variable has less than 3 characters then, the value is the character 0 (U+0030).
+    </td>
   </tr>
   <tr>
-    <td>d4</td><td>The fourth last character of the string in the id variable.</td>
+    <td>d4</td>
+    <td>
+      The fourth last character of the string in the id variable.
+      If the id variable has less than 4 characters then, the value is the character 0 (U+0030).
+    </td>
   </tr>
 </table>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -362,6 +362,12 @@ Some example inputs and the corresponding expansions:
   </tr>
     <tr>
     <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>az</td>
+    <td>//foo.bar/z/a/0/az</td>
+  </tr>
+  </tr>
+    <tr>
+    <td>//foo.bar{/d1,d2,d3,id}</td>
     <td>àbc</td>
     <td>//foo.bar/c/b/%C3%A0/%C3%A0bc</td>
   </tr>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="e7442421fd81ce94e416f70764295eba71cc1dcb" name="document-revision">
+  <meta content="72a27ee056df2d9e18ce0cb66e6066872b0abb18" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-16">16 April 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-17">17 April 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1210,9 +1210,15 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑨">formatFlags</a> bit 4 and/or 5 is set. The length is
       determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 4.2.2.2 Sparse Bit Set</a>. 
    </table>
+   <p>If an encoder is producing patches that will be stored on a file system and then served it’s recommended that only numeric entry IDs be
+used (via <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a>) as these will generally produce the smallest encoding of the format 2 patch map. String IDs
+are useful in cases where patches are not being stored in advance and the ID strings can be then used to encode information about the patch
+being requested.</p>
    <p>If an encoder is using string IDs via <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a> and <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength">entryIdStringLength</a> then, the
-encoder should only use <a href="https://www.rfc-editor.org/rfc/rfc3986#section-2.3">unreserved uri characters</a> in the ID strings to prevent the need for percent encoding of
-the ID values when expanding the URI templates.</p>
+encoder should only use <a href="https://www.rfc-editor.org/rfc/rfc3986#section-2.3">unreserved uri characters</a> in the ID strings. This will prevent the need for percent
+encoding of the ID values when expanding the URI templates and maximize compatibility of the URLs and associated file names. Particularly,
+if patch files are to be stored on a file system which does not support unicode encoded file names or is case insensitive then special care
+needs to be taken when choosing the set of characters to use in the file names.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="design-space-segment">Design Space Segment</dfn> encoding:</p>
    <table>
     <tbody>
@@ -1334,7 +1340,7 @@ the ID values when expanding the URI templates.</p>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①③">formatFlags</a> bit 2 is set, then an id delta or id string length is present:</p>
      <ul>
       <li data-md>
-       <p>If <var>id string bytes</var> is not present then, read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
+       <p>If <var>id string bytes</var> is not present then, read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta①">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
 and the mapping is malformed.</p>
       <li data-md>
        <p>Otherwise if <var>id string bytes</var> is present then, read <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength①">entryIdStringLength</a> bytes from <var>id string bytes</var> and interpret the bytes as a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> string. Set <var>entry id</var> to the result.</p>
@@ -2522,7 +2528,7 @@ window.dfnpanelData['mapping-entry-designspacecount'] = {"dfnID": "mapping-entry
 window.dfnpanelData['mapping-entry-designspacesegments'] = {"dfnID": "mapping-entry-designspacesegments", "url": "#mapping-entry-designspacesegments", "dfnText": "designSpaceSegments", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacesegments"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-copycount'] = {"dfnID": "mapping-entry-copycount", "url": "#mapping-entry-copycount", "dfnText": "copyCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copycount"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-copyindices'] = {"dfnID": "mapping-entry-copyindices", "url": "#mapping-entry-copyindices", "dfnText": "copyIndices", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copyindices"}, {"id": "ref-for-mapping-entry-copyindices\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-entryiddelta'] = {"dfnID": "mapping-entry-entryiddelta", "url": "#mapping-entry-entryiddelta", "dfnText": "entryIdDelta", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryiddelta"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-entryiddelta'] = {"dfnID": "mapping-entry-entryiddelta", "url": "#mapping-entry-entryiddelta", "dfnText": "entryIdDelta", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryiddelta"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-entryiddelta\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-entryidstringlength'] = {"dfnID": "mapping-entry-entryidstringlength", "url": "#mapping-entry-entryidstringlength", "dfnText": "entryIdStringLength", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryidstringlength"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-entryidstringlength\u2460"}, {"id": "ref-for-mapping-entry-entryidstringlength\u2461"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-patchencoding'] = {"dfnID": "mapping-entry-patchencoding", "url": "#mapping-entry-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-patchencoding"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-bias'] = {"dfnID": "mapping-entry-bias", "url": "#mapping-entry-bias", "dfnText": "bias", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-bias"}, {"id": "ref-for-mapping-entry-bias\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="6f5387f0d9d44e81dd829116a76ff54c5ea9a69a" name="document-revision">
+  <meta content="1254c302c3b6b2cab2e75f83a346c5821847f3c9" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -796,8 +796,8 @@ variation axis space) that a <a data-link-type="dfn" href="#font-subset" id="ref
    <p>Encoded data structures in the remainder of this specification are described in terms of the data types defined
 in <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types">OpenType Specification § otff#data-types</a>. As with the rest of OpenType, all fields use "big-endian" byte ordering.</p>
    <h3 class="heading settled" data-level="3.3" id="uri-templates"><span class="secno">3.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h3>
-   <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric indices into URIs where patch files are located. Given a numeric index value,
-several variables are defined which are used to produce the expansion of the template:</p>
+   <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string ids into URIs where patch files are located. Several variables are
+defined which are used to produce the expansion of the template:</p>
    <table>
     <tbody>
      <tr>
@@ -805,29 +805,29 @@ several variables are defined which are used to produce the expansion of the tem
       <th>Value
      <tr>
       <td>id
-      <td> The numeric index value converted to a string in hexadecimal representation (using the digits 0-9, A-F). No padding with 0’s is
-      used. 
+      <td> If the input id is numeric then this is the  numeric value converted to a string in hexadecimal representation
+      (using the digits 0-9, A-F). No padding with 0’s is used. Otherwise, this is the string id value. 
      <tr>
       <td>d1
-      <td>The first digit (least significant digit) of the numeric index in hexadecimal.
+      <td>The last character of the string in the id variable.
      <tr>
       <td>d2
-      <td>The second digit of the numeric index in hexadecimal, or 0 if the index does not have a second digit
+      <td>The second last character of the string in the id variable.
      <tr>
       <td>d3
-      <td>The third digit of the numeric index in hexadecimal, or 0 if the index does not have a third digit
+      <td>The third last character of the string in the id variable.
      <tr>
       <td>d4
-      <td>The fourth digit of the numeric index in hexadecimal, or 0 if the index does not have a fourth digit
+      <td>The fourth last character of the string in the id variable.
    </table>
-   <div class="example" id="example-2dff77c0">
-    <a class="self-link" href="#example-2dff77c0"></a> 
+   <div class="example" id="example-9169b4ee">
+    <a class="self-link" href="#example-9169b4ee"></a> 
     <p>Some example inputs and the corresponding expansions:</p>
     <table>
      <tbody>
       <tr>
        <th>Template
-       <th>Input Index
+       <th>Input ID
        <th>Expansion
       <tr>
        <td>//foo.bar/{id}
@@ -841,6 +841,10 @@ several variables are defined which are used to produce the expansion of the tem
        <td>//foo.bar{/d1,d2,d3,id}
        <td>123
        <td>//foo.bar/B/7/0/7B
+      <tr>
+       <td>//foo.bar{/d1,d2,d3,id}
+       <td>baz
+       <td>//foo.bar/z/a/b/baz
     </table>
    </div>
    <h2 class="heading settled" data-level="4" id="font-format-extensions"><span class="secno">4. </span><span class="content">Extensions to the Font Format</span><a class="self-link" href="#font-format-extensions"></a></h2>
@@ -1107,6 +1111,11 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entries">entries</dfn>
       <td>Offset to a <a data-link-type="dfn" href="#mapping-entries" id="ref-for-mapping-entries">Mapping Entries</a> sub table. Offset is from the start of this table.
      <tr>
+      <td>Offset32
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entryidstringdata">entryIdStringData</dfn>
+      <td> Offset to a block of data containing the concatentation of all of the entry ID strings.
+      May be null (0). Offset is from the start of this table. 
+     <tr>
       <td>uint16
       <td>uriTemplateLength
       <td> Length of the uriTemplate string. 
@@ -1168,14 +1177,18 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <tr>
       <td>int24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>
-      <td> Signed delta which is used to calculate the id for this entry. The id for this entry is the entry id of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> + 1 + entryIdDelta. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set. If not present delta is assumed
-      to be 0. 
+      <td> Signed delta which is used to calculate the id for this entry. The id for this entry is the entry id of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> + 1 + entryIdDelta. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0). If not present delta is assumed to be 0. 
+     <tr>
+      <td>uint16
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryidstringlength">entryIdStringLength</dfn>
+      <td> The number of bytes that the id string for this entry occupies in the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata①">entryIdStringData</a> data block.
+      Strings are encoded in <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑦">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata②">entryIdStringData</a> is not null (0). If not present the length is assumed to be 0. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchencoding">patchEncoding</dfn>
       <td> Specifies the format of the patch linked to by this entry. Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table.
       Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a>.
-      Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑦">formatFlags</a> bit 3 is set. 
+      Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 3 is set. 
      <tr>
       <td>uint16/uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-bias">bias</dfn>
@@ -1187,7 +1200,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codepoints</dfn>[variable]
       <td> Set of codepoints for this mapping. Encoded as a <a data-link-type="dfn" href="#sparse-bit-set" id="ref-for-sparse-bit-set">Sparse Bit Set</a>.
-      Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 4 and/or 5 is set. The length is
+      Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑨">formatFlags</a> bit 4 and/or 5 is set. The length is
       determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 4.2.2.2 Sparse Bit Set</a>. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="design-space-segment">Design Space Segment</dfn> encoding:</p>
@@ -1230,17 +1243,21 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
     <li data-md>
      <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 4.2.2 Patch Map Table: Format 2</a>. If it is not return an error.</p>
     <li data-md>
-     <p>Initialize <var>last entry id</var> to 0, and <var>current byte</var> to 0.</p>
+     <p>Initialize <var>last entry id</var> to 0, <var>current byte</var> to 0, and <var>current id string byte</var> to 0.</p>
     <li data-md>
      <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry①">Interpret Format 2 Patch Map Entry</a>, <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount①">entryCount</a> times. For each invocation:</p>
      <ul>
       <li data-md>
        <p>pass in the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
- the end of <var>patch map</var>, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding①">defaultPatchEncoding</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
+ the end of <var>patch map</var>,
+ the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a>[<var>current id string byte</var>]
+ to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding①">defaultPatchEncoding</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
        <p>Add the returned consumed byte count to <var>current byte</var>.</p>
+      <li data-md>
+       <p>Add the returned consumed id string byte count to <var>current id string byte</var>.</p>
       <li data-md>
        <p>If the returned value of ignored is false, then add the returned entry to <var>entry list</var>.</p>
      </ul>
@@ -1253,6 +1270,8 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
     <li data-md>
      <p><var>entry bytes</var>: a byte array that contains an encoded <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry③">Mapping Entry</a>.</p>
     <li data-md>
+     <p><var>id string bytes</var> (optional): a byte array the contains entry ID strings.</p>
+    <li data-md>
      <p><var>last entry id</var>: the entry id of the entry preceding this one.</p>
     <li data-md>
      <p><var>default patch encoding</var>: the default patch encoding if one isn’t specified.</p>
@@ -1262,11 +1281,13 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>entry id</var>: the numeric id of this entry.</p>
+     <p><var>entry id</var>: the numeric or string id of this entry.</p>
     <li data-md>
      <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a>.</p>
     <li data-md>
      <p><var>consumed bytes</var>: the number of bytes used to encode the entry.</p>
+    <li data-md>
+     <p><var>consumed id string bytes</var>: the number of bytes used to encode the entry id string.</p>
     <li data-md>
      <p><var>ignored</var>: if true, then this entry should be ignored.</p>
    </ul>
@@ -1276,13 +1297,13 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
      <p>For the all steps whenever data is loaded from <var>entry bytes</var> increment <var>consumed bytes</var> with the
  number of bytes read.</p>
     <li data-md>
-     <p>Set <var>entry id</var> = <var>last entry id</var> + 1.</p>
+     <p>If <var>id string bytes</var> is not present then, set <var>entry id</var> = <var>last entry id</var> + 1.</p>
     <li data-md>
      <p>Set the patch encoding of <var>entry</var> to <var>default patch encoding</var>.</p>
     <li data-md>
-     <p>Read <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑨">formatFlags</a> from <var>entry bytes</var>.</p>
+     <p>Read <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⓪">formatFlags</a> from <var>entry bytes</var>.</p>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⓪">formatFlags</a> bit 0 is set, then the feature tag and design space lists are present:</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①①">formatFlags</a> bit 0 is set, then the feature tag and design space lists are present:</p>
      <ul>
       <li data-md>
        <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to <var>entry</var>.</p>
@@ -1290,7 +1311,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
        <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to <var>entry</var>. Each segment defines an interval from <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start">start</a> to <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end">end</a> inclusive for the axis identified by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-space-segment-tag">tag</a>.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①①">formatFlags</a> bit 1 is set, then the copy indices list is present:</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①②">formatFlags</a> bit 1 is set, then the copy indices list is present:</p>
      <ul>
       <li data-md>
        <p>Read the copy indices list specified by <a data-link-type="dfn" href="#mapping-entry-copycount" id="ref-for-mapping-entry-copycount">copyCount</a> and <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices">copyIndices</a> from <var>entry bytes</var>.</p>
@@ -1300,18 +1321,24 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
  add all code points, feature tags, and design space segments from it to <var>entry</var>.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①②">formatFlags</a> bit 2 is set, then an id delta is present. Read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
- and the mapping is malformed.</p>
-    <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①③">formatFlags</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.</p>
-    <li data-md>
-     <p>If one or both of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①④">formatFlags</a> bit 4 and bit 5 are set, then a codepoint list is present:</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①③">formatFlags</a> bit 2 is set, then an id delta or id string length is present:</p>
      <ul>
       <li data-md>
-       <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑤">formatFlags</a> bit 4 is 0 and bit 5 is 1, then read the 2 byte (uint16) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias">bias</a> value
+       <p>If <var>id string bytes</var> is not present then, read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
+and the mapping is malformed.</p>
+      <li data-md>
+       <p>Otherwise if <var>id string bytes</var> is present then, read <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength">entryIdStringLength</a> bytes from <var>id string bytes</var> and interpret the bytes as a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> string. Set <var>entry id</var> to the result.</p>
+     </ul>
+    <li data-md>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①④">formatFlags</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.</p>
+    <li data-md>
+     <p>If one or both of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑤">formatFlags</a> bit 4 and bit 5 are set, then a codepoint list is present:</p>
+     <ul>
+      <li data-md>
+       <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑥">formatFlags</a> bit 4 is 0 and bit 5 is 1, then read the 2 byte (uint16) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias">bias</a> value
 from <var>entry bytes</var>.</p>
       <li data-md>
-       <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑥">formatFlags</a> bit 4 is 1 and bit 5 is 1, then read the 3 byte (uint24) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias①">bias</a> value
+       <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑦">formatFlags</a> bit 4 is 1 and bit 5 is 1, then read the 3 byte (uint24) <a data-link-type="dfn" href="#mapping-entry-bias" id="ref-for-mapping-entry-bias①">bias</a> value
 from <var>entry bytes</var>.</p>
       <li data-md>
        <p>Otherwise the bias is 0.</p>
@@ -1320,11 +1347,11 @@ from <var>entry bytes</var>.</p>
 codepoint add the bias value to it and then add the result to the codepoint set in <var>entry</var>.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑦">formatFlags</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑧">formatFlags</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
     <li data-md>
      <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 3.3 URI Templates</a>. Set the patch uri of <var>entry</var> to the generated URI.</p>
     <li data-md>
-     <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, and <var>ignored</var>.</p>
+     <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength①">entryIdStringLength</a> as <var>consumed id string bytes</var>, and <var>ignored</var>.</p>
    </ol>
    <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.2.2.2" id="sparse-bit-set-decoding"><span class="secno">4.2.2.2. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
    <p>A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
@@ -2153,6 +2180,8 @@ required too many patches.</p>
      <li><a href="#format-2-patch-map-entrycount">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
     </ul>
    <li><a href="#mapping-entry-entryiddelta">entryIdDelta</a><span>, in § 4.2.2</span>
+   <li><a href="#format-2-patch-map-entryidstringdata">entryIdStringData</a><span>, in § 4.2.2</span>
+   <li><a href="#mapping-entry-entryidstringlength">entryIdStringLength</a><span>, in § 4.2.2</span>
    <li><a href="#glyph-map-entryindex">entryIndex</a><span>, in § 4.2.1</span>
    <li><a href="#featurerecord-entrymapcount">entryMapCount</a><span>, in § 4.2.1</span>
    <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 4.2.1</span>
@@ -2469,11 +2498,12 @@ window.dfnpanelData['format-2-patch-map-id'] = {"dfnID": "format-2-patch-map-id"
 window.dfnpanelData['format-2-patch-map-defaultpatchencoding'] = {"dfnID": "format-2-patch-map-defaultpatchencoding", "url": "#format-2-patch-map-defaultpatchencoding", "dfnText": "defaultPatchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch-map-entrycount", "url": "#format-2-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entrycount"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entrycount\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-entries'] = {"dfnID": "format-2-patch-map-entries", "url": "#format-2-patch-map-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entries"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-entryidstringdata'] = {"dfnID": "format-2-patch-map-entryidstringdata", "url": "#format-2-patch-map-entryidstringdata", "dfnText": "entryIdStringData", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entryidstringdata"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2460"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2461"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entryidstringdata\u2462"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2463"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-uritemplate'] = {"dfnID": "format-2-patch-map-uritemplate", "url": "#format-2-patch-map-uritemplate", "dfnText": "uriTemplate", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-uritemplate"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entries'] = {"dfnID": "mapping-entries", "url": "#mapping-entries", "dfnText": "Mapping Entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries"}], "title": "4.2.2. Patch Map Table: Format 2"}], "external": false};
 window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}, {"id": "ref-for-mapping-entries-entries\u2460"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entries-entries\u2461"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry'] = {"dfnID": "mapping-entry", "url": "#mapping-entry", "dfnText": "Mapping Entry", "refSections": [{"refs": [{"id": "ref-for-mapping-entry"}, {"id": "ref-for-mapping-entry\u2460"}, {"id": "ref-for-mapping-entry\u2461"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry\u2462"}, {"id": "ref-for-mapping-entry\u2463"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-formatflags'] = {"dfnID": "mapping-entry-formatflags", "url": "#mapping-entry-formatflags", "dfnText": "formatFlags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-formatflags"}, {"id": "ref-for-mapping-entry-formatflags\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2466"}, {"id": "ref-for-mapping-entry-formatflags\u2467"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-formatflags\u2468"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u24ea"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2466"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-formatflags'] = {"dfnID": "mapping-entry-formatflags", "url": "#mapping-entry-formatflags", "dfnText": "formatFlags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-formatflags"}, {"id": "ref-for-mapping-entry-formatflags\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2466"}, {"id": "ref-for-mapping-entry-formatflags\u2467"}, {"id": "ref-for-mapping-entry-formatflags\u2468"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-formatflags\u2460\u24ea"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2460"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2461"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2462"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2463"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2464"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2465"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2466"}, {"id": "ref-for-mapping-entry-formatflags\u2460\u2467"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-featurecount'] = {"dfnID": "mapping-entry-featurecount", "url": "#mapping-entry-featurecount", "dfnText": "featureCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featurecount"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-featuretags'] = {"dfnID": "mapping-entry-featuretags", "url": "#mapping-entry-featuretags", "dfnText": "featureTags", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-featuretags"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-designspacecount'] = {"dfnID": "mapping-entry-designspacecount", "url": "#mapping-entry-designspacecount", "dfnText": "designSpaceCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-designspacecount"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
@@ -2481,6 +2511,7 @@ window.dfnpanelData['mapping-entry-designspacesegments'] = {"dfnID": "mapping-en
 window.dfnpanelData['mapping-entry-copycount'] = {"dfnID": "mapping-entry-copycount", "url": "#mapping-entry-copycount", "dfnText": "copyCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copycount"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-copyindices'] = {"dfnID": "mapping-entry-copyindices", "url": "#mapping-entry-copyindices", "dfnText": "copyIndices", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copyindices"}, {"id": "ref-for-mapping-entry-copyindices\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-entryiddelta'] = {"dfnID": "mapping-entry-entryiddelta", "url": "#mapping-entry-entryiddelta", "dfnText": "entryIdDelta", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryiddelta"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-entryidstringlength'] = {"dfnID": "mapping-entry-entryidstringlength", "url": "#mapping-entry-entryidstringlength", "dfnText": "entryIdStringLength", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryidstringlength"}, {"id": "ref-for-mapping-entry-entryidstringlength\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-patchencoding'] = {"dfnID": "mapping-entry-patchencoding", "url": "#mapping-entry-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-patchencoding"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-bias'] = {"dfnID": "mapping-entry-bias", "url": "#mapping-entry-bias", "dfnText": "bias", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-bias"}, {"id": "ref-for-mapping-entry-bias\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-codepoints'] = {"dfnID": "mapping-entry-codepoints", "url": "#mapping-entry-codepoints", "dfnText": "codepoints", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-codepoints"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="1254c302c3b6b2cab2e75f83a346c5821847f3c9" name="document-revision">
+  <meta content="e7442421fd81ce94e416f70764295eba71cc1dcb" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -796,8 +796,9 @@ variation axis space) that a <a data-link-type="dfn" href="#font-subset" id="ref
    <p>Encoded data structures in the remainder of this specification are described in terms of the data types defined
 in <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types">OpenType Specification § otff#data-types</a>. As with the rest of OpenType, all fields use "big-endian" byte ordering.</p>
    <h3 class="heading settled" data-level="3.3" id="uri-templates"><span class="secno">3.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h3>
-   <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string ids into URIs where patch files are located. Several variables are
-defined which are used to produce the expansion of the template:</p>
+   <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URIs where patch files are located.
+A string ID is a sequence of <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">Unicode</a> code point values obtained from decoding a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> string (see <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.6">URI Template § section-1.6</a>). Several variables are defined which are used to produce the
+expansion of the template:</p>
    <table>
     <tbody>
      <tr>
@@ -820,8 +821,10 @@ defined which are used to produce the expansion of the template:</p>
       <td>d4
       <td>The fourth last character of the string in the id variable.
    </table>
-   <div class="example" id="example-9169b4ee">
-    <a class="self-link" href="#example-9169b4ee"></a> 
+   <p>The variables d1 through d4 select a specific character of the id variable. In this context a character is a <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">[unicode]</a> code point.
+If the code point is not an ASCII code point then during expansion it will need to be converted to <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> and percent encoded as required by <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.6">URI Template § section-1.6</a>.</p>
+   <div class="example" id="example-762ebbf7">
+    <a class="self-link" href="#example-762ebbf7"></a> 
     <p>Some example inputs and the corresponding expansions:</p>
     <table>
      <tbody>
@@ -845,6 +848,10 @@ defined which are used to produce the expansion of the template:</p>
        <td>//foo.bar{/d1,d2,d3,id}
        <td>baz
        <td>//foo.bar/z/a/b/baz
+      <tr>
+       <td>//foo.bar{/d1,d2,d3,id}
+       <td>àbc
+       <td>//foo.bar/c/b/%C3%A0/%C3%A0bc
     </table>
    </div>
    <h2 class="heading settled" data-level="4" id="font-format-extensions"><span class="secno">4. </span><span class="content">Extensions to the Font Format</span><a class="self-link" href="#font-format-extensions"></a></h2>
@@ -1203,6 +1210,9 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑨">formatFlags</a> bit 4 and/or 5 is set. The length is
       determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 4.2.2.2 Sparse Bit Set</a>. 
    </table>
+   <p>If an encoder is using string IDs via <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a> and <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength">entryIdStringLength</a> then, the
+encoder should only use <a href="https://www.rfc-editor.org/rfc/rfc3986#section-2.3">unreserved uri characters</a> in the ID strings to prevent the need for percent encoding of
+the ID values when expanding the URI templates.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="design-space-segment">Design Space Segment</dfn> encoding:</p>
    <table>
     <tbody>
@@ -1250,8 +1260,8 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <li data-md>
        <p>pass in the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
- the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a>[<var>current id string byte</var>]
- to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding①">defaultPatchEncoding</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
+ the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a>[<var>current id string byte</var>]
+ to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑤">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding①">defaultPatchEncoding</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
@@ -1327,7 +1337,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
        <p>If <var>id string bytes</var> is not present then, read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
 and the mapping is malformed.</p>
       <li data-md>
-       <p>Otherwise if <var>id string bytes</var> is present then, read <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength">entryIdStringLength</a> bytes from <var>id string bytes</var> and interpret the bytes as a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> string. Set <var>entry id</var> to the result.</p>
+       <p>Otherwise if <var>id string bytes</var> is present then, read <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength①">entryIdStringLength</a> bytes from <var>id string bytes</var> and interpret the bytes as a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> string. Set <var>entry id</var> to the result.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①④">formatFlags</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.</p>
@@ -1351,7 +1361,7 @@ codepoint add the bias value to it and then add the result to the codepoint set 
     <li data-md>
      <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 3.3 URI Templates</a>. Set the patch uri of <var>entry</var> to the generated URI.</p>
     <li data-md>
-     <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength①">entryIdStringLength</a> as <var>consumed id string bytes</var>, and <var>ignored</var>.</p>
+     <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength②">entryIdStringLength</a> as <var>consumed id string bytes</var>, and <var>ignored</var>.</p>
    </ol>
    <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.2.2.2" id="sparse-bit-set-decoding"><span class="secno">4.2.2.2. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
    <p>A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
@@ -2297,6 +2307,8 @@ required too many patches.</p>
    <dd>J. Alakuijala; Z. Szabadka. <a href="https://www.rfc-editor.org/rfc/rfc7932"><cite>Brotli Compressed Data Format</cite></a>. July 2016. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc7932">https://www.rfc-editor.org/rfc/rfc7932</a>
    <dt id="biblio-shared-brotli">[Shared-Brotli]
    <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09"><cite>Shared Brotli Compressed Data Format</cite></a>. 27 Jul 2021. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09</a>
+   <dt id="biblio-unicode">[UNICODE]
+   <dd><a href="https://www.unicode.org/versions/latest/"><cite>The Unicode Standard</cite></a>. URL: <a href="https://www.unicode.org/versions/latest/">https://www.unicode.org/versions/latest/</a>
    <dt id="biblio-utf-8">[UTF-8]
    <dd>F. Yergeau. <a href="https://www.rfc-editor.org/rfc/rfc3629"><cite>UTF-8, a transformation format of ISO 10646</cite></a>. November 2003. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3629">https://www.rfc-editor.org/rfc/rfc3629</a>
    <dt id="biblio-woff2">[WOFF2]
@@ -2498,7 +2510,7 @@ window.dfnpanelData['format-2-patch-map-id'] = {"dfnID": "format-2-patch-map-id"
 window.dfnpanelData['format-2-patch-map-defaultpatchencoding'] = {"dfnID": "format-2-patch-map-defaultpatchencoding", "url": "#format-2-patch-map-defaultpatchencoding", "dfnText": "defaultPatchEncoding", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-defaultpatchencoding\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-entrycount'] = {"dfnID": "format-2-patch-map-entrycount", "url": "#format-2-patch-map-entrycount", "dfnText": "entryCount", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entrycount"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entrycount\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-entries'] = {"dfnID": "format-2-patch-map-entries", "url": "#format-2-patch-map-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entries"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['format-2-patch-map-entryidstringdata'] = {"dfnID": "format-2-patch-map-entryidstringdata", "url": "#format-2-patch-map-entryidstringdata", "dfnText": "entryIdStringData", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entryidstringdata"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2460"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2461"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entryidstringdata\u2462"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2463"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['format-2-patch-map-entryidstringdata'] = {"dfnID": "format-2-patch-map-entryidstringdata", "url": "#format-2-patch-map-entryidstringdata", "dfnText": "entryIdStringData", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-entryidstringdata"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2460"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2461"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2462"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-format-2-patch-map-entryidstringdata\u2463"}, {"id": "ref-for-format-2-patch-map-entryidstringdata\u2464"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['format-2-patch-map-uritemplate'] = {"dfnID": "format-2-patch-map-uritemplate", "url": "#format-2-patch-map-uritemplate", "dfnText": "uriTemplate", "refSections": [{"refs": [{"id": "ref-for-format-2-patch-map-uritemplate"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entries'] = {"dfnID": "mapping-entries", "url": "#mapping-entries", "dfnText": "Mapping Entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries"}], "title": "4.2.2. Patch Map Table: Format 2"}], "external": false};
 window.dfnpanelData['mapping-entries-entries'] = {"dfnID": "mapping-entries-entries", "url": "#mapping-entries-entries", "dfnText": "entries", "refSections": [{"refs": [{"id": "ref-for-mapping-entries-entries"}, {"id": "ref-for-mapping-entries-entries\u2460"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entries-entries\u2461"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
@@ -2511,7 +2523,7 @@ window.dfnpanelData['mapping-entry-designspacesegments'] = {"dfnID": "mapping-en
 window.dfnpanelData['mapping-entry-copycount'] = {"dfnID": "mapping-entry-copycount", "url": "#mapping-entry-copycount", "dfnText": "copyCount", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copycount"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-copyindices'] = {"dfnID": "mapping-entry-copyindices", "url": "#mapping-entry-copyindices", "dfnText": "copyIndices", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-copyindices"}, {"id": "ref-for-mapping-entry-copyindices\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-entryiddelta'] = {"dfnID": "mapping-entry-entryiddelta", "url": "#mapping-entry-entryiddelta", "dfnText": "entryIdDelta", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryiddelta"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
-window.dfnpanelData['mapping-entry-entryidstringlength'] = {"dfnID": "mapping-entry-entryidstringlength", "url": "#mapping-entry-entryidstringlength", "dfnText": "entryIdStringLength", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryidstringlength"}, {"id": "ref-for-mapping-entry-entryidstringlength\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
+window.dfnpanelData['mapping-entry-entryidstringlength'] = {"dfnID": "mapping-entry-entryidstringlength", "url": "#mapping-entry-entryidstringlength", "dfnText": "entryIdStringLength", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-entryidstringlength"}], "title": "4.2.2. Patch Map Table: Format 2"}, {"refs": [{"id": "ref-for-mapping-entry-entryidstringlength\u2460"}, {"id": "ref-for-mapping-entry-entryidstringlength\u2461"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-patchencoding'] = {"dfnID": "mapping-entry-patchencoding", "url": "#mapping-entry-patchencoding", "dfnText": "patchEncoding", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-patchencoding"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-bias'] = {"dfnID": "mapping-entry-bias", "url": "#mapping-entry-bias", "dfnText": "bias", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-bias"}, {"id": "ref-for-mapping-entry-bias\u2460"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};
 window.dfnpanelData['mapping-entry-codepoints'] = {"dfnID": "mapping-entry-codepoints", "url": "#mapping-entry-codepoints", "dfnText": "codepoints", "refSections": [{"refs": [{"id": "ref-for-mapping-entry-codepoints"}], "title": "4.2.2.1. Interpreting Format 2"}], "external": false};

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="6bb60b15f577efe88546283c8993edd4e070654e" name="document-revision">
+  <meta content="02c994591d3fd71b1b241c0687e128e57a2e81e7" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -827,8 +827,8 @@ expansion of the template:</p>
    </table>
    <p>The variables d1 through d4 select a specific character of the id variable. In this context a character is a <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">[unicode]</a> code point.
 If the code point is not an ASCII code point then during expansion it will need to be converted to <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> and percent encoded as required by <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.6">URI Template § section-1.6</a>.</p>
-   <div class="example" id="example-762ebbf7">
-    <a class="self-link" href="#example-762ebbf7"></a> 
+   <div class="example" id="example-096f0d2d">
+    <a class="self-link" href="#example-096f0d2d"></a> 
     <p>Some example inputs and the corresponding expansions:</p>
     <table>
      <tbody>
@@ -852,6 +852,10 @@ If the code point is not an ASCII code point then during expansion it will need 
        <td>//foo.bar{/d1,d2,d3,id}
        <td>baz
        <td>//foo.bar/z/a/b/baz
+      <tr>
+       <td>//foo.bar{/d1,d2,d3,id}
+       <td>az
+       <td>//foo.bar/z/a/0/az
       <tr>
        <td>//foo.bar{/d1,d2,d3,id}
        <td>àbc

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="72a27ee056df2d9e18ce0cb66e6066872b0abb18" name="document-revision">
+  <meta content="6bb60b15f577efe88546283c8993edd4e070654e" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-17">17 April 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-18">18 April 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -810,16 +810,20 @@ expansion of the template:</p>
       (using the digits 0-9, A-F). No padding with 0’s is used. Otherwise, this is the string id value. 
      <tr>
       <td>d1
-      <td>The last character of the string in the id variable.
+      <td> The last character of the string in the id variable.
+      If id variable is empty then, the value is the character 0 (U+0030). 
      <tr>
       <td>d2
-      <td>The second last character of the string in the id variable.
+      <td> The second last character of the string in the id variable.
+      If the id variable has less than 2 characters then, the value is the character 0 (U+0030). 
      <tr>
       <td>d3
-      <td>The third last character of the string in the id variable.
+      <td> The third last character of the string in the id variable.
+      If the id variable has less than 3 characters then, the value is the character 0 (U+0030). 
      <tr>
       <td>d4
-      <td>The fourth last character of the string in the id variable.
+      <td> The fourth last character of the string in the id variable.
+      If the id variable has less than 4 characters then, the value is the character 0 (U+0030). 
    </table>
    <p>The variables d1 through d4 select a specific character of the id variable. In this context a character is a <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">[unicode]</a> code point.
 If the code point is not an ASCII code point then during expansion it will need to be converted to <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> and percent encoded as required by <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.6">URI Template § section-1.6</a>.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version 5fcd28d6d, updated Tue May 30 13:12:11 2023 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="3769a95726e738c1c6c5baf1210438795bd25011" name="document-revision">
+  <meta content="6f5387f0d9d44e81dd829116a76ff54c5ea9a69a" name="document-revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -503,7 +503,7 @@ var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-12">12 April 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-16">16 April 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1099,7 +1099,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</dfn>
       <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry). Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 5.2 Formats Summary</a> table. 
      <tr>
-      <td>uint16
+      <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entrycount">entryCount</dfn>
       <td>Number of entries encoded in this table.
      <tr>
@@ -1149,7 +1149,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags</dfn>[featureCount]
       <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set. 
      <tr>
-      <td>uint8
+      <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount</dfn>
       <td> Number of elements in the design space list. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags②">formatFlags</a> bit 0 is set. 
      <tr>
@@ -1161,12 +1161,12 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copycount">copyCount</dfn>
       <td> Number of entries in the copyIndices list. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags④">formatFlags</a> bit 1 is set. 
      <tr>
-      <td>uint16
+      <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices</dfn>[copyCount]
       <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definition</a> should be copied into this entry. All
       values must be less than the index of this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
      <tr>
-      <td>int16
+      <td>int24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>
       <td> Signed delta which is used to calculate the id for this entry. The id for this entry is the entry id of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> + 1 + entryIdDelta. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set. If not present delta is assumed
       to be 0. 


### PR DESCRIPTION
Adds the ability to optionally assign entries in a format 2 table opaque string id's (instead of numeric ids).

Also widen several of the format 2 fields:
- entryCount (and associated copyIndices) uint16 -> uint24.
- designSpaceCount uint8 -> uint16 to match the max number of axes in fvar.
- entryIdDelta int16 -> int24 to allow for bigger gaps, and a higher maximum id value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/165.html" title="Last updated on Apr 18, 2024, 9:47 PM UTC (84496c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/165/6f5387f...84496c3.html" title="Last updated on Apr 18, 2024, 9:47 PM UTC (84496c3)">Diff</a>