### PR TITLE
Major Reorganization of Spec Sections.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -331,7 +331,7 @@ codepoints, layout features and/or design space.
 Patch Invalidations {#font-patch-invalidations}
 -----------------------------------------------
 
-The application of a patch to an an incremental [=font subset=] may invalidate some or all of the other mapped patches, so that if
+The application of a patch to an incremental [=font subset=] may invalidate some or all of the other mapped patches, so that if
 one of those were to be applied the result would be a corrupt
 [=font subset|font=]. Patch validity is tracked by the compatibility ID from the [[#patch-map-table]]. Every patch has a
 compatibility ID encoded within it which needs to match the compatibility ID from the [[#patch-map-table]] which lists that patch.

--- a/Overview.bs
+++ b/Overview.bs
@@ -316,8 +316,8 @@ in [[#font-format-extensions]].
   </tr>
 </table>
 
-Data Types {#data-types}
-------------------------
+Explanation of Data Types {#data-types}
+---------------------------------------
 
 Encoded data structures in the remainder of this specification are described in terms of the data types defined
 in [[open-type/otff#data-types]]. As with the rest of OpenType, all fields use "big-endian" byte ordering.
@@ -325,16 +325,17 @@ in [[open-type/otff#data-types]]. As with the rest of OpenType, all fields use "
 Extending a Font Subset {#extending-font-subset}
 ================================================
 
-This sections defines the algorithm that a client uses to extend an [=incremental font|incremental=] [=font subset=] to cover additional
+This section defines the algorithm that a client uses to extend an [=incremental font|incremental=] [=font subset=] to cover additional
 codepoints, layout features and/or design space.
 
 Patch Invalidations {#font-patch-invalidations}
 -----------------------------------------------
 
-Patches in an incremental [=font subset=] when applied may invalidate other available patches, making them invalid to be applied
-to the extended [=font subset=]. Patch validity is checked using the compatibility ID from the [[#patch-map-table]]. Every patch has a
+The application of a patch to an an incremental [=font subset=] may invalidate some or all of the other mapped patches, so that if
+one of those were to be applied the result would be a corrupt
+[=font subset|font=]. Patch validity is tracked by the compatibility ID from the [[#patch-map-table]]. Every patch has a
 compatibility ID encoded within it which needs to match the compatibility ID from the [[#patch-map-table]] which lists that patch.
-Additionally to aid the client in determining what invalidations will occur, every patch is categorized into one of three categories:
+Every patch is categorized into one of three types, depending on how it does or does not invalidate other patches in the map(s):
 
 * <dfn dfn>Full Invalidation</dfn>: when this patch is applied all other patches currently listed in the [=font subset=] are invalidated.
     The compatibility ID in both the 'IFT ' and 'IFTX' [[#patch-map-table]] will be changed.
@@ -345,7 +346,7 @@ Additionally to aid the client in determining what invalidations will occur, eve
 * <dfn dfn>No Invalidation</dfn>: no other patches will be invalidated by the application of this patch. The compatibility ID of the
     'IFT ' and 'IFTX' [[#patch-map-table]] will not change.
 
-The invalidation behaviour of a specific patch is encoded in its format number which can be found in [[#font-patch-formats-summary]].
+The invalidation behavior of a specific patch is encoded in its format number, which can be found in [[#font-patch-formats-summary]].
 
 <h3 algorithm id="extend-font-subset">Incremental Font Extension Algorithm</h2>
 
@@ -409,6 +410,9 @@ encouraged to pre-fetch patch files that will be applied in later iterations by 
 [[#font-patch-invalidations|invalidation categories]] can be used to predict which intersecting patches from step 4 will remain be valid
 to be applied.
 
+<!-- TODO: Can we say something specific in the above Note about "No Invalidation" patches? E.g. that when there are only such
+           patches they can always safely be loaded in parallel? -->
+
 <!-- TODO: provide criteria to exit if stuck in an infinite loop. Could require that no specific URL is loaded more than once?
            Could require that each patch application result in an extended coverage in some way? Also allow the client to define
 	   an max iteration count? -->
@@ -454,8 +458,15 @@ The inputs to this algorithm are:
 *   <var>Patch URI</var>: A [[rfc3986#section-4.1|URI Reference]] identifying the patch file to load. As a URI reference this may be a
      relative path.
 
-*   <var>Incremental Font URI</var>: An [[rfc3986#section-4.3|abslolute URI]] which identifies the incremental font which contains
+*   <var>Incremental Font URI</var>: An [[rfc3986#section-4.3|absolute URI]] which identifies the incremental font which contains
      the reference to <var>Patch URI</var>.
+
+<!-- TODO: We explicitly imply (via "may") that a Patch URI could be absolute. Then we say the Incremental Font URI "identifies
+           the incremental font which contains the reference to Patch URI". But only particular incremental instances may do so
+           e.g. in the case of full or partial invalidating patches. So are we meaning to leave open the option of the
+           Incremental Font URI changing over time, perhaps when a Patch URI is absolute? If not, we should change "Incremental
+           Font URI" to something like "Original Font URI". If so, I think we need to specify how that happens in the algorithm
+           below. -->
 
 The algorithm outputs:
 
@@ -483,6 +494,11 @@ Coming soon.
 This sections defines an algorithm that can be used to transform an incremental font into a fully expanded non-incremental font. This
 process loads all available data provided by the incremental font and produces a single static font file that contains no further
 patches to be applied.
+
+<!-- TODO:  Especially if we do plan to support having multiple invalidating patches that intersect some categories of
+            parameter but not others, might it be desirable to have some sort of breadcrumb in the map saying "privilege
+            this one next if you're trying to load the whole font"? Basically a field or a flag saying "this gets you
+            to the end fastest"? -->
 
 <dfn abstract-op>Fully Expand a Font Subset</dfn>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -354,11 +354,12 @@ The invalidation behavior of a specific patch is encoded in its format number, w
 
 The inputs to this algorithm are:
 
-* <var>font subset</var>: an [=incremental font|incremental=] [=font subset=].
+*  <var>font subset</var>: an [=incremental font|incremental=] [=font subset=].
 
-* <var>font subset URI</var>: an [[rfc3986#section-4.3|abslolute URI]] which identifies the location of <var>font subset</var>.
+*  <var>original font subset URI</var>: an [[rfc3986#section-4.3|absolute URI]] which identifies the location of the original incremental
+    font that <var>font subset</var> was derived from.
 
-* <var>target subset definition</var>: the [=font subset definition=] that the client wants to extend <var>font subset</var> to cover.
+*  <var>target subset definition</var>: the [=font subset definition=] that the client wants to extend <var>font subset</var> to cover.
 
 The algorithm outputs:
 
@@ -396,8 +397,8 @@ The algorithm:
     *  Otherwise select exactly one of the [=No Invalidation=] entries in <var>entry list</var>.
         The criteria for selecting the single entry is left up to the implementation to decide.
 
-7.  Load <var>patch file</var> by invoking [$Load patch file$] with the <var>font subset URI</var> as the incremental font URI and the
-    <var>entry</var> patch URI as the patch URI.
+7.  Load <var>patch file</var> by invoking [$Load patch file$] with the <var>original font subset URI</var> as the original font URI and
+    the <var>entry</var> patch URI as the patch URI.
 
 8.  Apply <var>patch file</var> using the appropriate application algorithm (matching the patches format in <var>entry</var>) from
     [[#font-patch-formats]] to apply the <var>patch file</var> using the patch URI and the compatibility id from <var>entry</var> to
@@ -408,15 +409,13 @@ The algorithm:
 Note: the algorithm here presents patch loads as being done one at a time; however, to improve performance client implementations are
 encouraged to pre-fetch patch files that will be applied in later iterations by the algorithm. The
 [[#font-patch-invalidations|invalidation categories]] can be used to predict which intersecting patches from step 4 will remain be valid
-to be applied.
-
-<!-- TODO: Can we say something specific in the above Note about "No Invalidation" patches? E.g. that when there are only such
-           patches they can always safely be loaded in parallel? -->
+to be applied. For example: in a case where there are only "No Invalidation" intersecting patches the client could safely load all
+intersecting patches in parallel, since no patch application will invalidate any of the other intersecting patches.
 
 <!-- TODO: provide criteria to exit if stuck in an infinite loop. Could require that no specific URL is loaded more than once?
            Could require that each patch application result in an extended coverage in some way? Also allow the client to define
 	   an max iteration count? -->
-<!-- TODO: also consider adding additional changes to prevent degenerate behaviour from happening (eg. iteration limits, minimum codepoint group sizes). -->
+<!-- TODO: also consider adding additional changes to prevent degenerate behavior from happening (eg. iteration limits, minimum codepoint group sizes). -->
     
 <dfn abstract-op>Check entry intersection</dfn>
 
@@ -458,15 +457,8 @@ The inputs to this algorithm are:
 *   <var>Patch URI</var>: A [[rfc3986#section-4.1|URI Reference]] identifying the patch file to load. As a URI reference this may be a
      relative path.
 
-*   <var>Incremental Font URI</var>: An [[rfc3986#section-4.3|absolute URI]] which identifies the incremental font which contains
-     the reference to <var>Patch URI</var>.
-
-<!-- TODO: We explicitly imply (via "may") that a Patch URI could be absolute. Then we say the Incremental Font URI "identifies
-           the incremental font which contains the reference to Patch URI". But only particular incremental instances may do so
-           e.g. in the case of full or partial invalidating patches. So are we meaning to leave open the option of the
-           Incremental Font URI changing over time, perhaps when a Patch URI is absolute? If not, we should change "Incremental
-           Font URI" to something like "Original Font URI". If so, I think we need to specify how that happens in the algorithm
-           below. -->
+*   <var>Original Font URI</var>: An [[rfc3986#section-4.3|absolute URI]] which identifies the original incremental font that the
+     patch URI was derived from.
 
 The algorithm outputs:
 
@@ -474,7 +466,7 @@ The algorithm outputs:
 
 The algorithm:
 
-1.  Perform [[rfc3986#section-5|reference resolution]] on <var>Patch URI</var> using <var>Incremental Font URI</var> as the base URI to
+1.  Perform [[rfc3986#section-5|reference resolution]] on <var>Patch URI</var> using <var>Original Font URI</var> as the base URI to
      produce the <var>target URI</var>.
 
 2.  Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers,

--- a/Overview.bs
+++ b/Overview.bs
@@ -115,22 +115,22 @@ to this specification.
 Overview {#overview}
 --------------------
 
-An IFT font is a regular [[open-type|OpenType]] font that is reformated to include incremental functionality, partly in virtue of
-of two additional [[open-type/otff#table-directory|tables]]. Using these new tables the font can be augmented (eg. to cover more codepoints)
-by loading and applying patches to it.
+An <dfn dfn>incremental font</dfn> is a regular [[open-type|OpenType]] font that is reformatted to include incremental functionality,
+partly in virtue of two additional [[open-type/otff#table-directory|tables]]. Using these new tables the font can be augmented
+(eg. to cover more codepoints) by loading and applying patches to it.
 
 The IFT technology has four main pieces:
+
+*  [[#extending-font-subset]]: provides the algorithm that is used by a client to select and apply patches.
 
 *  [[#font-format-extensions]]: defines the new tables which contain a list of patches that are available to be applied to a font.
 
 *  [[#font-patch-formats]]: defines three different types of patches that can be used. Two are "generic" binary patches, one is
      specific to the font's format for storing glyph data.
 
-*  [[#extending-font-subset]]: provides the algorithm that is used by a client to select and apply patches.
-
 *  [[#encoder]]: creates the font and associated patches that form an incremental font.
 
-At a high level an IFT font is used like this:
+At a high level an [=incremental font=] is used like this:
 
 1. The client downloads an initial font file, which contains some initial subset of data from the full version of the font along with
     [[#font-format-extensions|embedded data]] describing the set of [[#font-patch-formats|patches]] which can be used to extend 
@@ -146,7 +146,7 @@ Creating an Incremental Font {#making-incremental-fonts}
 It is expected that the most common way to produce an incremental font will be to convert an existing font to use the incremental
 encoding defined in this specification. At a high level converting an existing font to be incremental will look like this:
 
-1.  Choose the content of the initial [[#font-subset-info|subset]], this will be included in the initial font file the client loads
+1.  Choose the content of the initial [[#font-subset-dfn|subset]], this will be included in the initial font file the client loads
     and usually consists of any data from the original font that is expected to always be needed.
 
 2.  Choose a segmentation of the font. Individual segments will be added to the base subset by the client using patches. Choosing an
@@ -254,7 +254,7 @@ by invoking [$Fully Expand a Font Subset$] and replace references to the increme
 Definitions {#definitions}
 ===============================
 
-Font Subset {#font-subset-info}
+Font Subset {#font-subset-dfn}
 -------------------------------
 
 A <dfn dfn>font subset</dfn> is a modified version of a font file [[!iso14496-22]] that contains only the data
@@ -276,116 +276,238 @@ variation axis space) that a [=font subset=] should support.
 Note: For convenience the remainder of this document links to the [[open-type]] specification which is a copy of
 [[!iso14496-22]].
 
+Font Patch {#font-patch-definitions}
+-------------------------------------
+
+A <dfn dfn>font patch</dfn> is a file which encodes changes to be made to an IFT-encoded font. Patches are used to extend
+an existing [=font subset=] and provide expanded coverage.
+
+A <dfn dfn>patch format</dfn> is a specified encoding of changes to be applied relative to a [=font subset=]. A set of
+changes encoded according to the format is a [=font patch=]. Each [=patch format=] has an associated 
+<dfn dfn>patch application algorithm</dfn> which takes a
+[=font subset=] and a [=font patch=] encoded in the [=patch format=] as input and outputs an extended
+[=font subset=].
+
+
+Patch Map {#patch-map-dfn}
+--------------------------
+
+A <dfn dfn>patch map</dfn> is an [[open-type/otff#table-directory|open type table]] which encodes a collection of mappings from
+[=font subset definition|font subset definitions=] to URIs which host [[#font-patch-formats|patches]] that extend the
+[=incremental font=]. A [=patch map=] table encodes a list of <dfn dfn>patch map entries</dfn>, where each entry has a key and value.
+The key is a [=font subset definition=] and the value is a URI, the [[#font-patch-formats]] used by the data at the URI, and the
+[[#font-patch-invalidations|compatibility ID]] of the patch map table. More details of the format of patch maps can be found
+in [[#font-format-extensions]].
+
+[=patch map entries|Patch Map Entry=] summary:
+<table>
+  <tr><th>Key</th><th>Value</th></tr>
+  <tr>
+    <td>
+      * [=font subset definition=]
+
+    </td>
+    <td>
+      * Patch URI
+      * [[#font-patch-formats|Patch Format]]
+      * [[#font-patch-invalidations|compatibility ID]]
+      
+    </td>
+  </tr>
+</table>
+
 Data Types {#data-types}
 ------------------------
 
 Encoded data structures in the remainder of this specification are described in terms of the data types defined
 in [[open-type/otff#data-types]]. As with the rest of OpenType, all fields use "big-endian" byte ordering.
 
-URI Templates {#uri-templates}
-------------------------------
+Extending a Font Subset {#extending-font-subset}
+================================================
 
-URI templates [[!rfc6570]] are used to convert numeric or string IDs into URIs where patch files are located.
-A string ID is a sequence of [[!unicode|Unicode]] code point values obtained from decoding a
-[[UTF-8]] string (see [[rfc6570#section-1.6]]). Several variables are defined which are used to produce the
-expansion of the template:
+This sections defines the algorithm that a client uses to extend an [=incremental font|incremental=] [=font subset=] to cover additional
+codepoints, layout features and/or design space.
 
-<table>
-  <tr><th>Variable</th><th>Value</th></tr>
-  <tr>
-    <td>id</td>
-    <td>
-      If the input id is numeric then this is the  numeric value converted to a string in hexadecimal representation
-      (using the digits 0-9, A-F). No padding with 0's is used. Otherwise, this is the string id value.
-    </td>
-  </tr>
-  <tr>
-    <td>d1</td>
-    <td>
-      The last character of the string in the id variable.
-      If id variable is empty then, the value is the character 0 (U+0030).
-    </td>
-  </tr>
-  <tr>
-    <td>d2</td>
-    <td>
-      The second last character of the string in the id variable.
-      If the id variable has less than 2 characters then, the value is the character 0 (U+0030).
-    </td>
-  </tr>
-  <tr>
-    <td>d3</td>
-    <td>
-      The third last character of the string in the id variable.
-      If the id variable has less than 3 characters then, the value is the character 0 (U+0030).
-    </td>
-  </tr>
-  <tr>
-    <td>d4</td>
-    <td>
-      The fourth last character of the string in the id variable.
-      If the id variable has less than 4 characters then, the value is the character 0 (U+0030).
-    </td>
-  </tr>
-</table>
+Patch Invalidations {#font-patch-invalidations}
+-----------------------------------------------
 
-The variables d1 through d4 select a specific character of the id variable. In this context a character is a [[!unicode]] code point.
-If the code point is not an ASCII code point then during expansion it will need to be converted to
-[[UTF-8]] and percent encoded as required by [[rfc6570#section-1.6]].
+Patches in an incremental [=font subset=] when applied may invalidate other available patches, making them invalid to be applied
+to the extended [=font subset=]. Patch validity is checked using the compatibility ID from the [[#patch-map-table]]. Every patch has a
+compatibility ID encoded within it which needs to match the compatibility ID from the [[#patch-map-table]] which lists that patch.
+Additionally to aid the client in determining what invalidations will occur, every patch is categorized into one of three categories:
 
-<div class="example">
+* <dfn dfn>Full Invalidation</dfn>: when this patch is applied all other patches currently listed in the [=font subset=] are invalidated.
+    The compatibility ID in both the 'IFT ' and 'IFTX' [[#patch-map-table]] will be changed.
 
-Some example inputs and the corresponding expansions:
+* <dfn dfn>Partial Invalidation</dfn>: when this patch is applied all other patches in the same [[#patch-map-table]] will be invalidated.
+    The compatibility ID of only the [[#patch-map-table]] which contains this patch will be changed.
 
-<table>
-  <tr><th>Template</th><th>Input ID</th><th>Expansion</th></tr>
-  <tr>
-    <td>//foo.bar/{id}</td>
-    <td>123</td>
-    <td>//foo.bar/7B</td>
-  </tr>
-  <tr>
-    <td>//foo.bar{/d1,d2,id}</td>
-    <td>123</td>
-    <td>//foo.bar/B/7/7B</td>
-  </tr>
-  <tr>
-    <td>//foo.bar{/d1,d2,d3,id}</td>
-    <td>123</td>
-    <td>//foo.bar/B/7/0/7B</td>
-  </tr>
-    <tr>
-    <td>//foo.bar{/d1,d2,d3,id}</td>
-    <td>baz</td>
-    <td>//foo.bar/z/a/b/baz</td>
-  </tr>
-  </tr>
-    <tr>
-    <td>//foo.bar{/d1,d2,d3,id}</td>
-    <td>az</td>
-    <td>//foo.bar/z/a/0/az</td>
-  </tr>
-  </tr>
-    <tr>
-    <td>//foo.bar{/d1,d2,d3,id}</td>
-    <td>àbc</td>
-    <td>//foo.bar/c/b/%C3%A0/%C3%A0bc</td>
-  </tr>
-</table>
+* <dfn dfn>No Invalidation</dfn>: no other patches will be invalidated by the application of this patch. The compatibility ID of the
+    'IFT ' and 'IFTX' [[#patch-map-table]] will not change.
 
-</div>
+The invalidation behaviour of a specific patch is encoded in its format number which can be found in [[#font-patch-formats-summary]].
 
+<h3 algorithm id="extend-font-subset">Incremental Font Extension Algorithm</h2>
+
+<dfn abstract-op>Extend an Incremental Font Subset</dfn>
+
+The inputs to this algorithm are:
+
+* <var>font subset</var>: an [=incremental font|incremental=] [=font subset=].
+
+* <var>font subset URI</var>: an [[rfc3986#section-4.3|abslolute URI]] which identifies the location of <var>font subset</var>.
+
+* <var>target subset definition</var>: the [=font subset definition=] that the client wants to extend <var>font subset</var> to cover.
+
+The algorithm outputs:
+
+* <var>extended font subset</var>: an extended version of <var>font subset</var>. May or may not be an [=incremental font=].
+
+The algorithm:
+
+1.  Set <var>extended font subset</var> to <var>font subset</var>.
+
+2.  Load the 'IFT ' and 'IFTX' (if present) mapping [[open-type/otff#table-directory|tables]] from <var>extended font subset</var>. Both
+    tables are formatted as a [[#patch-map-table]]. Check that they are valid according to the requirements in [[#patch-map-table]]. If
+    either table is not valid, invoke [$Handle errors$]. If <var>extended font subset</var> does not have an 'IFT ' table, then it is
+    not an [=incremental font=] and cannot be extended, return <var>extended font subset</var>.
+
+3.  For each of [[open-type/otff#table-directory|tables]] 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
+    invoking [$Interpret Format 1 Patch Map$] or [$Interpret Format 2 Patch Map$]. Concatenate the returned entry lists into a single list,
+    <var>entry list</var>.
+
+4.  For each <var>entry</var> in <var>entry list</var> invoke [$Check entry intersection$] with <var>entry</var> and
+    <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var>
+    from <var>entry list</var>.
+
+5.  If <var>entry list</var> is empty, then the extension operation is finished, return <var>extended font subset</var>.
+
+6.  Pick one <var>entry</var> from <var>entry list</var> with the following procedure:
+
+    *  If <var>entry list</var> contains one or more [=patch map entries=] which have a patch format that is [=Full Invalidation=]
+        then, select exactly one of the [=Full Invalidation=] entries in <var>entry list</var>. The criteria for selecting the single
+        entry is left up to the implementation to decide.
+
+    *  Otherwise if <var>entry list</var> contains one or more [=patch map entries=] which have a patch format that is
+        [=Partial Invalidation=] then, select exactly one of the [=Partial Invalidation=] entries in <var>entry list</var>.
+        The criteria for selecting the single entry is left up to the implementation to decide.
+
+    *  Otherwise select exactly one of the [=No Invalidation=] entries in <var>entry list</var>.
+        The criteria for selecting the single entry is left up to the implementation to decide.
+
+7.  Load <var>patch file</var> by invoking [$Load patch file$] with the <var>font subset URI</var> as the incremental font URI and the
+    <var>entry</var> patch URI as the patch URI.
+
+8.  Apply <var>patch file</var> using the appropriate application algorithm (matching the patches format in <var>entry</var>) from
+    [[#font-patch-formats]] to apply the <var>patch file</var> using the patch URI and the compatibility id from <var>entry</var> to
+    <var>extended font subset</var>.
+
+9.  Go to step 2.
+
+Note: the algorithm here presents patch loads as being done one at a time; however, to improve performance client implementations are
+encouraged to pre-fetch patch files that will be applied in later iterations by the algorithm. The
+[[#font-patch-invalidations|invalidation categories]] can be used to predict which intersecting patches from step 4 will remain be valid
+to be applied.
+
+<!-- TODO: provide criteria to exit if stuck in an infinite loop. Could require that no specific URL is loaded more than once?
+           Could require that each patch application result in an extended coverage in some way? Also allow the client to define
+	   an max iteration count? -->
+<!-- TODO: also consider adding additional changes to prevent degenerate behaviour from happening (eg. iteration limits, minimum codepoint group sizes). -->
+    
+<dfn abstract-op>Check entry intersection</dfn>
+
+The inputs to this algorithm are:
+
+*   <var>mapping entry</var>: a [=patch map entries|patch map entry=].
+
+*   <var>subset definition</var>: a [=font subset definition=].
+
+The algorithm outputs:
+
+*   <var>intersects</var>: true if <var>subset definition</var> intersects <var>mapping entry</var>, otherwise false.
+
+The algorithm:
+
+1.  For each set in <var>subset definition</var> (codepoints, feature tags, design space) check if the set intersects
+     the corresponding set from <var>mapping entry</var>. A set intersects when:
+
+     <table>
+       <tr>
+         <th></th><th>subset definition set is empty</th><th>subset definition set is not empty</th>
+       </tr>
+       <tr>
+         <th>mapping entry set is empty</th><td>true</td><td>true</td>
+       </tr>
+       <tr>
+         <th>mapping entry set is not empty</th><td>false</td><td>true if the two sets intersect</td>
+       </tr>
+     </table>
+
+2. If all sets checked in step 1 intersect, then return true for <var>intersects</var> otherwise false.
+
+<dfn abstract-op>Load patch file</dfn>
+
+<!-- TODO: consider requiring HTTPS (or disallowing HTTP specifically if we want to allow file:// and other url types) -->
+
+The inputs to this algorithm are:
+
+*   <var>Patch URI</var>: A [[rfc3986#section-4.1|URI Reference]] identifying the patch file to load. As a URI reference this may be a
+     relative path.
+
+*   <var>Incremental Font URI</var>: An [[rfc3986#section-4.3|abslolute URI]] which identifies the incremental font which contains
+     the reference to <var>Patch URI</var>.
+
+The algorithm outputs:
+
+*   <var>patch file</var>: the content (bytes) identified by <var>Patch URI</var>.
+
+The algorithm:
+
+1.  Perform [[rfc3986#section-5|reference resolution]] on <var>Patch URI</var> using <var>Incremental Font URI</var> as the base URI to
+     produce the <var>target URI</var>.
+
+2.  Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers,
+     [[fetch]] should be used. Return the retrieved contents as <var>patch file</var>, or an error if the fetch resulted in an error.
+
+<dfn abstract-op>Handle errors</dfn>
+
+Coming soon.
+
+<!-- TODO -->
+
+<!-- TODO: we should consider defining a valid encoded IFT font as one that produces a correct font subset for the corresponding
+           definition in the entry. This would likely be the only requirement made for encoders. -->
+
+<h3 algorithm id="fully-expanding-a-font">Fully Expanding a Font</h3>
+
+This sections defines an algorithm that can be used to transform an incremental font into a fully expanded non-incremental font. This
+process loads all available data provided by the incremental font and produces a single static font file that contains no further
+patches to be applied.
+
+<dfn abstract-op>Fully Expand a Font Subset</dfn>
+
+The inputs to this algorithm are:
+
+* <var>font subset</var>: an [=incremental font|incremental=] [=font subset=].
+
+The algorithm outputs:
+
+* <var>expanded font</var>: an [[open-type]] font that is not incremental.
+
+The algorithm:
+
+1. Invoke [$Extend an Incremental Font Subset$] with <var>font subset</var>. The input target subset definition is a special one which
+    is considered to intersect all entries in the [$Check entry intersection$] step. Return the resulting font subset as
+    the <var>expanded font</var>.
 
 Extensions to the Font Format {#font-format-extensions}
 =======================================================
 
-An <dfn dfn>incremental font</dfn> follows the existing [[open-type|OpenType]] format, but includes two new
+An [=incremental font=] follows the existing [[open-type|OpenType]] format, but includes two new
 [[open-type/otff#table-directory|tables]] identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both
-[[#patch-map|patch maps]], which encode a collection of mappings from [=font subset definition|font subset definitions=] to URIs which
-host [[#font-patch-formats|patches]] that extend the incremental font. All incremental fonts must contain the 'IFT ' table.
-The 'IFTX' table is optional. When both tables are present, the mapping of the font as a whole is the union of the mappings of
-the two tables. The two new tables are used only in this specification and are not being added to the [[open-type|Open-Type]]
-specification.
+[=patch map|patch maps=]. All incremental fonts must contain the 'IFT ' table. The 'IFTX' table is optional. When both tables are
+present, the mapping of the font as a whole is the union of the mappings of the two tables. The two new tables are used only in this
+specification and are not being added to the [[open-type|Open-Type]] specification.
 
 Note: allowing the mapping to be split between two distinct tables allows an incremental font to more easily make use of multiple
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
@@ -411,12 +533,10 @@ is taken. If an incremental font will be encoded by WOFF2 for transfer:
 The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in
 [[WOFF2#table_format]].
 
-Patch Map Table {#patch-map}
-----------------------------
+Patch Map Table {#patch-map-table}
+----------------------------------
 
-A patch map table encodes a list of <dfn dfn>patch map entries</dfn>, where each entry has a key and value. The key is a
-[=font subset definition=] and the value is a URI, the [[#font-patch-formats]] used by the data at the URI, and the compatibility ID
-of the patch map table. A map is encoded in one of two formats:
+A [=patch map=] is encoded in one of two formats:
 
 *  Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URIs. It does
     not support [=font subset definitions=] with design space or entries with overlapping subset definitions.
@@ -425,10 +545,10 @@ of the patch map table. A map is encoded in one of two formats:
     is typically less compact than format 1.
 
 Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The
-[$Extend a Font Subset$] algorithm invokes the interpretation algorithms and operates on the resulting entry list. The encoded bytes
-are the source of truth at all times for the patch map. Patch application during subset extension will alter the encoded bytes of the
-patch map and as a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets the encoded
-bytes at the start of every iteration to pick up any changes made in the previous iteration.
+[$Extend an Incremental Font Subset$] algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
+encoded bytes are the source of truth at all times for the patch map. Patch application during subset extension will alter the encoded
+bytes of the patch map and as a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets
+the encoded bytes at the start of every iteration to pick up any changes made in the previous iteration.
 
 ### Patch Map Table: Format 1 ### {#patch-map-format-1}
 
@@ -949,14 +1069,13 @@ needs to be taken when choosing the set of characters to use in the file names.
 
 <h5 algorithm id="interpreting-patch-map-format-2">Interpreting Format 2</h5>
 
-This algorithm is used to convert a format 2 patch map into a list of [=patch map entries=].
-
+This algorithm is used to convert a format 2 [=patch map=] into a list of [=patch map entries=].
 
 <dfn abstract-op>Interpret Format 2 Patch Map</dfn>
 
 The inputs to this algorithm are:
 
-* <var>patch map</var>: a [=Format 2 Patch Map=] encoded patch map.
+* <var>patch map</var>: a [=Format 2 Patch Map=] encoded [=patch map=].
 
 The algorithm outputs:
 
@@ -1254,6 +1373,99 @@ to give the smallest encodings for most unicode codepoint sets typically encount
   ```
 </div>
 
+### URI Templates ### {#uri-templates}
+
+URI templates [[!rfc6570]] are used to convert numeric or string IDs into URIs where patch files are located.
+A string ID is a sequence of [[!unicode|Unicode]] code point values obtained from decoding a
+[[UTF-8]] string (see [[rfc6570#section-1.6]]). Several variables are defined which are used to produce the
+expansion of the template:
+
+<table>
+  <tr><th>Variable</th><th>Value</th></tr>
+  <tr>
+    <td>id</td>
+    <td>
+      If the input id is numeric then this is the  numeric value converted to a string in hexadecimal representation
+      (using the digits 0-9, A-F). No padding with 0's is used. Otherwise, this is the string id value.
+    </td>
+  </tr>
+  <tr>
+    <td>d1</td>
+    <td>
+      The last character of the string in the id variable.
+      If id variable is empty then, the value is the character 0 (U+0030).
+    </td>
+  </tr>
+  <tr>
+    <td>d2</td>
+    <td>
+      The second last character of the string in the id variable.
+      If the id variable has less than 2 characters then, the value is the character 0 (U+0030).
+    </td>
+  </tr>
+  <tr>
+    <td>d3</td>
+    <td>
+      The third last character of the string in the id variable.
+      If the id variable has less than 3 characters then, the value is the character 0 (U+0030).
+    </td>
+  </tr>
+  <tr>
+    <td>d4</td>
+    <td>
+      The fourth last character of the string in the id variable.
+      If the id variable has less than 4 characters then, the value is the character 0 (U+0030).
+    </td>
+  </tr>
+</table>
+
+The variables d1 through d4 select a specific character of the id variable. In this context a character is a [[!unicode]] code point.
+If the code point is not an ASCII code point then during expansion it will need to be converted to
+[[UTF-8]] and percent encoded as required by [[rfc6570#section-1.6]].
+
+<div class="example">
+
+Some example inputs and the corresponding expansions:
+
+<table>
+  <tr><th>Template</th><th>Input ID</th><th>Expansion</th></tr>
+  <tr>
+    <td>//foo.bar/{id}</td>
+    <td>123</td>
+    <td>//foo.bar/7B</td>
+  </tr>
+  <tr>
+    <td>//foo.bar{/d1,d2,id}</td>
+    <td>123</td>
+    <td>//foo.bar/B/7/7B</td>
+  </tr>
+  <tr>
+    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>123</td>
+    <td>//foo.bar/B/7/0/7B</td>
+  </tr>
+n    <tr>
+    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>baz</td>
+    <td>//foo.bar/z/a/b/baz</td>
+  </tr>
+  </tr>
+    <tr>
+    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>az</td>
+    <td>//foo.bar/z/a/0/az</td>
+  </tr>
+  </tr>
+    <tr>
+    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>àbc</td>
+    <td>//foo.bar/c/b/%C3%A0/%C3%A0bc</td>
+  </tr>
+</table>
+
+</div>
+
+
 Font Patch Formats {#font-patch-formats}
 ========================================
 
@@ -1261,36 +1473,6 @@ In incremental font transfer [=font subset|font subsets=] are extended by applyi
 This specification defines three patch formats, each appropriate to its own set of augmentation scenarios. A single
 encoding can make use of more than one patch format.
 
-Definitions {#font-patch-definitions}
--------------------------------------
-
-A <dfn dfn>font patch</dfn> is a file which encodes changes to be made to an IFT-encoded font. Patches are used to extend
-an existing [=font subset=] and provide expanded coverage.
-
-A <dfn dfn>patch format</dfn> is a specified encoding of changes to be applied relative to a [=font subset=]. A set of
-changes encoded according to the format is a [=font patch=]. Each [=patch format=] has an associated 
-<dfn dfn>patch application algorithm</dfn> which takes a
-[=font subset=] and a [=font patch=] encoded in the [=patch format=] as input and outputs an extended
-[=font subset=].
-
-Patch Invalidations {#font-patch-invalidations}
------------------------------------------------
-
-Patches in an incremental [=font subset=] when applied may invalidate other available patches, making them invalid to be applied
-to the extended [=font subset=]. Patch validity is checked using the compatibility ID from the [[#patch-map]]. Every patch has a
-compatibility ID encoded within it which needs to match the compatibility ID from the [[#patch-map]] which lists that patch. Additionally
-to aid the client in determining what invalidations will occur, every patch is categorized into one of three categories:
-
-* <dfn dfn>Full Invalidation</dfn>: when this patch is applied all other patches currently listed in the [=font subset=] are invalidated.
-    The compatibility ID in both the 'IFT ' and 'IFTX' [[#patch-map]] will be changed.
-
-* <dfn dfn>Partial Invalidation</dfn>: when this patch is applied all other patches in the same [[#patch-map]] will be invalidated.
-    The compatibility ID of only the [[#patch-map]] which contains this patch will be changed.
-
-* <dfn dfn>No Invalidation</dfn>: no other patches will be invalidated by the application of this patch. The compatibility ID of the
-    'IFT ' and 'IFTX' [[#patch-map]] will not change.
-
-The invalidation behaviour of a specific patch is encoded in its format number which can be found in the following section.
 
 Formats Summary {#font-patch-formats-summary}
 ---------------------------------------------
@@ -1701,7 +1883,7 @@ The algorithm:
 
 
 
-5. Locate the [[#patch-map]] table which has the same [=Glyph keyed patch/compatibilityId=] as <var>compatibility id</var>. If it is a
+5. Locate the [[#patch-map-table]] which has the same [=Glyph keyed patch/compatibilityId=] as <var>compatibility id</var>. If it is a
     format 1 patch map then, invoke [$Remove Entries from Format 1 Patch Map$] with the patch map table and <var>patch uri</var> as an
     input. Otherwise if it is a format 2 patch map then, invoke [$Remove Entries from Format 2 Patch Map$] with the patch map table and
     <var>patch uri</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.
@@ -1713,162 +1895,6 @@ The algorithm:
     for each modified table: update the checksums in the [[open-type/otff#table-directory|fonts table directory]] to match the table's
     new contents.
 
-<h2 algorithm id="extending-font-subset">Extending a Font Subset</h2>
-
-This sections defines the algorithm that a client uses to extend an [=incremental font|incremental=] [=font subset=] to cover additional
-codepoints, layout features and/or design space.
-
-<dfn abstract-op>Extend a Font Subset</dfn>
-
-The inputs to this algorithm are:
-
-* <var>font subset</var>: an [=incremental font|incremental=] [=font subset=].
-
-* <var>font subset URI</var>: an [[rfc3986#section-4.3|abslolute URI]] which identifies the location of <var>font subset</var>.
-
-* <var>target subset definition</var>: the [=font subset definition=] that the client wants to extend <var>font subset</var> to cover.
-
-The algorithm outputs:
-
-* <var>extended font subset</var>: an extended version of <var>font subset</var>. May or may not be an [=incremental font=].
-
-The algorithm:
-
-1.  Set <var>extended font subset</var> to <var>font subset</var>.
-
-2.  Load the 'IFT ' and 'IFTX' (if present) mapping [[open-type/otff#table-directory|tables]] from <var>extended font subset</var>. Both
-    tables are formatted as a [[#patch-map]]. Check that they are valid according to the requirements in [[#patch-map]]. If either table
-    is not valid, invoke [$Handle errors$]. If <var>extended font subset</var> does not have an 'IFT ' table, then it is not an
-    [=incremental font=] and cannot be extended, return <var>extended font subset</var>.
-
-3.  For each of [[open-type/otff#table-directory|tables]] 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
-    invoking [$Interpret Format 1 Patch Map$] or [$Interpret Format 2 Patch Map$]. Concatenate the returned entry lists into a single list,
-    <var>entry list</var>.
-
-4.  For each <var>entry</var> in <var>entry list</var> invoke [$Check entry intersection$] with <var>entry</var> and
-    <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var>
-    from <var>entry list</var>.
-
-5.  If <var>entry list</var> is empty, then the extension operation is finished, return <var>extended font subset</var>.
-
-6.  Pick one <var>entry</var> from <var>entry list</var> with the following procedure:
-
-    *  If <var>entry list</var> contains one or more [=patch map entries=] which have a patch format that is [=Full Invalidation=]
-        then, select exactly one of the [=Full Invalidation=] entries in <var>entry list</var>. The criteria for selecting the single
-        entry is left up to the implementation to decide.
-
-    *  Otherwise if <var>entry list</var> contains one or more [=patch map entries=] which have a patch format that is
-        [=Partial Invalidation=] then, select exactly one of the [=Partial Invalidation=] entries in <var>entry list</var>.
-        The criteria for selecting the single entry is left up to the implementation to decide.
-
-    *  Otherwise select exactly one of the [=No Invalidation=] entries in <var>entry list</var>.
-        The criteria for selecting the single entry is left up to the implementation to decide.
-
-7.  Load <var>patch file</var> by invoking [$Load patch file$] with the <var>font subset URI</var> as the incremental font URI and the
-    <var>entry</var> patch URI as the patch URI.
-
-8.  Apply <var>patch file</var> using the appropriate application algorithm (matching the patches format in <var>entry</var>) from
-    [[#font-patch-formats]] to apply the <var>patch file</var> using the patch URI and the compatibility id from <var>entry</var> to
-    <var>extended font subset</var>.
-
-9.  Go to step 2.
-
-Note: the algorithm here presents patch loads as being done one at a time; however, to improve performance client implementations are
-encouraged to pre-fetch patch files that will be applied in later iterations by the algorithm. The
-[[#font-patch-invalidations|invalidation categories]] can be used to predict which intersecting patches from step 4 will remain be valid
-to be applied.
-
-<!-- TODO: provide criteria to exit if stuck in an infinite loop. Could require that no specific URL is loaded more than once?
-           Could require that each patch application result in an extended coverage in some way? Also allow the client to define
-	   an max iteration count? -->
-<!-- TODO: also consider adding additional changes to prevent degenerate behaviour from happening (eg. iteration limits, minimum codepoint group sizes). -->
-    
-<dfn abstract-op>Check entry intersection</dfn>
-
-The inputs to this algorithm are:
-
-*   <var>mapping entry</var>: a [=patch map entries|patch map entry=].
-
-*   <var>subset definition</var>: a [=font subset definition=].
-
-The algorithm outputs:
-
-*   <var>intersects</var>: true if <var>subset definition</var> intersects <var>mapping entry</var>, otherwise false.
-
-The algorithm:
-
-1.  For each set in <var>subset definition</var> (codepoints, feature tags, design space) check if the set intersects
-     the corresponding set from <var>mapping entry</var>. A set intersects when:
-
-     <table>
-       <tr>
-         <th></th><th>subset definition set is empty</th><th>subset definition set is not empty</th>
-       </tr>
-       <tr>
-         <th>mapping entry set is empty</th><td>true</td><td>true</td>
-       </tr>
-       <tr>
-         <th>mapping entry set is not empty</th><td>false</td><td>true if the two sets intersect</td>
-       </tr>
-     </table>
-
-2. If all sets checked in step 1 intersect, then return true for <var>intersects</var> otherwise false.
-
-<dfn abstract-op>Load patch file</dfn>
-
-<!-- TODO: consider requiring HTTPS (or disallowing HTTP specifically if we want to allow file:// and other url types) -->
-
-The inputs to this algorithm are:
-
-*   <var>Patch URI</var>: A [[rfc3986#section-4.1|URI Reference]] identifying the patch file to load. As a URI reference this may be a
-     relative path.
-
-*   <var>Incremental Font URI</var>: An [[rfc3986#section-4.3|abslolute URI]] which identifies the incremental font which contains
-     the reference to <var>Patch URI</var>.
-
-The algorithm outputs:
-
-*   <var>patch file</var>: the content (bytes) identified by <var>Patch URI</var>.
-
-The algorithm:
-
-1.  Perform [[rfc3986#section-5|reference resolution]] on <var>Patch URI</var> using <var>Incremental Font URI</var> as the base URI to
-     produce the <var>target URI</var>.
-
-2.  Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers,
-     [[fetch]] should be used. Return the retrieved contents as <var>patch file</var>, or an error if the fetch resulted in an error.
-
-<dfn abstract-op>Handle errors</dfn>
-
-Coming soon.
-
-<!-- TODO -->
-
-<!-- TODO: we should consider defining a valid encoded IFT font as one that produces a correct font subset for the corresponding
-           definition in the entry. This would likely be the only requirement made for encoders. -->
-
-<h3 algorithm id="fully-expanding-a-font">Fully Expanding a Font</h3>
-
-This sections defines an algorithm that can be used to transform an incremental font into a fully expanded non-incremental font. This
-process loads all available data provided by the incremental font and produces a single static font file that contains no further
-patches to be applied.
-
-<dfn abstract-op>Fully Expand a Font Subset</dfn>
-
-The inputs to this algorithm are:
-
-* <var>font subset</var>: an [=incremental font|incremental=] [=font subset=].
-
-The algorithm outputs:
-
-* <var>expanded font</var>: an [[open-type]] font that is not incremental.
-
-The algorithm:
-
-1. Invoke [$Extend a Font Subset$] with <var>font subset</var>. The input target subset definition is a special one which
-    is considered to intersect all entries in the [$Check entry intersection$] step. Return the resulting font subset as
-    the <var>expanded font</var>.
-
 Encoder {#encoder}
 ==================
 
@@ -1877,13 +1903,13 @@ The [=incremental font=] and associated patches produced by a compliant encoder:
 
 1.  Must meet all of the requirements in [[#font-format-extensions]] and [[#font-patch-formats]].
 
-2.  Must be consistent, that is: for any possible [=font subset definition=] the result of invoking [$Extend a Font Subset$] 
+2.  Must be consistent, that is: for any possible [=font subset definition=] the result of invoking [$Extend an Incremental Font Subset$] 
     with that subset definition and the [=incremental font=] must always be the same regardless of the particular order
-    of patch selection chosen in step 6 of [$Extend a Font Subset$].
+    of patch selection chosen in step 6 of [$Extend an Incremental Font Subset$].
 
 3.  Should preserve the functionality of the fully expanded font, that is:
      given the [$Fully Expand a Font Subset|fully expanded font$] derived from the [=incremental font=]
-     and any content, then the [=font subset=] produced by invoking [$Extend a Font Subset$] with the
+     and any content, then the [=font subset=] produced by invoking [$Extend an Incremental Font Subset$] with the
      [=incremental font=] and the minimal subset definition covering that content should
      render identically to the fully expanded font for that content.
 

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="0230aa3505b2277beff13ee7dbf0970e02e4dbb7" name="revision">
+  <meta content="4a24a41b1b8d0b2a4f6190f92c39b4c5e3488950" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -607,7 +607,7 @@ var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBC
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-26">26 April 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-29">29 April 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -674,58 +674,60 @@ be loaded over multiple requests where each request incrementally adds additiona
     <li>
      <a href="#definitions"><span class="secno">3</span> <span class="content">Definitions</span></a>
      <ol class="toc">
-      <li><a href="#font-subset-info"><span class="secno">3.1</span> <span class="content">Font Subset</span></a>
-      <li><a href="#data-types"><span class="secno">3.2</span> <span class="content">Data Types</span></a>
-      <li><a href="#uri-templates"><span class="secno">3.3</span> <span class="content">URI Templates</span></a>
+      <li><a href="#font-subset-dfn"><span class="secno">3.1</span> <span class="content">Font Subset</span></a>
+      <li><a href="#font-patch-definitions"><span class="secno">3.2</span> <span class="content">Font Patch</span></a>
+      <li><a href="#patch-map-dfn"><span class="secno">3.3</span> <span class="content">Patch Map</span></a>
+      <li><a href="#data-types"><span class="secno">3.4</span> <span class="content">Data Types</span></a>
      </ol>
     <li>
-     <a href="#font-format-extensions"><span class="secno">4</span> <span class="content">Extensions to the Font Format</span></a>
+     <a href="#extending-font-subset"><span class="secno">4</span> <span class="content">Extending a Font Subset</span></a>
      <ol class="toc">
-      <li><a href="#ift-and-woff2"><span class="secno">4.1</span> <span class="content">Incremental Font Transfer and WOFF2</span></a>
+      <li><a href="#font-patch-invalidations"><span class="secno">4.1</span> <span class="content">Patch Invalidations</span></a>
+      <li><a href="#extend-font-subset"><span class="secno">4.2</span> <span class="content">Incremental Font Extension Algorithm</span></a>
+      <li><a href="#fully-expanding-a-font"><span class="secno">4.3</span> <span class="content">Fully Expanding a Font</span></a>
+     </ol>
+    <li>
+     <a href="#font-format-extensions"><span class="secno">5</span> <span class="content">Extensions to the Font Format</span></a>
+     <ol class="toc">
+      <li><a href="#ift-and-woff2"><span class="secno">5.1</span> <span class="content">Incremental Font Transfer and WOFF2</span></a>
       <li>
-       <a href="#patch-map"><span class="secno">4.2</span> <span class="content">Patch Map Table</span></a>
+       <a href="#patch-map-table"><span class="secno">5.2</span> <span class="content">Patch Map Table</span></a>
        <ol class="toc">
         <li>
-         <a href="#patch-map-format-1"><span class="secno">4.2.1</span> <span class="content">Patch Map Table: Format 1</span></a>
+         <a href="#patch-map-format-1"><span class="secno">5.2.1</span> <span class="content">Patch Map Table: Format 1</span></a>
          <ol class="toc">
-          <li><a href="#interpreting-patch-map-format-1"><span class="secno">4.2.1.1</span> <span class="content">Interpreting Format 1</span></a>
-          <li><a href="#remove-entries-format-1"><span class="secno">4.2.1.2</span> <span class="content">Remove Entries from Format 1</span></a>
+          <li><a href="#interpreting-patch-map-format-1"><span class="secno">5.2.1.1</span> <span class="content">Interpreting Format 1</span></a>
+          <li><a href="#remove-entries-format-1"><span class="secno">5.2.1.2</span> <span class="content">Remove Entries from Format 1</span></a>
          </ol>
         <li>
-         <a href="#patch-map-format-2"><span class="secno">4.2.2</span> <span class="content">Patch Map Table: Format 2</span></a>
+         <a href="#patch-map-format-2"><span class="secno">5.2.2</span> <span class="content">Patch Map Table: Format 2</span></a>
          <ol class="toc">
-          <li><a href="#interpreting-patch-map-format-2"><span class="secno">4.2.2.1</span> <span class="content">Interpreting Format 2</span></a>
-          <li><a href="#remove-entries-format-2"><span class="secno">4.2.2.2</span> <span class="content">Remove Entries from Format 2</span></a>
-          <li><a href="#sparse-bit-set-decoding"><span class="secno">4.2.2.3</span> <span class="content">Sparse Bit Set</span></a>
+          <li><a href="#interpreting-patch-map-format-2"><span class="secno">5.2.2.1</span> <span class="content">Interpreting Format 2</span></a>
+          <li><a href="#remove-entries-format-2"><span class="secno">5.2.2.2</span> <span class="content">Remove Entries from Format 2</span></a>
+          <li><a href="#sparse-bit-set-decoding"><span class="secno">5.2.2.3</span> <span class="content">Sparse Bit Set</span></a>
          </ol>
+        <li><a href="#uri-templates"><span class="secno">5.2.3</span> <span class="content">URI Templates</span></a>
        </ol>
      </ol>
     <li>
-     <a href="#font-patch-formats"><span class="secno">5</span> <span class="content">Font Patch Formats</span></a>
+     <a href="#font-patch-formats"><span class="secno">6</span> <span class="content">Font Patch Formats</span></a>
      <ol class="toc">
-      <li><a href="#font-patch-definitions"><span class="secno">5.1</span> <span class="content">Definitions</span></a>
-      <li><a href="#font-patch-invalidations"><span class="secno">5.2</span> <span class="content">Patch Invalidations</span></a>
-      <li><a href="#font-patch-formats-summary"><span class="secno">5.3</span> <span class="content">Formats Summary</span></a>
+      <li><a href="#font-patch-formats-summary"><span class="secno">6.1</span> <span class="content">Formats Summary</span></a>
       <li>
-       <a href="#brotli"><span class="secno">5.4</span> <span class="content">Brotli Patch</span></a>
+       <a href="#brotli"><span class="secno">6.2</span> <span class="content">Brotli Patch</span></a>
        <ol class="toc">
-        <li><a href="#apply-brotli"><span class="secno">5.4.1</span> <span class="content">Applying Brotli Patches</span></a>
+        <li><a href="#apply-brotli"><span class="secno">6.2.1</span> <span class="content">Applying Brotli Patches</span></a>
        </ol>
       <li>
-       <a href="#per-table-brotli"><span class="secno">5.5</span> <span class="content">Per Table Brotli</span></a>
+       <a href="#per-table-brotli"><span class="secno">6.3</span> <span class="content">Per Table Brotli</span></a>
        <ol class="toc">
-        <li><a href="#apply-per-table-brotli"><span class="secno">5.5.1</span> <span class="content">Applying Per Table Brotli Patches</span></a>
+        <li><a href="#apply-per-table-brotli"><span class="secno">6.3.1</span> <span class="content">Applying Per Table Brotli Patches</span></a>
        </ol>
       <li>
-       <a href="#glyph-keyed"><span class="secno">5.6</span> <span class="content">Glyph Keyed</span></a>
+       <a href="#glyph-keyed"><span class="secno">6.4</span> <span class="content">Glyph Keyed</span></a>
        <ol class="toc">
-        <li><a href="#apply-glyph-keyed"><span class="secno">5.6.1</span> <span class="content">Applying Glyph Keyed Patches</span></a>
+        <li><a href="#apply-glyph-keyed"><span class="secno">6.4.1</span> <span class="content">Applying Glyph Keyed Patches</span></a>
        </ol>
-     </ol>
-    <li>
-     <a href="#extending-font-subset"><span class="secno">6</span> <span class="content">Extending a Font Subset</span></a>
-     <ol class="toc">
-      <li><a href="#fully-expanding-a-font"><span class="secno">6.1</span> <span class="content">Fully Expanding a Font</span></a>
      </ol>
     <li>
      <a href="#encoder"><span class="secno">7</span> <span class="content">Encoder</span></a>
@@ -770,22 +772,22 @@ example, even using WOFF 2 <a data-link-type="biblio" href="#biblio-woff2" title
    <p>See the Progressive Font Enrichment: Evaluation Report <a data-link-type="biblio" href="#biblio-pfe-report" title="Progressive Font Enrichment: Evaluation Report">[PFE-report]</a> for the investigation which led
 to this specification.</p>
    <h3 class="heading settled" data-level="1.2" id="overview"><span class="secno">1.2. </span><span class="content">Overview</span><a class="self-link" href="#overview"></a></h3>
-   <p>An IFT font is a regular <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> font that is reformated to include incremental functionality, partly in virtue of
-of two additional <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a>. Using these new tables the font can be augmented (eg. to cover more codepoints)
-by loading and applying patches to it.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="incremental-font">incremental font</dfn> is a regular <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> font that is reformatted to include incremental functionality,
+partly in virtue of two additional <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a>. Using these new tables the font can be augmented
+(eg. to cover more codepoints) by loading and applying patches to it.</p>
    <p>The IFT technology has four main pieces:</p>
    <ul>
     <li data-md>
-     <p><a href="#font-format-extensions">§ 4 Extensions to the Font Format</a>: defines the new tables which contain a list of patches that are available to be applied to a font.</p>
+     <p><a href="#extending-font-subset">§ 4 Extending a Font Subset</a>: provides the algorithm that is used by a client to select and apply patches.</p>
     <li data-md>
-     <p><a href="#font-patch-formats">§ 5 Font Patch Formats</a>: defines three different types of patches that can be used. Two are "generic" binary patches, one is
+     <p><a href="#font-format-extensions">§ 5 Extensions to the Font Format</a>: defines the new tables which contain a list of patches that are available to be applied to a font.</p>
+    <li data-md>
+     <p><a href="#font-patch-formats">§ 6 Font Patch Formats</a>: defines three different types of patches that can be used. Two are "generic" binary patches, one is
  specific to the font’s format for storing glyph data.</p>
-    <li data-md>
-     <p><a href="#extending-font-subset">§ 6 Extending a Font Subset</a>: provides the algorithm that is used by a client to select and apply patches.</p>
     <li data-md>
      <p><a href="#encoder">§ 7 Encoder</a>: creates the font and associated patches that form an incremental font.</p>
    </ul>
-   <p>At a high level an IFT font is used like this:</p>
+   <p>At a high level an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font">incremental font</a> is used like this:</p>
    <ol>
     <li data-md>
      <p>The client downloads an initial font file, which contains some initial subset of data from the full version of the font along with <a href="#font-format-extensions">embedded data</a> describing the set of <a href="#font-patch-formats">patches</a> which can be used to extend 
@@ -800,7 +802,7 @@ content.</p>
 encoding defined in this specification. At a high level converting an existing font to be incremental will look like this:</p>
    <ol>
     <li data-md>
-     <p>Choose the content of the initial <a href="#font-subset-info">subset</a>, this will be included in the initial font file the client loads
+     <p>Choose the content of the initial <a href="#font-subset-dfn">subset</a>, this will be included in the initial font file the client loads
 and usually consists of any data from the original font that is expected to always be needed.</p>
     <li data-md>
      <p>Choose a segmentation of the font. Individual segments will be added to the base subset by the client using patches. Choosing an
@@ -880,7 +882,7 @@ transferred font since the saved page won’t be able to increment the font if c
 due to JavaScript execution). In these cases the page saving mechanism should fully expand the incremental font
 by invoking <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset">Fully Expand a Font Subset</a> and replace references to the incremental font with the fully expanded one.</p>
    <h2 class="heading settled" data-level="3" id="definitions"><span class="secno">3. </span><span class="content">Definitions</span><a class="self-link" href="#definitions"></a></h2>
-   <h3 class="heading settled" data-level="3.1" id="font-subset-info"><span class="secno">3.1. </span><span class="content">Font Subset</span><a class="self-link" href="#font-subset-info"></a></h3>
+   <h3 class="heading settled" data-level="3.1" id="font-subset-dfn"><span class="secno">3.1. </span><span class="content">Font Subset</span><a class="self-link" href="#font-subset-dfn"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-subset">font subset</dfn> is a modified version of a font file <a data-link-type="biblio" href="#biblio-iso14496-22" title="Information technology — Coding of audio-visual objects — Part 22: Open Font Format">[iso14496-22]</a> that contains only the data
 needed to render a subset of:</p>
    <ul>
@@ -898,117 +900,237 @@ are specified using the user-axis scales (<a href="https://docs.microsoft.com/en
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-subset-definition">font subset definition</dfn> describes the minimum data (codepoints, layout features,
 variation axis space) that a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset">font subset</a> should support.</p>
    <p class="note" role="note"><span class="marker">Note:</span> For convenience the remainder of this document links to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">[open-type]</a> specification which is a copy of <a data-link-type="biblio" href="#biblio-iso14496-22" title="Information technology — Coding of audio-visual objects — Part 22: Open Font Format">[iso14496-22]</a>.</p>
-   <h3 class="heading settled" data-level="3.2" id="data-types"><span class="secno">3.2. </span><span class="content">Data Types</span><a class="self-link" href="#data-types"></a></h3>
-   <p>Encoded data structures in the remainder of this specification are described in terms of the data types defined
-in <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types">OpenType Specification § otff#data-types</a>. As with the rest of OpenType, all fields use "big-endian" byte ordering.</p>
-   <h3 class="heading settled" data-level="3.3" id="uri-templates"><span class="secno">3.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h3>
-   <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URIs where patch files are located.
-A string ID is a sequence of <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">Unicode</a> code point values obtained from decoding a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> string (see <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.6">URI Template § section-1.6</a>). Several variables are defined which are used to produce the
-expansion of the template:</p>
+   <h3 class="heading settled" data-level="3.2" id="font-patch-definitions"><span class="secno">3.2. </span><span class="content">Font Patch</span><a class="self-link" href="#font-patch-definitions"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-patch">font patch</dfn> is a file which encodes changes to be made to an IFT-encoded font. Patches are used to extend
+an existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①">font subset</a> and provide expanded coverage.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-format">patch format</dfn> is a specified encoding of changes to be applied relative to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②">font subset</a>. A set of
+changes encoded according to the format is a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Each <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
+   <h3 class="heading settled" data-level="3.3" id="patch-map-dfn"><span class="secno">3.3. </span><span class="content">Patch Map</span><a class="self-link" href="#patch-map-dfn"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map">patch map</dfn> is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">open type table</a> which encodes a collection of mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which host <a href="#font-patch-formats">patches</a> that extend the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental font</a>. A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map">patch map</a> table encodes a list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map-entries">patch map entries</dfn>, where each entry has a key and value.
+The key is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a> and the value is a URI, the <a href="#font-patch-formats">§ 6 Font Patch Formats</a> used by the data at the URI, and the <a href="#font-patch-invalidations">compatibility ID</a> of the patch map table. More details of the format of patch maps can be found
+in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a>.</p>
+   <p><a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries">Patch Map Entry</a> summary:</p>
    <table>
     <tbody>
      <tr>
-      <th>Variable
+      <th>Key
       <th>Value
      <tr>
-      <td>id
-      <td> If the input id is numeric then this is the  numeric value converted to a string in hexadecimal representation
-      (using the digits 0-9, A-F). No padding with 0’s is used. Otherwise, this is the string id value. 
-     <tr>
-      <td>d1
-      <td> The last character of the string in the id variable.
-      If id variable is empty then, the value is the character 0 (U+0030). 
-     <tr>
-      <td>d2
-      <td> The second last character of the string in the id variable.
-      If the id variable has less than 2 characters then, the value is the character 0 (U+0030). 
-     <tr>
-      <td>d3
-      <td> The third last character of the string in the id variable.
-      If the id variable has less than 3 characters then, the value is the character 0 (U+0030). 
-     <tr>
-      <td>d4
-      <td> The fourth last character of the string in the id variable.
-      If the id variable has less than 4 characters then, the value is the character 0 (U+0030). 
+      <td>
+       <ul>
+        <li data-md>
+         <p><a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">font subset definition</a></p>
+       </ul>
+      <td>
+       <ul>
+        <li data-md>
+         <p>Patch URI</p>
+        <li data-md>
+         <p><a href="#font-patch-formats">Patch Format</a></p>
+        <li data-md>
+         <p><a href="#font-patch-invalidations">compatibility ID</a></p>
+       </ul>
    </table>
-   <p>The variables d1 through d4 select a specific character of the id variable. In this context a character is a <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">[unicode]</a> code point.
-If the code point is not an ASCII code point then during expansion it will need to be converted to <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> and percent encoded as required by <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.6">URI Template § section-1.6</a>.</p>
-   <div class="example" id="example-096f0d2d">
-    <a class="self-link" href="#example-096f0d2d"></a> 
-    <p>Some example inputs and the corresponding expansions:</p>
-    <table>
-     <tbody>
-      <tr>
-       <th>Template
-       <th>Input ID
-       <th>Expansion
-      <tr>
-       <td>//foo.bar/{id}
-       <td>123
-       <td>//foo.bar/7B
-      <tr>
-       <td>//foo.bar{/d1,d2,id}
-       <td>123
-       <td>//foo.bar/B/7/7B
-      <tr>
-       <td>//foo.bar{/d1,d2,d3,id}
-       <td>123
-       <td>//foo.bar/B/7/0/7B
-      <tr>
-       <td>//foo.bar{/d1,d2,d3,id}
-       <td>baz
-       <td>//foo.bar/z/a/b/baz
-      <tr>
-       <td>//foo.bar{/d1,d2,d3,id}
-       <td>az
-       <td>//foo.bar/z/a/0/az
-      <tr>
-       <td>//foo.bar{/d1,d2,d3,id}
-       <td>àbc
-       <td>//foo.bar/c/b/%C3%A0/%C3%A0bc
-    </table>
-   </div>
-   <h2 class="heading settled" data-level="4" id="font-format-extensions"><span class="secno">4. </span><span class="content">Extensions to the Font Format</span><a class="self-link" href="#font-format-extensions"></a></h2>
-   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="incremental-font">incremental font</dfn> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but includes two new <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both <a href="#patch-map">patch maps</a>, which encode a collection of mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which
-host <a href="#font-patch-formats">patches</a> that extend the incremental font. All incremental fonts must contain the 'IFT ' table.
-The 'IFTX' table is optional. When both tables are present, the mapping of the font as a whole is the union of the mappings of
-the two tables. The two new tables are used only in this specification and are not being added to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">Open-Type</a> specification.</p>
+   <h3 class="heading settled" data-level="3.4" id="data-types"><span class="secno">3.4. </span><span class="content">Data Types</span><a class="self-link" href="#data-types"></a></h3>
+   <p>Encoded data structures in the remainder of this specification are described in terms of the data types defined
+in <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types">OpenType Specification § otff#data-types</a>. As with the rest of OpenType, all fields use "big-endian" byte ordering.</p>
+   <h2 class="heading settled" data-level="4" id="extending-font-subset"><span class="secno">4. </span><span class="content">Extending a Font Subset</span><a class="self-link" href="#extending-font-subset"></a></h2>
+   <p>This sections defines the algorithm that a client uses to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> to cover additional
+codepoints, layout features and/or design space.</p>
+   <h3 class="heading settled" data-level="4.1" id="font-patch-invalidations"><span class="secno">4.1. </span><span class="content">Patch Invalidations</span><a class="self-link" href="#font-patch-invalidations"></a></h3>
+   <p>Patches in an incremental <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> when applied may invalidate other available patches, making them invalid to be applied
+to the extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a>. Patch validity is checked using the compatibility ID from the <a href="#patch-map-table">§ 5.2 Patch Map Table</a>. Every patch has a
+compatibility ID encoded within it which needs to match the compatibility ID from the <a href="#patch-map-table">§ 5.2 Patch Map Table</a> which lists that patch.
+Additionally to aid the client in determining what invalidations will occur, every patch is categorized into one of three categories:</p>
+   <ul>
+    <li data-md>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="full-invalidation">Full Invalidation</dfn>: when this patch is applied all other patches currently listed in the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a> are invalidated.
+The compatibility ID in both the 'IFT ' and 'IFTX' <a href="#patch-map-table">§ 5.2 Patch Map Table</a> will be changed.</p>
+    <li data-md>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="partial-invalidation">Partial Invalidation</dfn>: when this patch is applied all other patches in the same <a href="#patch-map-table">§ 5.2 Patch Map Table</a> will be invalidated.
+The compatibility ID of only the <a href="#patch-map-table">§ 5.2 Patch Map Table</a> which contains this patch will be changed.</p>
+    <li data-md>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="no-invalidation">No Invalidation</dfn>: no other patches will be invalidated by the application of this patch. The compatibility ID of the
+'IFT ' and 'IFTX' <a href="#patch-map-table">§ 5.2 Patch Map Table</a> will not change.</p>
+   </ul>
+   <p>The invalidation behaviour of a specific patch is encoded in its format number which can be found in <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a>.</p>
+   <h3 class="heading settled algorithm" data-algorithm="Incremental Font Extension Algorithm" data-level="4.2" id="extend-font-subset"><span class="secno">4.2. </span><span class="content">Incremental Font Extension Algorithm</span><a class="self-link" href="#extend-font-subset"></a></h3>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</dfn></p>
+   <p>The inputs to this algorithm are:</p>
+   <ul>
+    <li data-md>
+     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font③">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a>.</p>
+    <li data-md>
+     <p><var>font subset URI</var>: an <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the location of <var>font subset</var>.</p>
+    <li data-md>
+     <p><var>target subset definition</var>: the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a> that the client wants to extend <var>font subset</var> to cover.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p><var>extended font subset</var>: an extended version of <var>font subset</var>. May or may not be an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font④">incremental font</a>.</p>
+   </ul>
+   <p>The algorithm:</p>
+   <ol>
+    <li data-md>
+     <p>Set <var>extended font subset</var> to <var>font subset</var>.</p>
+    <li data-md>
+     <p>Load the 'IFT ' and 'IFTX' (if present) mapping <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> from <var>extended font subset</var>. Both
+tables are formatted as a <a href="#patch-map-table">§ 5.2 Patch Map Table</a>. Check that they are valid according to the requirements in <a href="#patch-map-table">§ 5.2 Patch Map Table</a>. If
+either table is not valid, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors">Handle errors</a>. If <var>extended font subset</var> does not have an 'IFT ' table, then it is
+not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑤">incremental font</a> and cannot be extended, return <var>extended font subset</var>.</p>
+    <li data-md>
+     <p>For each of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
+invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a> or <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a>. Concatenate the returned entry lists into a single list, <var>entry list</var>.</p>
+    <li data-md>
+     <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection">Check entry intersection</a> with <var>entry</var> and <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var> from <var>entry list</var>.</p>
+    <li data-md>
+     <p>If <var>entry list</var> is empty, then the extension operation is finished, return <var>extended font subset</var>.</p>
+    <li data-md>
+     <p>Pick one <var>entry</var> from <var>entry list</var> with the following procedure:</p>
+     <ul>
+      <li data-md>
+       <p>If <var>entry list</var> contains one or more <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①">patch map entries</a> which have a patch format that is <a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation">Full Invalidation</a> then, select exactly one of the <a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation①">Full Invalidation</a> entries in <var>entry list</var>. The criteria for selecting the single
+entry is left up to the implementation to decide.</p>
+      <li data-md>
+       <p>Otherwise if <var>entry list</var> contains one or more <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries②">patch map entries</a> which have a patch format that is <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation">Partial Invalidation</a> then, select exactly one of the <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation①">Partial Invalidation</a> entries in <var>entry list</var>.
+The criteria for selecting the single entry is left up to the implementation to decide.</p>
+      <li data-md>
+       <p>Otherwise select exactly one of the <a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation">No Invalidation</a> entries in <var>entry list</var>.
+The criteria for selecting the single entry is left up to the implementation to decide.</p>
+     </ul>
+    <li data-md>
+     <p>Load <var>patch file</var> by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>font subset URI</var> as the incremental font URI and the <var>entry</var> patch URI as the patch URI.</p>
+    <li data-md>
+     <p>Apply <var>patch file</var> using the appropriate application algorithm (matching the patches format in <var>entry</var>) from <a href="#font-patch-formats">§ 6 Font Patch Formats</a> to apply the <var>patch file</var> using the patch URI and the compatibility id from <var>entry</var> to <var>extended font subset</var>.</p>
+    <li data-md>
+     <p>Go to step 2.</p>
+   </ol>
+   <p class="note" role="note"><span class="marker">Note:</span> the algorithm here presents patch loads as being done one at a time; however, to improve performance client implementations are
+encouraged to pre-fetch patch files that will be applied in later iterations by the algorithm. The <a href="#font-patch-invalidations">invalidation categories</a> can be used to predict which intersecting patches from step 4 will remain be valid
+to be applied.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-check-entry-intersection">Check entry intersection</dfn></p>
+   <p>The inputs to this algorithm are:</p>
+   <ul>
+    <li data-md>
+     <p><var>mapping entry</var>: a <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries③">patch map entry</a>.</p>
+    <li data-md>
+     <p><var>subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition④">font subset definition</a>.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p><var>intersects</var>: true if <var>subset definition</var> intersects <var>mapping entry</var>, otherwise false.</p>
+   </ul>
+   <p>The algorithm:</p>
+   <ol>
+    <li data-md>
+     <p>For each set in <var>subset definition</var> (codepoints, feature tags, design space) check if the set intersects
+ the corresponding set from <var>mapping entry</var>. A set intersects when:</p>
+     <table>
+      <tbody>
+       <tr>
+        <th>
+        <th>subset definition set is empty
+        <th>subset definition set is not empty
+       <tr>
+        <th>mapping entry set is empty
+        <td>true
+        <td>true
+       <tr>
+        <th>mapping entry set is not empty
+        <td>false
+        <td>true if the two sets intersect
+     </table>
+    <li data-md>
+     <p>If all sets checked in step 1 intersect, then return true for <var>intersects</var> otherwise false.</p>
+   </ol>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-load-patch-file">Load patch file</dfn></p>
+   <p>The inputs to this algorithm are:</p>
+   <ul>
+    <li data-md>
+     <p><var>Patch URI</var>: A <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.1">URI Reference</a> identifying the patch file to load. As a URI reference this may be a
+ relative path.</p>
+    <li data-md>
+     <p><var>Incremental Font URI</var>: An <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the incremental font which contains
+ the reference to <var>Patch URI</var>.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p><var>patch file</var>: the content (bytes) identified by <var>Patch URI</var>.</p>
+   </ul>
+   <p>The algorithm:</p>
+   <ol>
+    <li data-md>
+     <p>Perform <a href="https://www.rfc-editor.org/rfc/rfc3986#section-5">reference resolution</a> on <var>Patch URI</var> using <var>Incremental Font URI</var> as the base URI to
+ produce the <var>target URI</var>.</p>
+    <li data-md>
+     <p>Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers, <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[fetch]</a> should be used. Return the retrieved contents as <var>patch file</var>, or an error if the fetch resulted in an error.</p>
+   </ol>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-errors">Handle errors</dfn></p>
+   <p>Coming soon.</p>
+   <h3 class="heading settled algorithm" data-algorithm="Fully Expanding a Font" data-level="4.3" id="fully-expanding-a-font"><span class="secno">4.3. </span><span class="content">Fully Expanding a Font</span><a class="self-link" href="#fully-expanding-a-font"></a></h3>
+   <p>This sections defines an algorithm that can be used to transform an incremental font into a fully expanded non-incremental font. This
+process loads all available data provided by the incremental font and produces a single static font file that contains no further
+patches to be applied.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-fully-expand-a-font-subset">Fully Expand a Font Subset</dfn></p>
+   <p>The inputs to this algorithm are:</p>
+   <ul>
+    <li data-md>
+     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑥">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a>.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p><var>expanded font</var>: an <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">[open-type]</a> font that is not incremental.</p>
+   </ul>
+   <p>The algorithm:</p>
+   <ol>
+    <li data-md>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</a> with <var>font subset</var>. The input target subset definition is a special one which
+is considered to intersect all entries in the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> step. Return the resulting font subset as
+the <var>expanded font</var>.</p>
+   </ol>
+   <h2 class="heading settled" data-level="5" id="font-format-extensions"><span class="secno">5. </span><span class="content">Extensions to the Font Format</span><a class="self-link" href="#font-format-extensions"></a></h2>
+   <p>An <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑦">incremental font</a> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but includes two new <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①">patch maps</a>. All incremental fonts must contain the 'IFT ' table. The 'IFTX' table is optional. When both tables are
+present, the mapping of the font as a whole is the union of the mappings of the two tables. The two new tables are used only in this
+specification and are not being added to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">Open-Type</a> specification.</p>
    <p class="note" role="note"><span class="marker">Note:</span> allowing the mapping to be split between two distinct tables allows an incremental font to more easily make use of multiple
 patch types. For example all patches of one type can be specified in the 'IFT ' table, and all patches of a second type in the
 'IFTX' table. Those patches can make updates only to one of the mapping tables and avoid making conflicting updates.</p>
-   <h3 class="heading settled" data-level="4.1" id="ift-and-woff2"><span class="secno">4.1. </span><span class="content">Incremental Font Transfer and WOFF2</span><a class="self-link" href="#ift-and-woff2"></a></h3>
+   <h3 class="heading settled" data-level="5.1" id="ift-and-woff2"><span class="secno">5.1. </span><span class="content">Incremental Font Transfer and WOFF2</span><a class="self-link" href="#ift-and-woff2"></a></h3>
    <p><a data-link-type="biblio" href="#biblio-woff2" title="WOFF File Format 2.0">[WOFF2]</a> is a commonly used to encode fonts for transfer on the web. Incremental fonts can be encoded with WOFF2 as long as special care
 is taken. If an incremental font will be encoded by WOFF2 for transfer:</p>
    <ol>
     <li data-md>
-     <p>The incremental font should not make use of <a href="#brotli">§ 5.4 Brotli Patch</a> patches. The WOFF2 format does not guarantee the ordering of tables in
- the decoded font. <a href="#brotli">§ 5.4 Brotli Patch</a> patches are relative to a specific fixed set of bytes and thus cannot be used if the decoded font
- has unpredictable decoded bytes. <a href="#per-table-brotli">§ 5.5 Per Table Brotli</a> patches do not depend on a specific table ordering and may be used.</p>
+     <p>The incremental font should not make use of <a href="#brotli">§ 6.2 Brotli Patch</a> patches. The WOFF2 format does not guarantee the ordering of tables in
+ the decoded font. <a href="#brotli">§ 6.2 Brotli Patch</a> patches are relative to a specific fixed set of bytes and thus cannot be used if the decoded font
+ has unpredictable decoded bytes. <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches do not depend on a specific table ordering and may be used.</p>
     <li data-md>
      <p>If the WOFF2 encoding will include a transformed glyf and loca table (<a href="https://w3c.github.io/woff/woff2/#glyf_table_format"><cite>WOFF 2.0</cite> § 5.1 Transformed glyf table format</a>) then, the incremental
- font should not contain <a href="#per-table-brotli">§ 5.5 Per Table Brotli</a> patches which modify either the glyf or loca table. The WOFF2 format does not
+ font should not contain <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches which modify either the glyf or loca table. The WOFF2 format does not
  guarantee the specific bytes that result from decoding a transformed glyf and loca table, so as with #1 brotli patches cannot
- be used. <a href="#glyph-keyed">§ 5.6 Glyph Keyed</a> patches may be used in conjunction with a transformed glyf and loca table.</p>
+ be used. <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches may be used in conjunction with a transformed glyf and loca table.</p>
     <li data-md>
-     <p>When utilizing a WOFF2 encoded IFT font, the client must first fully decode the WOFF2 font before <a href="#extending-font-subset">§ 6 Extending a Font Subset</a>.</p>
+     <p>When utilizing a WOFF2 encoded IFT font, the client must first fully decode the WOFF2 font before <a href="#extending-font-subset">§ 4 Extending a Font Subset</a>.</p>
    </ol>
    <p>The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in <a href="https://w3c.github.io/woff/woff2/#table_format"><cite>WOFF 2.0</cite> § 5 Compressed data format</a>.</p>
-   <h3 class="heading settled" data-level="4.2" id="patch-map"><span class="secno">4.2. </span><span class="content">Patch Map Table</span><a class="self-link" href="#patch-map"></a></h3>
-   <p>A patch map table encodes a list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map-entries">patch map entries</dfn>, where each entry has a key and value. The key is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a> and the value is a URI, the <a href="#font-patch-formats">§ 5 Font Patch Formats</a> used by the data at the URI, and the compatibility ID
-of the patch map table. A map is encoded in one of two formats:</p>
+   <h3 class="heading settled" data-level="5.2" id="patch-map-table"><span class="secno">5.2. </span><span class="content">Patch Map Table</span><a class="self-link" href="#patch-map-table"></a></h3>
+   <p>A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map②">patch map</a> is encoded in one of two formats:</p>
    <ul>
     <li data-md>
      <p>Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URIs. It does
-not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
+not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
     <li data-md>
      <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
 is typically less compact than format 1.</p>
    </ul>
-   <p>Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset">Extend a Font Subset</a> algorithm invokes the interpretation algorithms and operates on the resulting entry list. The encoded bytes
-are the source of truth at all times for the patch map. Patch application during subset extension will alter the encoded bytes of the
-patch map and as a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets the encoded
-bytes at the start of every iteration to pick up any changes made in the previous iteration.</p>
-   <h4 class="heading settled" data-level="4.2.1" id="patch-map-format-1"><span class="secno">4.2.1. </span><span class="content">Patch Map Table: Format 1</span><a class="self-link" href="#patch-map-format-1"></a></h4>
+   <p>Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①">Extend an Incremental Font Subset</a> algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
+encoded bytes are the source of truth at all times for the patch map. Patch application during subset extension will alter the encoded
+bytes of the patch map and as a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets
+the encoded bytes at the start of every iteration to pick up any changes made in the previous iteration.</p>
+   <h4 class="heading settled" data-level="5.2.1" id="patch-map-format-1"><span class="secno">5.2.1. </span><span class="content">Patch Map Table: Format 1</span><a class="self-link" href="#patch-map-format-1"></a></h4>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="format-1-patch-map">Format 1 Patch Map</dfn> encoding:</p>
    <table>
     <tbody>
@@ -1027,7 +1149,7 @@ bytes at the start of every iteration to pick up any changes made in the previou
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-compatibilityid">compatibilityId</dfn>[4]
-      <td> Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 5.2 Patch Invalidations</a>). The encoder chooses this
+      <td> Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>). The encoder chooses this
       value. The encoder should set it to a random value which has not previously been used while encoding the IFT font. 
      <tr>
       <td>uint32
@@ -1057,11 +1179,11 @@ bytes at the start of every iteration to pick up any changes made in the previou
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 3.3 URI Templates</a> which is used to produce URIs associated with each entry. 
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.2.3 URI Templates</a> which is used to produce URIs associated with each entry. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchencoding">patchEncoding</dfn>
-      <td> Specifies the format of the patches linked to by uriTemplate. Using the ID number from the <a href="#font-patch-formats-summary">§ 5.3 Formats Summary</a> table. 
+      <td> Specifies the format of the patches linked to by uriTemplate. Using the ID number from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-map">Glyph Map</dfn> encoding:</p>
    <p>A glyph map table associates each glyph index in the font with an entry index.</p>
@@ -1146,25 +1268,25 @@ bytes at the start of every iteration to pick up any changes made in the previou
       Must be greater than or equal to firstEntryIndex. 
    </table>
    <p>An entry map record matches any entry indices that are greater than or equal to firstEntryIndex and less than or equal to  lastEntryIndex.</p>
-   <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 1" data-level="4.2.1.1" id="interpreting-patch-map-format-1"><span class="secno">4.2.1.1. </span><span class="content">Interpreting Format 1</span><a class="self-link" href="#interpreting-patch-map-format-1"></a></h5>
-   <p>This algorithm is used to convert a format 1 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries">patch map entries</a>.</p>
+   <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 1" data-level="5.2.1.1" id="interpreting-patch-map-format-1"><span class="secno">5.2.1.1. </span><span class="content">Interpreting Format 1</span><a class="self-link" href="#interpreting-patch-map-format-1"></a></h5>
+   <p>This algorithm is used to convert a format 1 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
      <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-1-patch-map" id="ref-for-format-1-patch-map">Format 1 Patch Map</a> encoded patch map.</p>
     <li data-md>
-     <p><var>font subset</var>: the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①">font subset</a> which contains <var>patch map</var>.</p>
+     <p><var>font subset</var>: the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> which contains <var>patch map</var>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①">patch map entries</a>.</p>
+     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">patch map entries</a>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 4.2.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 5.2.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
     <li data-md>
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex">entryIndex</a>:</p>
      <ul>
@@ -1175,9 +1297,9 @@ bytes at the start of every iteration to pick up any changes made in the previou
       <li data-md>
        <p>c. Convert the set of glyph indices to a set of unicode code points using the code point to glyph mapping in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.</p>
       <li data-md>
-       <p>d. Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate">uriTemplate</a> following <a href="#uri-templates">§ 3.3 URI Templates</a>.</p>
+       <p>d. Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
       <li data-md>
-       <p>e. Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries②">entry</a> to <var>entry list</var> whose subset definition contains only the unicode code point set and
+       <p>e. Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> to <var>entry list</var> whose subset definition contains only the unicode code point set and
 maps to the generated URI, the patch encoding specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
      </ul>
     <li data-md>
@@ -1190,11 +1312,11 @@ maps to the generated URI, the patch encoding specified by <a data-link-type="df
         <li data-md>
          <p>Compute <var>mapped entry index</var> = <a data-link-type="dfn" href="#featurerecord-firstentryindex" id="ref-for-featurerecord-firstentryindex">FeatureRecord::firstEntryIndex</a> + <var>entry index</var> - <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex①">EntryMapRecord::firstEntryIndex</a>.</p>
         <li data-md>
-         <p>Convert <var>mapped entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 3.3 URI Templates</a>.</p>
+         <p>Convert <var>mapped entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
         <li data-md>
          <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
         <li data-md>
-         <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries③">entry</a> to <var>entry list</var> whose subset definition contains the unicode code point set and
+         <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> to <var>entry list</var> whose subset definition contains the unicode code point set and
 a feature tag set containing only <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag①">featureTag</a>. The entry  maps to the generated URI, the patch encoding
 specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding①">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>.</p>
        </ul>
@@ -1202,7 +1324,7 @@ specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id
     <li data-md>
      <p>Return <var>entry list</var>.</p>
    </ol>
-   <h5 class="heading settled algorithm" data-algorithm="Remove Entries from Format 1" data-level="4.2.1.2" id="remove-entries-format-1"><span class="secno">4.2.1.2. </span><span class="content">Remove Entries from Format 1</span><a class="self-link" href="#remove-entries-format-1"></a></h5>
+   <h5 class="heading settled algorithm" data-algorithm="Remove Entries from Format 1" data-level="5.2.1.2" id="remove-entries-format-1"><span class="secno">5.2.1.2. </span><span class="content">Remove Entries from Format 1</span><a class="self-link" href="#remove-entries-format-1"></a></h5>
    <p>This algorithm is used to remove entries from a format 1 patch map. This removal modifies the bytes of the patch map but does not
 change the number of bytes.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</dfn></p>
@@ -1216,19 +1338,19 @@ change the number of bytes.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format①">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 4.2.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format①">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 5.2.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
     <li data-md>
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex①">entryIndex</a> of <var>patch map</var>:</p>
      <ul>
       <li data-md>
        <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap②">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate②">uriTemplate</a> following <a href="#uri-templates">§ 3.3 URI Templates</a>.</p>
+       <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate②">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
       <li data-md>
        <p>If the generated URI is equal to <var>patch URI</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> to 1.</p>
      </ul>
    </ol>
-   <h4 class="heading settled" data-level="4.2.2" id="patch-map-format-2"><span class="secno">4.2.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
+   <h4 class="heading settled" data-level="5.2.2" id="patch-map-format-2"><span class="secno">5.2.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="format-2-patch-map">Format 2 Patch Map</dfn> encoding:</p>
    <table>
     <tbody>
@@ -1247,12 +1369,12 @@ change the number of bytes.</p>
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-compatibilityid">compatibilityId</dfn>[4]
-      <td> Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 5.2 Patch Invalidations</a>). The encoder chooses this
+      <td> Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>). The encoder chooses this
       value. The encoder should set it to a random value which has not previously been used while encoding the IFT font. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</dfn>
-      <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry). Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 5.3 Formats Summary</a> table. 
+      <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry). Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entrycount">entryCount</dfn>
@@ -1273,7 +1395,7 @@ change the number of bytes.</p>
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 3.3 URI Templates</a> which is used to produce URIs associated with each entry. 
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.2.3 URI Templates</a> which is used to produce URIs associated with each entry. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entries">Mapping Entries</dfn> encoding:</p>
    <table>
@@ -1307,7 +1429,7 @@ change the number of bytes.</p>
      <tr>
       <td>Tag
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags</dfn>[featureCount]
-      <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set. 
+      <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑥">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set. 
      <tr>
       <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount</dfn>
@@ -1315,7 +1437,7 @@ change the number of bytes.</p>
      <tr>
       <td><a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment">Design Space Segment</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments</dfn>[designSpaceCount]
-      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition④">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set. 
+      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copycount">copyCount</dfn>
@@ -1323,7 +1445,7 @@ change the number of bytes.</p>
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices</dfn>[copyCount]
-      <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definition</a> should be copied into this entry. All
+      <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> should be copied into this entry. All
       values must be less than the index of this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
      <tr>
       <td>int24
@@ -1337,7 +1459,7 @@ change the number of bytes.</p>
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchencoding">patchEncoding</dfn>
-      <td> Specifies the format of the patch linked to by this entry. Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 5.3 Formats Summary</a> table.
+      <td> Specifies the format of the patch linked to by this entry. Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.
       Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 3 is set. 
      <tr>
@@ -1352,7 +1474,7 @@ change the number of bytes.</p>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codepoints</dfn>[variable]
       <td> Set of codepoints for this mapping. Encoded as a <a data-link-type="dfn" href="#sparse-bit-set" id="ref-for-sparse-bit-set">Sparse Bit Set</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑨">formatFlags</a> bit 4 and/or 5 is set. The length is
-      determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 4.2.2.3 Sparse Bit Set</a>. 
+      determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 5.2.2.3 Sparse Bit Set</a>. 
    </table>
    <p>If an encoder is producing patches that will be stored on a file system and then served it’s recommended that only numeric entry IDs be
 used (via <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a>) as these will generally produce the smallest encoding of the format 2 patch map. String IDs
@@ -1383,23 +1505,23 @@ needs to be taken when choosing the set of characters to use in the file names.<
       <td><dfn class="dfn-paneled" data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-end">end</dfn>
       <td> End (inclusive) of the segment. Must be greater than or equal to start. This value uses the user axis scale: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
    </table>
-   <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="4.2.2.1" id="interpreting-patch-map-format-2"><span class="secno">4.2.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
-   <p>This algorithm is used to convert a format 2 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a>.</p>
+   <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="5.2.2.1" id="interpreting-patch-map-format-2"><span class="secno">5.2.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
+   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map③">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map">Format 2 Patch Map</a> encoded patch map.</p>
+     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map">Format 2 Patch Map</a> encoded <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map④">patch map</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">patch map entries</a>.</p>
+     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑨">patch map entries</a>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 4.2.2 Patch Map Table: Format 2</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 5.2.2 Patch Map Table: Format 2</a>. If it is not return an error.</p>
     <li data-md>
      <p>Initialize <var>last entry id</var> to 0, <var>current byte</var> to 0, and <var>current id string byte</var> to 0.</p>
     <li data-md>
@@ -1441,7 +1563,7 @@ needs to be taken when choosing the set of characters to use in the file names.<
     <li data-md>
      <p><var>entry id</var>: the numeric or string id of this entry.</p>
     <li data-md>
-     <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a>.</p>
+     <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①⓪">entry</a>.</p>
     <li data-md>
      <p><var>consumed bytes</var>: the number of bytes used to encode the entry.</p>
     <li data-md>
@@ -1501,17 +1623,17 @@ from <var>entry bytes</var>.</p>
       <li data-md>
        <p>Otherwise the bias is 0.</p>
       <li data-md>
-       <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codepoints</a> from <var>entry bytes</var> following <a href="#sparse-bit-set-decoding">§ 4.2.2.3 Sparse Bit Set</a>. For each
+       <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codepoints</a> from <var>entry bytes</var> following <a href="#sparse-bit-set-decoding">§ 5.2.2.3 Sparse Bit Set</a>. For each
 codepoint add the bias value to it and then add the result to the codepoint set in <var>entry</var>.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑧">formatFlags</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
     <li data-md>
-     <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 3.3 URI Templates</a>. Set the patch uri of <var>entry</var> to the generated URI.</p>
+     <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>. Set the patch uri of <var>entry</var> to the generated URI.</p>
     <li data-md>
      <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength②">entryIdStringLength</a> as <var>consumed id string bytes</var>, and <var>ignored</var>.</p>
    </ol>
-   <h5 class="heading settled algorithm" data-algorithm="Remove Entries from Format 2" data-level="4.2.2.2" id="remove-entries-format-2"><span class="secno">4.2.2.2. </span><span class="content">Remove Entries from Format 2</span><a class="self-link" href="#remove-entries-format-2"></a></h5>
+   <h5 class="heading settled algorithm" data-algorithm="Remove Entries from Format 2" data-level="5.2.2.2" id="remove-entries-format-2"><span class="secno">5.2.2.2. </span><span class="content">Remove Entries from Format 2</span><a class="self-link" href="#remove-entries-format-2"></a></h5>
    <p>This algorithm is used to remove entries from a format 2 patch map. This removal modifies the bytes of the patch map but does not
 change the number of bytes.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</dfn></p>
@@ -1522,15 +1644,15 @@ change the number of bytes.</p>
     <li data-md>
      <p><var>patch URI</var>: URI for a patch which identifies the entries to be removed.</p>
    </ul>
-   <p>This algorithm is a modified version of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a>, invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map①">Interpret Format 2 Patch Map</a> with <var>patch map</var> as an input but with the following changes:</p>
+   <p>This algorithm is a modified version of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map①">Interpret Format 2 Patch Map</a>, invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map②">Interpret Format 2 Patch Map</a> with <var>patch map</var> as an input but with the following changes:</p>
    <ul>
     <li data-md>
      <p>After step 11 of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry②">Interpret Format 2 Patch Map Entry</a>: compare the URI generated in step 11 to <var>patch URI</var> if they
 are equal then, set bit 6 of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑨">formatFlags</a> to 1.</p>
     <li data-md>
-     <p>The return value of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map②">Interpret Format 2 Patch Map</a> is not used.</p>
+     <p>The return value of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map③">Interpret Format 2 Patch Map</a> is not used.</p>
    </ul>
-   <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="4.2.2.3" id="sparse-bit-set-decoding"><span class="secno">4.2.2.3. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
+   <h5 class="heading settled algorithm" data-algorithm="Sparse Bit Set" data-level="5.2.2.3" id="sparse-bit-set-decoding"><span class="secno">5.2.2.3. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
    <p>A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
 each node has a fixed number of children that recursively sub-divides an interval into equal partitions. A tree of height <i>H</i> with
 branching factor <i>B</i> can store set membership for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree
@@ -1676,33 +1798,79 @@ byte string:
 ]
 </pre>
    </div>
-   <h2 class="heading settled" data-level="5" id="font-patch-formats"><span class="secno">5. </span><span class="content">Font Patch Formats</span><a class="self-link" href="#font-patch-formats"></a></h2>
-   <p>In incremental font transfer <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②">font subsets</a> are extended by applying patches.
+   <h4 class="heading settled" data-level="5.2.3" id="uri-templates"><span class="secno">5.2.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h4>
+   <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URIs where patch files are located.
+A string ID is a sequence of <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">Unicode</a> code point values obtained from decoding a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> string (see <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.6">URI Template § section-1.6</a>). Several variables are defined which are used to produce the
+expansion of the template:</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Variable
+      <th>Value
+     <tr>
+      <td>id
+      <td> If the input id is numeric then this is the  numeric value converted to a string in hexadecimal representation
+      (using the digits 0-9, A-F). No padding with 0’s is used. Otherwise, this is the string id value. 
+     <tr>
+      <td>d1
+      <td> The last character of the string in the id variable.
+      If id variable is empty then, the value is the character 0 (U+0030). 
+     <tr>
+      <td>d2
+      <td> The second last character of the string in the id variable.
+      If the id variable has less than 2 characters then, the value is the character 0 (U+0030). 
+     <tr>
+      <td>d3
+      <td> The third last character of the string in the id variable.
+      If the id variable has less than 3 characters then, the value is the character 0 (U+0030). 
+     <tr>
+      <td>d4
+      <td> The fourth last character of the string in the id variable.
+      If the id variable has less than 4 characters then, the value is the character 0 (U+0030). 
+   </table>
+   <p>The variables d1 through d4 select a specific character of the id variable. In this context a character is a <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">[unicode]</a> code point.
+If the code point is not an ASCII code point then during expansion it will need to be converted to <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> and percent encoded as required by <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.6">URI Template § section-1.6</a>.</p>
+   <div class="example" id="example-7d75e350">
+    <a class="self-link" href="#example-7d75e350"></a> 
+    <p>Some example inputs and the corresponding expansions:</p>
+     n 
+    <table>
+     <tbody>
+      <tr>
+       <th>Template
+       <th>Input ID
+       <th>Expansion
+      <tr>
+       <td>//foo.bar/{id}
+       <td>123
+       <td>//foo.bar/7B
+      <tr>
+       <td>//foo.bar{/d1,d2,id}
+       <td>123
+       <td>//foo.bar/B/7/7B
+      <tr>
+       <td>//foo.bar{/d1,d2,d3,id}
+       <td>123
+       <td>//foo.bar/B/7/0/7B
+      <tr>
+       <td>//foo.bar{/d1,d2,d3,id}
+       <td>baz
+       <td>//foo.bar/z/a/b/baz
+      <tr>
+       <td>//foo.bar{/d1,d2,d3,id}
+       <td>az
+       <td>//foo.bar/z/a/0/az
+      <tr>
+       <td>//foo.bar{/d1,d2,d3,id}
+       <td>àbc
+       <td>//foo.bar/c/b/%C3%A0/%C3%A0bc
+    </table>
+   </div>
+   <h2 class="heading settled" data-level="6" id="font-patch-formats"><span class="secno">6. </span><span class="content">Font Patch Formats</span><a class="self-link" href="#font-patch-formats"></a></h2>
+   <p>In incremental font transfer <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subsets</a> are extended by applying patches.
 This specification defines three patch formats, each appropriate to its own set of augmentation scenarios. A single
 encoding can make use of more than one patch format.</p>
-   <h3 class="heading settled" data-level="5.1" id="font-patch-definitions"><span class="secno">5.1. </span><span class="content">Definitions</span><a class="self-link" href="#font-patch-definitions"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-patch">font patch</dfn> is a file which encodes changes to be made to an IFT-encoded font. Patches are used to extend
-an existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> and provide expanded coverage.</p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-format">patch format</dfn> is a specified encoding of changes to be applied relative to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>. A set of
-changes encoded according to the format is a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Each <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a>.</p>
-   <h3 class="heading settled" data-level="5.2" id="font-patch-invalidations"><span class="secno">5.2. </span><span class="content">Patch Invalidations</span><a class="self-link" href="#font-patch-invalidations"></a></h3>
-   <p>Patches in an incremental <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a> when applied may invalidate other available patches, making them invalid to be applied
-to the extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a>. Patch validity is checked using the compatibility ID from the <a href="#patch-map">§ 4.2 Patch Map Table</a>. Every patch has a
-compatibility ID encoded within it which needs to match the compatibility ID from the <a href="#patch-map">§ 4.2 Patch Map Table</a> which lists that patch. Additionally
-to aid the client in determining what invalidations will occur, every patch is categorized into one of three categories:</p>
-   <ul>
-    <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="full-invalidation">Full Invalidation</dfn>: when this patch is applied all other patches currently listed in the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a> are invalidated.
-The compatibility ID in both the 'IFT ' and 'IFTX' <a href="#patch-map">§ 4.2 Patch Map Table</a> will be changed.</p>
-    <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="partial-invalidation">Partial Invalidation</dfn>: when this patch is applied all other patches in the same <a href="#patch-map">§ 4.2 Patch Map Table</a> will be invalidated.
-The compatibility ID of only the <a href="#patch-map">§ 4.2 Patch Map Table</a> which contains this patch will be changed.</p>
-    <li data-md>
-     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="no-invalidation">No Invalidation</dfn>: no other patches will be invalidated by the application of this patch. The compatibility ID of the
-'IFT ' and 'IFTX' <a href="#patch-map">§ 4.2 Patch Map Table</a> will not change.</p>
-   </ul>
-   <p>The invalidation behaviour of a specific patch is encoded in its format number which can be found in the following section.</p>
-   <h3 class="heading settled" data-level="5.3" id="font-patch-formats-summary"><span class="secno">5.3. </span><span class="content">Formats Summary</span><a class="self-link" href="#font-patch-formats-summary"></a></h3>
+   <h3 class="heading settled" data-level="6.1" id="font-patch-formats-summary"><span class="secno">6.1. </span><span class="content">Formats Summary</span><a class="self-link" href="#font-patch-formats-summary"></a></h3>
    <p>The following patch formats are defined by this specification:</p>
    <table>
     <tbody>
@@ -1712,33 +1880,33 @@ The compatibility ID of only the <a href="#patch-map">§ 4.2 Patch Map Table</
       <th>Invalidation
       <th>Description
      <tr>
-      <td><a href="#brotli">§ 5.4 Brotli Patch</a>
+      <td><a href="#brotli">§ 6.2 Brotli Patch</a>
       <td>1
-      <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation">Full Invalidation</a>
-      <td>A brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> as a base.
+      <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation②">Full Invalidation</a>
+      <td>A brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as a base.
      <tr>
-      <td><a href="#brotli">§ 5.4 Brotli Patch</a>
+      <td><a href="#brotli">§ 6.2 Brotli Patch</a>
       <td>2
-      <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation">Partial Invalidation</a>
-      <td>A brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> as a base.
+      <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation②">Partial Invalidation</a>
+      <td>A brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> as a base.
      <tr>
-      <td><a href="#per-table-brotli">§ 5.5 Per Table Brotli</a>
+      <td><a href="#per-table-brotli">§ 6.3 Per Table Brotli</a>
       <td>3
-      <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation①">Full Invalidation</a>
-      <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> as bases.
+      <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation③">Full Invalidation</a>
+      <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> as bases.
      <tr>
-      <td><a href="#per-table-brotli">§ 5.5 Per Table Brotli</a>
+      <td><a href="#per-table-brotli">§ 6.3 Per Table Brotli</a>
       <td>4
-      <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation①">Partial Invalidation</a>
-      <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as bases.
+      <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation③">Partial Invalidation</a>
+      <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> as bases.
      <tr>
-      <td><a href="#glyph-keyed">§ 5.6 Glyph Keyed</a>
+      <td><a href="#glyph-keyed">§ 6.4 Glyph Keyed</a>
       <td>5
-      <td><a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation">No Invalidation</a>
+      <td><a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation①">No Invalidation</a>
       <td>Contains a collection of opaque binary blobs, each associated with a glyph id and table.
    </table>
    <p>More detailed descriptions of each algorithm can be found in the following sections.</p>
-   <h3 class="heading settled" data-level="5.4" id="brotli"><span class="secno">5.4. </span><span class="content">Brotli Patch</span><a class="self-link" href="#brotli"></a></h3>
+   <h3 class="heading settled" data-level="6.2" id="brotli"><span class="secno">6.2. </span><span class="content">Brotli Patch</span><a class="self-link" href="#brotli"></a></h3>
    <p>In a brotli patch the target file is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the
 source file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A brotli encoded patch consists
 of a short header followed by brotli encoded data.</p>
@@ -1760,7 +1928,7 @@ of a short header followed by brotli encoded data.</p>
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 5.2 Patch Invalidations</a>.
+      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint32
       <td>length
@@ -1770,14 +1938,14 @@ of a short header followed by brotli encoded data.</p>
       <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-brotlistream">brotliStream</dfn>[variable]
       <td>Brotli encoded byte stream.
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Brotli Patches" data-level="5.4.1" id="apply-brotli"><span class="secno">5.4.1. </span><span class="content">Applying Brotli Patches</span><a class="self-link" href="#apply-brotli"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> to cover additional codepoints,
+   <h4 class="heading settled algorithm" data-algorithm="Applying Brotli Patches" data-level="6.2.1" id="apply-brotli"><span class="secno">6.2.1. </span><span class="content">Applying Brotli Patches</span><a class="self-link" href="#apply-brotli"></a></h4>
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-brotli-patch">Apply brotli patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#brotli-patch" id="ref-for-brotli-patch">brotli patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -1786,7 +1954,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1803,10 +1971,10 @@ has failed, return an error.</p>
 using the <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. Return the decoded
 result as the <var>extended font subset</var></p>
    </ol>
-   <h3 class="heading settled" data-level="5.5" id="per-table-brotli"><span class="secno">5.5. </span><span class="content">Per Table Brotli</span><a class="self-link" href="#per-table-brotli"></a></h3>
+   <h3 class="heading settled" data-level="6.3" id="per-table-brotli"><span class="secno">6.3. </span><span class="content">Per Table Brotli</span><a class="self-link" href="#per-table-brotli"></a></h3>
    <p>A per table brotli patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A per table brotli encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
-or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a>.</p>
+or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch">Per table brotli patch</dfn> encoding:</p>
    <table>
     <tbody>
@@ -1825,7 +1993,7 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 5.2 Patch Invalidations</a>.
+      <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint16
       <td>patchesCount
@@ -1861,14 +2029,14 @@ of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">Ta
       <td><dfn class="dfn-paneled" data-dfn-for="TablePatch" data-dfn-type="dfn" data-noexport id="tablepatch-brotlistream">brotliStream</dfn>[variable]
       <td>Brotli encoded byte stream.
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Brotli Patches" data-level="5.5.1" id="apply-per-table-brotli"><span class="secno">5.5.1. </span><span class="content">Applying Per Table Brotli Patches</span><a class="self-link" href="#apply-per-table-brotli"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm①">patch application algorithm</a> is used to apply a per table brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> to cover additional codepoints,
+   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Brotli Patches" data-level="6.3.1" id="apply-per-table-brotli"><span class="secno">6.3.1. </span><span class="content">Applying Per Table Brotli Patches</span><a class="self-link" href="#apply-per-table-brotli"></a></h4>
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm①">patch application algorithm</a> is used to apply a per table brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#per-table-brotli-patch" id="ref-for-per-table-brotli-patch">per table brotli patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -1877,7 +2045,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑤">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1917,7 +2085,7 @@ are listed in the <a data-link-type="dfn" href="#per-table-brotli-patch-patches"
      <p>For each <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> in <var>base font subset</var> which has a tag that was not found in any of
 the entries processed in step 5, add a copy of that table to <var>extended font subset</var>.</p>
    </ol>
-   <h3 class="heading settled" data-level="5.6" id="glyph-keyed"><span class="secno">5.6. </span><span class="content">Glyph Keyed</span><a class="self-link" href="#glyph-keyed"></a></h3>
+   <h3 class="heading settled" data-level="6.4" id="glyph-keyed"><span class="secno">6.4. </span><span class="content">Glyph Keyed</span><a class="self-link" href="#glyph-keyed"></a></h3>
    <p>A glyph keyed patch contains a collection of data chunks that are each associated with a glyph index and a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font table</a>. The encoded data replaces any existing data for that glyph index in the referenced <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>. Glyph keyed patches can encode data for <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a>/<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/loca#">loca</a>, <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/gvar#">gvar</a>, <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cff#">CFF</a>, and <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cff2#">CFF2</a> tables.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-keyed-patch">Glyph keyed patch</dfn> encoding:</p>
    <table>
@@ -1941,7 +2109,7 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Glyph keyed patch" data-dfn-type="dfn" data-noexport id="glyph-keyed-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 5.2 Patch Invalidations</a>.
+      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑥">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint32
       <td>length
@@ -1986,14 +2154,14 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
    </table>
    <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets">glyphDataOffsets</a> array gives the size
 of that glyph data.</p>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Glyph Keyed Patches" data-level="5.6.1" id="apply-glyph-keyed"><span class="secno">5.6.1. </span><span class="content">Applying Glyph Keyed Patches</span><a class="self-link" href="#apply-glyph-keyed"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm②">patch application algorithm</a> is used to apply a glyph keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> to cover additional codepoints,
+   <h4 class="heading settled algorithm" data-algorithm="Applying Glyph Keyed Patches" data-level="6.4.1" id="apply-glyph-keyed"><span class="secno">6.4.1. </span><span class="content">Applying Glyph Keyed Patches</span><a class="self-link" href="#apply-glyph-keyed"></a></h4>
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm②">patch application algorithm</a> is used to apply a glyph keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑦">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑤">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#glyph-keyed-patch" id="ref-for-glyph-keyed-patch">glyph keyed patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -2004,7 +2172,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑥">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑨">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -2040,7 +2208,7 @@ of any other types must be ignored.</p>
        <p>Insert the synthesized table into <var>extended font subset</var>.</p>
      </ul>
     <li data-md>
-     <p>Locate the <a href="#patch-map">§ 4.2 Patch Map Table</a> table which has the same <a data-link-type="dfn" href="#glyph-keyed-patch-compatibilityid" id="ref-for-glyph-keyed-patch-compatibilityid①">compatibilityId</a> as <var>compatibility id</var>. If it is a
+     <p>Locate the <a href="#patch-map-table">§ 5.2 Patch Map Table</a> which has the same <a data-link-type="dfn" href="#glyph-keyed-patch-compatibilityid" id="ref-for-glyph-keyed-patch-compatibilityid①">compatibilityId</a> as <var>compatibility id</var>. If it is a
 format 1 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-1-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a> with the patch map table and <var>patch uri</var> as an
 input. Otherwise if it is a format 2 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-2-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a> with the patch map table and <var>patch uri</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.</p>
     <li data-md>
@@ -2051,165 +2219,26 @@ the entries processed in step 4 or 5, add a copy of that table to <var>extended 
 for each modified table: update the checksums in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">fonts table directory</a> to match the table’s
 new contents.</p>
    </ol>
-   <h2 class="heading settled algorithm" data-algorithm="Extending a Font Subset" data-level="6" id="extending-font-subset"><span class="secno">6. </span><span class="content">Extending a Font Subset</span><a class="self-link" href="#extending-font-subset"></a></h2>
-   <p>This sections defines the algorithm that a client uses to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑦">font subset</a> to cover additional
-codepoints, layout features and/or design space.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-extend-a-font-subset">Extend a Font Subset</dfn></p>
-   <p>The inputs to this algorithm are:</p>
-   <ul>
-    <li data-md>
-     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a>.</p>
-    <li data-md>
-     <p><var>font subset URI</var>: an <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the location of <var>font subset</var>.</p>
-    <li data-md>
-     <p><var>target subset definition</var>: the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑥">font subset definition</a> that the client wants to extend <var>font subset</var> to cover.</p>
-   </ul>
-   <p>The algorithm outputs:</p>
-   <ul>
-    <li data-md>
-     <p><var>extended font subset</var>: an extended version of <var>font subset</var>. May or may not be an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②">incremental font</a>.</p>
-   </ul>
-   <p>The algorithm:</p>
-   <ol>
-    <li data-md>
-     <p>Set <var>extended font subset</var> to <var>font subset</var>.</p>
-    <li data-md>
-     <p>Load the 'IFT ' and 'IFTX' (if present) mapping <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> from <var>extended font subset</var>. Both
-tables are formatted as a <a href="#patch-map">§ 4.2 Patch Map Table</a>. Check that they are valid according to the requirements in <a href="#patch-map">§ 4.2 Patch Map Table</a>. If either table
-is not valid, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors">Handle errors</a>. If <var>extended font subset</var> does not have an 'IFT ' table, then it is not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font③">incremental font</a> and cannot be extended, return <var>extended font subset</var>.</p>
-    <li data-md>
-     <p>For each of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
-invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a> or <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map③">Interpret Format 2 Patch Map</a>. Concatenate the returned entry lists into a single list, <var>entry list</var>.</p>
-    <li data-md>
-     <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection">Check entry intersection</a> with <var>entry</var> and <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var> from <var>entry list</var>.</p>
-    <li data-md>
-     <p>If <var>entry list</var> is empty, then the extension operation is finished, return <var>extended font subset</var>.</p>
-    <li data-md>
-     <p>Pick one <var>entry</var> from <var>entry list</var> with the following procedure:</p>
-     <ul>
-      <li data-md>
-       <p>If <var>entry list</var> contains one or more <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">patch map entries</a> which have a patch format that is <a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation②">Full Invalidation</a> then, select exactly one of the <a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation③">Full Invalidation</a> entries in <var>entry list</var>. The criteria for selecting the single
-entry is left up to the implementation to decide.</p>
-      <li data-md>
-       <p>Otherwise if <var>entry list</var> contains one or more <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a> which have a patch format that is <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation②">Partial Invalidation</a> then, select exactly one of the <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation③">Partial Invalidation</a> entries in <var>entry list</var>.
-The criteria for selecting the single entry is left up to the implementation to decide.</p>
-      <li data-md>
-       <p>Otherwise select exactly one of the <a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation①">No Invalidation</a> entries in <var>entry list</var>.
-The criteria for selecting the single entry is left up to the implementation to decide.</p>
-     </ul>
-    <li data-md>
-     <p>Load <var>patch file</var> by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>font subset URI</var> as the incremental font URI and the <var>entry</var> patch URI as the patch URI.</p>
-    <li data-md>
-     <p>Apply <var>patch file</var> using the appropriate application algorithm (matching the patches format in <var>entry</var>) from <a href="#font-patch-formats">§ 5 Font Patch Formats</a> to apply the <var>patch file</var> using the patch URI and the compatibility id from <var>entry</var> to <var>extended font subset</var>.</p>
-    <li data-md>
-     <p>Go to step 2.</p>
-   </ol>
-   <p class="note" role="note"><span class="marker">Note:</span> the algorithm here presents patch loads as being done one at a time; however, to improve performance client implementations are
-encouraged to pre-fetch patch files that will be applied in later iterations by the algorithm. The <a href="#font-patch-invalidations">invalidation categories</a> can be used to predict which intersecting patches from step 4 will remain be valid
-to be applied.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-check-entry-intersection">Check entry intersection</dfn></p>
-   <p>The inputs to this algorithm are:</p>
-   <ul>
-    <li data-md>
-     <p><var>mapping entry</var>: a <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑨">patch map entry</a>.</p>
-    <li data-md>
-     <p><var>subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definition</a>.</p>
-   </ul>
-   <p>The algorithm outputs:</p>
-   <ul>
-    <li data-md>
-     <p><var>intersects</var>: true if <var>subset definition</var> intersects <var>mapping entry</var>, otherwise false.</p>
-   </ul>
-   <p>The algorithm:</p>
-   <ol>
-    <li data-md>
-     <p>For each set in <var>subset definition</var> (codepoints, feature tags, design space) check if the set intersects
- the corresponding set from <var>mapping entry</var>. A set intersects when:</p>
-     <table>
-      <tbody>
-       <tr>
-        <th>
-        <th>subset definition set is empty
-        <th>subset definition set is not empty
-       <tr>
-        <th>mapping entry set is empty
-        <td>true
-        <td>true
-       <tr>
-        <th>mapping entry set is not empty
-        <td>false
-        <td>true if the two sets intersect
-     </table>
-    <li data-md>
-     <p>If all sets checked in step 1 intersect, then return true for <var>intersects</var> otherwise false.</p>
-   </ol>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-load-patch-file">Load patch file</dfn></p>
-   <p>The inputs to this algorithm are:</p>
-   <ul>
-    <li data-md>
-     <p><var>Patch URI</var>: A <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.1">URI Reference</a> identifying the patch file to load. As a URI reference this may be a
- relative path.</p>
-    <li data-md>
-     <p><var>Incremental Font URI</var>: An <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the incremental font which contains
- the reference to <var>Patch URI</var>.</p>
-   </ul>
-   <p>The algorithm outputs:</p>
-   <ul>
-    <li data-md>
-     <p><var>patch file</var>: the content (bytes) identified by <var>Patch URI</var>.</p>
-   </ul>
-   <p>The algorithm:</p>
-   <ol>
-    <li data-md>
-     <p>Perform <a href="https://www.rfc-editor.org/rfc/rfc3986#section-5">reference resolution</a> on <var>Patch URI</var> using <var>Incremental Font URI</var> as the base URI to
- produce the <var>target URI</var>.</p>
-    <li data-md>
-     <p>Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers, <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[fetch]</a> should be used. Return the retrieved contents as <var>patch file</var>, or an error if the fetch resulted in an error.</p>
-   </ol>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-errors">Handle errors</dfn></p>
-   <p>Coming soon.</p>
-   <h3 class="heading settled algorithm" data-algorithm="Fully Expanding a Font" data-level="6.1" id="fully-expanding-a-font"><span class="secno">6.1. </span><span class="content">Fully Expanding a Font</span><a class="self-link" href="#fully-expanding-a-font"></a></h3>
-   <p>This sections defines an algorithm that can be used to transform an incremental font into a fully expanded non-incremental font. This
-process loads all available data provided by the incremental font and produces a single static font file that contains no further
-patches to be applied.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-fully-expand-a-font-subset">Fully Expand a Font Subset</dfn></p>
-   <p>The inputs to this algorithm are:</p>
-   <ul>
-    <li data-md>
-     <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font④">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑨">font subset</a>.</p>
-   </ul>
-   <p>The algorithm outputs:</p>
-   <ul>
-    <li data-md>
-     <p><var>expanded font</var>: an <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">[open-type]</a> font that is not incremental.</p>
-   </ul>
-   <p>The algorithm:</p>
-   <ol>
-    <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset①">Extend a Font Subset</a> with <var>font subset</var>. The input target subset definition is a special one which
-is considered to intersect all entries in the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> step. Return the resulting font subset as
-the <var>expanded font</var>.</p>
-   </ol>
    <h2 class="heading settled" data-level="7" id="encoder"><span class="secno">7. </span><span class="content">Encoder</span><a class="self-link" href="#encoder"></a></h2>
-   <p>An encoder is a tool which produces an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑤">incremental font</a> and set of associated <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch②">patches</a>.
-The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑥">incremental font</a> and associated patches produced by a compliant encoder:</p>
+   <p>An encoder is a tool which produces an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> and set of associated <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch②">patches</a>.
+The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑨">incremental font</a> and associated patches produced by a compliant encoder:</p>
    <ol>
     <li data-md>
-     <p>Must meet all of the requirements in <a href="#font-format-extensions">§ 4 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 5 Font Patch Formats</a>.</p>
+     <p>Must meet all of the requirements in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 6 Font Patch Formats</a>.</p>
     <li data-md>
-     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset②">Extend a Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑦">incremental font</a> must always be the same regardless of the particular order
-of patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset③">Extend a Font Subset</a>.</p>
+     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset②">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⓪">incremental font</a> must always be the same regardless of the particular order
+of patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset③">Extend an Incremental Font Subset</a>.</p>
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font, that is:
- given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-a-font-subset" id="ref-for-abstract-opdef-extend-a-font-subset④">Extend a Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑨">incremental font</a> and the minimal subset definition covering that content should
+ given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset④">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
     <li data-md>
-     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⓪">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
+     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
  should have all of the same <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> as the existing font (excluding the incremental IFT/IFTX
  tables) and each of those tables should be functionally equivalent to the corresponding table in the existing font. Note: the fully
  expanded may not always be an exact binary match with the existing font.</p>
    </ol>
-   <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> and a client is implemented according to the
+   <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①④">incremental font</a> and a client is implemented according to the
 other sections of this document, the intent of the IFT specification is that appearance and behavior of the font in the client will be the
 same as if the entire file were transferred to the client. A primary goal of the IFT specification is that the IFT format and protocol can
 serve as a neutral medium for font transfer, comparable to WOFF2. If an encoder produces an encoding from a source font which meets all of
@@ -2231,7 +2260,7 @@ guidance that encoder implementations may want to consider.</p>
    <p>As discussed in <a href="#encoder">§ 7 Encoder</a> a high quality encoder should preserve the functionality of the original font. One way to
 achieve this is to leverage an existing font subsetter implementation to produce font subsets that retain the functionality
 of the original font. The IFT patches can then be derived from these subsets.</p>
-   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③①">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a>. The practice of reliably
+   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③①">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a>. The practice of reliably
 subsetting a font is well understood and has multiple open-source implementations (a full formal description is
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
@@ -2367,146 +2396,147 @@ required too many patches.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a><span>, in § 4.2.1</span>
-   <li><a href="#abstract-opdef-apply-brotli-patch">Apply brotli patch</a><span>, in § 5.4.1</span>
-   <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 5.6.1</span>
-   <li><a href="#abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</a><span>, in § 5.5.1</span>
-   <li><a href="#mapping-entry-bias">bias</a><span>, in § 4.2.2</span>
-   <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 4.2.2.3</span>
-   <li><a href="#brotli-patch">Brotli patch</a><span>, in § 5.4</span>
+   <li><a href="#format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a><span>, in § 5.2.1</span>
+   <li><a href="#abstract-opdef-apply-brotli-patch">Apply brotli patch</a><span>, in § 6.2.1</span>
+   <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 6.4.1</span>
+   <li><a href="#abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</a><span>, in § 6.3.1</span>
+   <li><a href="#mapping-entry-bias">bias</a><span>, in § 5.2.2</span>
+   <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 5.2.2.3</span>
+   <li><a href="#brotli-patch">Brotli patch</a><span>, in § 6.2</span>
    <li>
     brotliStream
     <ul>
-     <li><a href="#brotli-patch-brotlistream">dfn for Brotli patch</a><span>, in § 5.4</span>
-     <li><a href="#glyph-keyed-patch-brotlistream">dfn for Glyph keyed patch</a><span>, in § 5.6</span>
-     <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 5.5</span>
+     <li><a href="#brotli-patch-brotlistream">dfn for Brotli patch</a><span>, in § 6.2</span>
+     <li><a href="#glyph-keyed-patch-brotlistream">dfn for Glyph keyed patch</a><span>, in § 6.4</span>
+     <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 6.3</span>
     </ul>
-   <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 6</span>
-   <li><a href="#mapping-entry-codepoints">codepoints</a><span>, in § 4.2.2</span>
+   <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 4.2</span>
+   <li><a href="#mapping-entry-codepoints">codepoints</a><span>, in § 5.2.2</span>
    <li>
     compatibilityId
     <ul>
-     <li><a href="#brotli-patch-compatibilityid">dfn for Brotli patch</a><span>, in § 5.4</span>
-     <li><a href="#format-1-patch-map-compatibilityid">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
-     <li><a href="#format-2-patch-map-compatibilityid">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
-     <li><a href="#glyph-keyed-patch-compatibilityid">dfn for Glyph keyed patch</a><span>, in § 5.6</span>
-     <li><a href="#per-table-brotli-patch-compatibilityid">dfn for Per table brotli patch</a><span>, in § 5.5</span>
+     <li><a href="#brotli-patch-compatibilityid">dfn for Brotli patch</a><span>, in § 6.2</span>
+     <li><a href="#format-1-patch-map-compatibilityid">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
+     <li><a href="#format-2-patch-map-compatibilityid">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
+     <li><a href="#glyph-keyed-patch-compatibilityid">dfn for Glyph keyed patch</a><span>, in § 6.4</span>
+     <li><a href="#per-table-brotli-patch-compatibilityid">dfn for Per table brotli patch</a><span>, in § 6.3</span>
     </ul>
-   <li><a href="#mapping-entry-copycount">copyCount</a><span>, in § 4.2.2</span>
-   <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 4.2.2</span>
-   <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 4.2.2.3</span>
-   <li><a href="#format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a><span>, in § 4.2.2</span>
-   <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 4.2.2</span>
-   <li><a href="#design-space-segment">Design Space Segment</a><span>, in § 4.2.2</span>
-   <li><a href="#mapping-entry-designspacesegments">designSpaceSegments</a><span>, in § 4.2.2</span>
-   <li><a href="#design-space-segment-end">end</a><span>, in § 4.2.2</span>
+   <li><a href="#mapping-entry-copycount">copyCount</a><span>, in § 5.2.2</span>
+   <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 5.2.2</span>
+   <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 5.2.2.3</span>
+   <li><a href="#format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a><span>, in § 5.2.2</span>
+   <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 5.2.2</span>
+   <li><a href="#design-space-segment">Design Space Segment</a><span>, in § 5.2.2</span>
+   <li><a href="#mapping-entry-designspacesegments">designSpaceSegments</a><span>, in § 5.2.2</span>
+   <li><a href="#design-space-segment-end">end</a><span>, in § 5.2.2</span>
    <li>
     entries
     <ul>
-     <li><a href="#format-2-patch-map-entries">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
-     <li><a href="#mapping-entries-entries">dfn for Mapping Entries</a><span>, in § 4.2.2</span>
+     <li><a href="#format-2-patch-map-entries">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
+     <li><a href="#mapping-entries-entries">dfn for Mapping Entries</a><span>, in § 5.2.2</span>
     </ul>
    <li>
     entryCount
     <ul>
-     <li><a href="#format-1-patch-map-entrycount">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
-     <li><a href="#format-2-patch-map-entrycount">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
+     <li><a href="#format-1-patch-map-entrycount">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
+     <li><a href="#format-2-patch-map-entrycount">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
     </ul>
-   <li><a href="#mapping-entry-entryiddelta">entryIdDelta</a><span>, in § 4.2.2</span>
-   <li><a href="#format-2-patch-map-entryidstringdata">entryIdStringData</a><span>, in § 4.2.2</span>
-   <li><a href="#mapping-entry-entryidstringlength">entryIdStringLength</a><span>, in § 4.2.2</span>
-   <li><a href="#glyph-map-entryindex">entryIndex</a><span>, in § 4.2.1</span>
-   <li><a href="#featurerecord-entrymapcount">entryMapCount</a><span>, in § 4.2.1</span>
-   <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 4.2.1</span>
-   <li><a href="#feature-map-entrymaprecords">entryMapRecords</a><span>, in § 4.2.1</span>
-   <li><a href="#abstract-opdef-extend-a-font-subset">Extend a Font Subset</a><span>, in § 6</span>
-   <li><a href="#mapping-entry-featurecount">featureCount</a><span>, in § 4.2.2</span>
-   <li><a href="#feature-map">Feature Map</a><span>, in § 4.2.1</span>
-   <li><a href="#featurerecord">FeatureRecord</a><span>, in § 4.2.1</span>
-   <li><a href="#feature-map-featurerecords">featureRecords</a><span>, in § 4.2.1</span>
-   <li><a href="#featurerecord-featuretag">featureTag</a><span>, in § 4.2.1</span>
-   <li><a href="#mapping-entry-featuretags">featureTags</a><span>, in § 4.2.2</span>
+   <li><a href="#mapping-entry-entryiddelta">entryIdDelta</a><span>, in § 5.2.2</span>
+   <li><a href="#format-2-patch-map-entryidstringdata">entryIdStringData</a><span>, in § 5.2.2</span>
+   <li><a href="#mapping-entry-entryidstringlength">entryIdStringLength</a><span>, in § 5.2.2</span>
+   <li><a href="#glyph-map-entryindex">entryIndex</a><span>, in § 5.2.1</span>
+   <li><a href="#featurerecord-entrymapcount">entryMapCount</a><span>, in § 5.2.1</span>
+   <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 5.2.1</span>
+   <li><a href="#feature-map-entrymaprecords">entryMapRecords</a><span>, in § 5.2.1</span>
+   <li><a href="#abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</a><span>, in § 4.2</span>
+   <li><a href="#mapping-entry-featurecount">featureCount</a><span>, in § 5.2.2</span>
+   <li><a href="#feature-map">Feature Map</a><span>, in § 5.2.1</span>
+   <li><a href="#featurerecord">FeatureRecord</a><span>, in § 5.2.1</span>
+   <li><a href="#feature-map-featurerecords">featureRecords</a><span>, in § 5.2.1</span>
+   <li><a href="#featurerecord-featuretag">featureTag</a><span>, in § 5.2.1</span>
+   <li><a href="#mapping-entry-featuretags">featureTags</a><span>, in § 5.2.2</span>
    <li>
     firstEntryIndex
     <ul>
-     <li><a href="#entrymaprecord-firstentryindex">dfn for EntryMapRecord</a><span>, in § 4.2.1</span>
-     <li><a href="#featurerecord-firstentryindex">dfn for FeatureRecord</a><span>, in § 4.2.1</span>
+     <li><a href="#entrymaprecord-firstentryindex">dfn for EntryMapRecord</a><span>, in § 5.2.1</span>
+     <li><a href="#featurerecord-firstentryindex">dfn for FeatureRecord</a><span>, in § 5.2.1</span>
     </ul>
-   <li><a href="#glyph-map-firstmappedglyph">firstMappedGlyph</a><span>, in § 4.2.1</span>
+   <li><a href="#glyph-map-firstmappedglyph">firstMappedGlyph</a><span>, in § 5.2.1</span>
    <li>
     flags
     <ul>
-     <li><a href="#glyph-keyed-patch-flags">dfn for Glyph keyed patch</a><span>, in § 5.6</span>
-     <li><a href="#tablepatch-flags">dfn for TablePatch</a><span>, in § 5.5</span>
+     <li><a href="#glyph-keyed-patch-flags">dfn for Glyph keyed patch</a><span>, in § 6.4</span>
+     <li><a href="#tablepatch-flags">dfn for TablePatch</a><span>, in § 6.3</span>
     </ul>
-   <li><a href="#font-patch">font patch</a><span>, in § 5.1</span>
+   <li><a href="#font-patch">font patch</a><span>, in § 3.2</span>
    <li><a href="#font-subset">font subset</a><span>, in § 3.1</span>
    <li><a href="#font-subset-definition">font subset definition</a><span>, in § 3.1</span>
    <li>
     format
     <ul>
-     <li><a href="#brotli-patch-format">dfn for Brotli patch</a><span>, in § 5.4</span>
-     <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
-     <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
-     <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 5.6</span>
-     <li><a href="#per-table-brotli-patch-format">dfn for Per table brotli patch</a><span>, in § 5.5</span>
+     <li><a href="#brotli-patch-format">dfn for Brotli patch</a><span>, in § 6.2</span>
+     <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
+     <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
+     <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 6.4</span>
+     <li><a href="#per-table-brotli-patch-format">dfn for Per table brotli patch</a><span>, in § 6.3</span>
     </ul>
-   <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 4.2.1</span>
-   <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 4.2.2</span>
-   <li><a href="#mapping-entry-formatflags">formatFlags</a><span>, in § 4.2.2</span>
-   <li><a href="#full-invalidation">Full Invalidation</a><span>, in § 5.2</span>
-   <li><a href="#abstract-opdef-fully-expand-a-font-subset">Fully Expand a Font Subset</a><span>, in § 6.1</span>
+   <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 5.2.1</span>
+   <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 5.2.2</span>
+   <li><a href="#mapping-entry-formatflags">formatFlags</a><span>, in § 5.2.2</span>
+   <li><a href="#full-invalidation">Full Invalidation</a><span>, in § 4.1</span>
+   <li><a href="#abstract-opdef-fully-expand-a-font-subset">Fully Expand a Font Subset</a><span>, in § 4.3</span>
    <li>
     glyphCount
     <ul>
-     <li><a href="#format-1-patch-map-glyphcount">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
-     <li><a href="#glyphpatches-glyphcount">dfn for GlyphPatches</a><span>, in § 5.6</span>
+     <li><a href="#format-1-patch-map-glyphcount">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
+     <li><a href="#glyphpatches-glyphcount">dfn for GlyphPatches</a><span>, in § 6.4</span>
     </ul>
-   <li><a href="#glyphpatches-glyphdata">glyphData</a><span>, in § 5.6</span>
-   <li><a href="#glyphpatches-glyphdataoffsets">glyphDataOffsets</a><span>, in § 5.6</span>
-   <li><a href="#glyphpatches-glyphids">glyphIds</a><span>, in § 5.6</span>
-   <li><a href="#glyph-keyed-patch">Glyph keyed patch</a><span>, in § 5.6</span>
-   <li><a href="#glyph-map">Glyph Map</a><span>, in § 4.2.1</span>
-   <li><a href="#glyphpatches">GlyphPatches</a><span>, in § 5.6</span>
-   <li><a href="#abstract-opdef-handle-errors">Handle errors</a><span>, in § 6</span>
-   <li><a href="#incremental-font">incremental font</a><span>, in § 4</span>
-   <li><a href="#abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a><span>, in § 4.2.1.1</span>
-   <li><a href="#abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a><span>, in § 4.2.2.1</span>
-   <li><a href="#abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a><span>, in § 4.2.2.1</span>
-   <li><a href="#entrymaprecord-lastentryindex">lastEntryIndex</a><span>, in § 4.2.1</span>
-   <li><a href="#abstract-opdef-load-patch-file">Load patch file</a><span>, in § 6</span>
-   <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 4.2.2</span>
-   <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 4.2.2</span>
-   <li><a href="#no-invalidation">No Invalidation</a><span>, in § 5.2</span>
-   <li><a href="#partial-invalidation">Partial Invalidation</a><span>, in § 5.2</span>
-   <li><a href="#patch-application-algorithm">patch application algorithm</a><span>, in § 5.1</span>
+   <li><a href="#glyphpatches-glyphdata">glyphData</a><span>, in § 6.4</span>
+   <li><a href="#glyphpatches-glyphdataoffsets">glyphDataOffsets</a><span>, in § 6.4</span>
+   <li><a href="#glyphpatches-glyphids">glyphIds</a><span>, in § 6.4</span>
+   <li><a href="#glyph-keyed-patch">Glyph keyed patch</a><span>, in § 6.4</span>
+   <li><a href="#glyph-map">Glyph Map</a><span>, in § 5.2.1</span>
+   <li><a href="#glyphpatches">GlyphPatches</a><span>, in § 6.4</span>
+   <li><a href="#abstract-opdef-handle-errors">Handle errors</a><span>, in § 4.2</span>
+   <li><a href="#incremental-font">incremental font</a><span>, in § 1.2</span>
+   <li><a href="#abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a><span>, in § 5.2.1.1</span>
+   <li><a href="#abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a><span>, in § 5.2.2.1</span>
+   <li><a href="#abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a><span>, in § 5.2.2.1</span>
+   <li><a href="#entrymaprecord-lastentryindex">lastEntryIndex</a><span>, in § 5.2.1</span>
+   <li><a href="#abstract-opdef-load-patch-file">Load patch file</a><span>, in § 4.2</span>
+   <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 5.2.2</span>
+   <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 5.2.2</span>
+   <li><a href="#no-invalidation">No Invalidation</a><span>, in § 4.1</span>
+   <li><a href="#partial-invalidation">Partial Invalidation</a><span>, in § 4.1</span>
+   <li><a href="#patch-application-algorithm">patch application algorithm</a><span>, in § 3.2</span>
    <li>
     patchEncoding
     <ul>
-     <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
-     <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 4.2.2</span>
+     <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
+     <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 5.2.2</span>
     </ul>
-   <li><a href="#per-table-brotli-patch-patches">patches</a><span>, in § 5.5</span>
-   <li><a href="#patch-format">patch format</a><span>, in § 5.1</span>
-   <li><a href="#patch-map-entries">patch map entries</a><span>, in § 4.2</span>
-   <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 5.5</span>
-   <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 4.2.1.2</span>
-   <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 4.2.2.2</span>
-   <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 4.2.2.3</span>
-   <li><a href="#design-space-segment-start">start</a><span>, in § 4.2.2</span>
-   <li><a href="#tablepatch">TablePatch</a><span>, in § 5.5</span>
-   <li><a href="#glyphpatches-tables">tables</a><span>, in § 5.6</span>
+   <li><a href="#per-table-brotli-patch-patches">patches</a><span>, in § 6.3</span>
+   <li><a href="#patch-format">patch format</a><span>, in § 3.2</span>
+   <li><a href="#patch-map">patch map</a><span>, in § 3.3</span>
+   <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
+   <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 6.3</span>
+   <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.2.1.2</span>
+   <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 5.2.2.2</span>
+   <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.2.2.3</span>
+   <li><a href="#design-space-segment-start">start</a><span>, in § 5.2.2</span>
+   <li><a href="#tablepatch">TablePatch</a><span>, in § 6.3</span>
+   <li><a href="#glyphpatches-tables">tables</a><span>, in § 6.4</span>
    <li>
     tag
     <ul>
-     <li><a href="#design-space-segment-tag">dfn for Design Space Segment</a><span>, in § 4.2.2</span>
-     <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 5.5</span>
+     <li><a href="#design-space-segment-tag">dfn for Design Space Segment</a><span>, in § 5.2.2</span>
+     <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 6.3</span>
     </ul>
    <li>
     uriTemplate
     <ul>
-     <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 4.2.1</span>
-     <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 4.2.2</span>
+     <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
+     <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -2749,100 +2779,101 @@ let dfnPanelData = {
 "abstract-opdef-apply-brotli-patch": {"dfnID":"abstract-opdef-apply-brotli-patch","dfnText":"Apply brotli patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-brotli-patch"},
 "abstract-opdef-apply-glyph-keyed-patch": {"dfnID":"abstract-opdef-apply-glyph-keyed-patch","dfnText":"Apply glyph keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-glyph-keyed-patch"},
 "abstract-opdef-apply-per-table-brotli-patch": {"dfnID":"abstract-opdef-apply-per-table-brotli-patch","dfnText":"Apply per table brotli patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-per-table-brotli-patch"},
-"abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"}],"title":"6. Extending a Font Subset"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"6.1. Fully Expanding a Font"}],"url":"#abstract-opdef-check-entry-intersection"},
+"abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.3. Fully Expanding a Font"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
-"abstract-opdef-extend-a-font-subset": {"dfnID":"abstract-opdef-extend-a-font-subset","dfnText":"Extend a Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-a-font-subset"}],"title":"4.2. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-a-font-subset\u2460"}],"title":"6.1. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-a-font-subset\u2461"},{"id":"ref-for-abstract-opdef-extend-a-font-subset\u2462"},{"id":"ref-for-abstract-opdef-extend-a-font-subset\u2463"}],"title":"7. Encoder"}],"url":"#abstract-opdef-extend-a-font-subset"},
+"abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"}],"title":"4.3. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"}],"title":"7. Encoder"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "abstract-opdef-fully-expand-a-font-subset": {"dfnID":"abstract-opdef-fully-expand-a-font-subset","dfnText":"Fully Expand a Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset"}],"title":"2.1. Offline Usage"},{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2460"},{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2461"}],"title":"7. Encoder"}],"url":"#abstract-opdef-fully-expand-a-font-subset"},
-"abstract-opdef-handle-errors": {"dfnID":"abstract-opdef-handle-errors","dfnText":"Handle errors","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-handle-errors"}],"title":"6. Extending a Font Subset"}],"url":"#abstract-opdef-handle-errors"},
-"abstract-opdef-interpret-format-1-patch-map": {"dfnID":"abstract-opdef-interpret-format-1-patch-map","dfnText":"Interpret Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-1-patch-map"}],"title":"6. Extending a Font Subset"}],"url":"#abstract-opdef-interpret-format-1-patch-map"},
-"abstract-opdef-interpret-format-2-patch-map": {"dfnID":"abstract-opdef-interpret-format-2-patch-map","dfnText":"Interpret Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map"},{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2460"},{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2461"}],"title":"4.2.2.2. Remove Entries from Format 2"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2462"}],"title":"6. Extending a Font Subset"}],"url":"#abstract-opdef-interpret-format-2-patch-map"},
-"abstract-opdef-interpret-format-2-patch-map-entry": {"dfnID":"abstract-opdef-interpret-format-2-patch-map-entry","dfnText":"Interpret Format 2 Patch Map Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}],"title":"4.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2461"}],"title":"4.2.2.2. Remove Entries from Format 2"}],"url":"#abstract-opdef-interpret-format-2-patch-map-entry"},
-"abstract-opdef-load-patch-file": {"dfnID":"abstract-opdef-load-patch-file","dfnText":"Load patch file","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file"}],"title":"6. Extending a Font Subset"}],"url":"#abstract-opdef-load-patch-file"},
-"abstract-opdef-remove-entries-from-format-1-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-1-patch-map","dfnText":"Remove Entries from Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-1-patch-map"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-1-patch-map"},
-"abstract-opdef-remove-entries-from-format-2-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-2-patch-map","dfnText":"Remove Entries from Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-2-patch-map"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-2-patch-map"},
-"branch-factor-encoding": {"dfnID":"branch-factor-encoding","dfnText":"Branch Factor Encoding","external":false,"refSections":[{"refs":[{"id":"ref-for-branch-factor-encoding"}],"title":"4.2.2.3. Sparse Bit Set"}],"url":"#branch-factor-encoding"},
-"brotli-patch": {"dfnID":"brotli-patch","dfnText":"Brotli patch","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch"}],"title":"5.4.1. Applying Brotli Patches"}],"url":"#brotli-patch"},
-"brotli-patch-brotlistream": {"dfnID":"brotli-patch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-brotlistream"}],"title":"5.4. Brotli Patch"},{"refs":[{"id":"ref-for-brotli-patch-brotlistream\u2460"}],"title":"5.4.1. Applying Brotli Patches"}],"url":"#brotli-patch-brotlistream"},
-"brotli-patch-compatibilityid": {"dfnID":"brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-compatibilityid"}],"title":"5.4.1. Applying Brotli Patches"}],"url":"#brotli-patch-compatibilityid"},
-"brotli-patch-format": {"dfnID":"brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-format"}],"title":"5.4.1. Applying Brotli Patches"}],"url":"#brotli-patch-format"},
-"design-space-segment": {"dfnID":"design-space-segment","dfnText":"Design Space Segment","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment"}],"title":"4.2.2. Patch Map Table: Format 2"}],"url":"#design-space-segment"},
-"design-space-segment-end": {"dfnID":"design-space-segment-end","dfnText":"end","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-end"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-end"},
-"design-space-segment-start": {"dfnID":"design-space-segment-start","dfnText":"start","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-start"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-start"},
-"design-space-segment-tag": {"dfnID":"design-space-segment-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-tag"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-tag"},
-"entrymaprecord": {"dfnID":"entrymaprecord","dfnText":"EntryMapRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord"},{"id":"ref-for-entrymaprecord\u2460"}],"title":"4.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-entrymaprecord\u2461"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord"},
-"entrymaprecord-firstentryindex": {"dfnID":"entrymaprecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-firstentryindex"},{"id":"ref-for-entrymaprecord-firstentryindex\u2460"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-firstentryindex"},
-"entrymaprecord-lastentryindex": {"dfnID":"entrymaprecord-lastentryindex","dfnText":"lastEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-lastentryindex"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-lastentryindex"},
-"feature-map": {"dfnID":"feature-map","dfnText":"Feature Map","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map"}],"title":"4.2.1. Patch Map Table: Format 1"}],"url":"#feature-map"},
-"feature-map-entrymaprecords": {"dfnID":"feature-map-entrymaprecords","dfnText":"entryMapRecords","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map-entrymaprecords"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#feature-map-entrymaprecords"},
-"feature-map-featurerecords": {"dfnID":"feature-map-featurerecords","dfnText":"featureRecords","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map-featurerecords"}],"title":"4.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-feature-map-featurerecords\u2460"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#feature-map-featurerecords"},
-"featurerecord": {"dfnID":"featurerecord","dfnText":"FeatureRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord"}],"title":"4.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord\u2460"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#featurerecord"},
-"featurerecord-entrymapcount": {"dfnID":"featurerecord-entrymapcount","dfnText":"entryMapCount","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-entrymapcount"}],"title":"4.2.1. Patch Map Table: Format 1"}],"url":"#featurerecord-entrymapcount"},
-"featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"4.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
-"featurerecord-firstentryindex": {"dfnID":"featurerecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstentryindex"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstentryindex"},
-"font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"5.1. Definitions"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoder"}],"url":"#font-patch"},
-"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"}],"title":"4.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2461"}],"title":"5. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"},{"id":"ref-for-font-subset\u2464"},{"id":"ref-for-font-subset\u2465"}],"title":"5.1. Definitions"},{"refs":[{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"},{"id":"ref-for-font-subset\u2468"}],"title":"5.2. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"},{"id":"ref-for-font-subset\u2460\u2460"},{"id":"ref-for-font-subset\u2460\u2461"},{"id":"ref-for-font-subset\u2460\u2462"}],"title":"5.3. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2463"}],"title":"5.4. Brotli Patch"},{"refs":[{"id":"ref-for-font-subset\u2460\u2464"},{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"}],"title":"5.4.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2467"},{"id":"ref-for-font-subset\u2460\u2468"}],"title":"5.5. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"},{"id":"ref-for-font-subset\u2461\u2461"}],"title":"5.5.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"}],"title":"5.6. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u2463"},{"id":"ref-for-font-subset\u2461\u2464"},{"id":"ref-for-font-subset\u2461\u2465"}],"title":"5.6.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2466"},{"id":"ref-for-font-subset\u2461\u2467"}],"title":"6. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2461\u2468"}],"title":"6.1. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2462\u24ea"}],"title":"7. Encoder"},{"refs":[{"id":"ref-for-font-subset\u2462\u2460"}],"title":"7.1. Encoder Considerations"}],"url":"#font-subset"},
-"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"}],"title":"4. Extensions to the Font Format"},{"refs":[{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"4.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"},{"id":"ref-for-font-subset-definition\u2463"},{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"},{"id":"ref-for-font-subset-definition\u2466"}],"title":"6. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset-definition\u2467"}],"title":"7. Encoder"},{"refs":[{"id":"ref-for-font-subset-definition\u2468"}],"title":"7.1. Encoder Considerations"}],"url":"#font-subset-definition"},
-"format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"4.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"4.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
-"format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}],"title":"4.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"}],"title":"4.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
-"format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
-"format-1-patch-map-entrycount": {"dfnID":"format-1-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-entrycount"},{"id":"ref-for-format-1-patch-map-entrycount\u2460"},{"id":"ref-for-format-1-patch-map-entrycount\u2461"},{"id":"ref-for-format-1-patch-map-entrycount\u2462"},{"id":"ref-for-format-1-patch-map-entrycount\u2463"}],"title":"4.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-entrycount"},
-"format-1-patch-map-format": {"dfnID":"format-1-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-format"}],"title":"4.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-format\u2460"}],"title":"4.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-format"},
-"format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"}],"title":"4.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
-"format-1-patch-map-patchencoding": {"dfnID":"format-1-patch-map-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchencoding"},{"id":"ref-for-format-1-patch-map-patchencoding\u2460"}],"title":"4.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchencoding"},
-"format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"4.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"4.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
-"format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"4.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"4.2.2.2. Remove Entries from Format 2"}],"url":"#format-2-patch-map"},
-"format-2-patch-map-compatibilityid": {"dfnID":"format-2-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-compatibilityid"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-compatibilityid"},
-"format-2-patch-map-defaultpatchencoding": {"dfnID":"format-2-patch-map-defaultpatchencoding","dfnText":"defaultPatchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchencoding"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchencoding\u2460"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-defaultpatchencoding"},
-"format-2-patch-map-entries": {"dfnID":"format-2-patch-map-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entries"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entries"},
-"format-2-patch-map-entrycount": {"dfnID":"format-2-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entrycount"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entrycount\u2460"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entrycount"},
-"format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
-"format-2-patch-map-format": {"dfnID":"format-2-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-format"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-format"},
-"format-2-patch-map-uritemplate": {"dfnID":"format-2-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-uritemplate"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-uritemplate"},
-"full-invalidation": {"dfnID":"full-invalidation","dfnText":"Full Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-full-invalidation"},{"id":"ref-for-full-invalidation\u2460"}],"title":"5.3. Formats Summary"},{"refs":[{"id":"ref-for-full-invalidation\u2461"},{"id":"ref-for-full-invalidation\u2462"}],"title":"6. Extending a Font Subset"}],"url":"#full-invalidation"},
-"glyph-keyed-patch": {"dfnID":"glyph-keyed-patch","dfnText":"Glyph keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch"},
-"glyph-keyed-patch-brotlistream": {"dfnID":"glyph-keyed-patch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-brotlistream"}],"title":"5.6. Glyph Keyed"},{"refs":[{"id":"ref-for-glyph-keyed-patch-brotlistream\u2460"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-brotlistream"},
-"glyph-keyed-patch-compatibilityid": {"dfnID":"glyph-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-compatibilityid"},{"id":"ref-for-glyph-keyed-patch-compatibilityid\u2460"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-compatibilityid"},
-"glyph-keyed-patch-flags": {"dfnID":"glyph-keyed-patch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-flags"}],"title":"5.6. Glyph Keyed"}],"url":"#glyph-keyed-patch-flags"},
-"glyph-keyed-patch-format": {"dfnID":"glyph-keyed-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-format"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-format"},
-"glyph-map": {"dfnID":"glyph-map","dfnText":"Glyph Map","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map"}],"title":"4.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map"},
-"glyph-map-entryindex": {"dfnID":"glyph-map-entryindex","dfnText":"entryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-entryindex"}],"title":"4.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-glyph-map-entryindex\u2460"}],"title":"4.2.1.2. Remove Entries from Format 1"}],"url":"#glyph-map-entryindex"},
-"glyph-map-firstmappedglyph": {"dfnID":"glyph-map-firstmappedglyph","dfnText":"firstMappedGlyph","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-firstmappedglyph"}],"title":"4.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map-firstmappedglyph"},
-"glyphpatches": {"dfnID":"glyphpatches","dfnText":"GlyphPatches","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches"},{"id":"ref-for-glyphpatches\u2460"}],"title":"5.6. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches\u2461"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches"},
-"glyphpatches-glyphcount": {"dfnID":"glyphpatches-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphcount"},{"id":"ref-for-glyphpatches-glyphcount\u2460"}],"title":"5.6. Glyph Keyed"}],"url":"#glyphpatches-glyphcount"},
-"glyphpatches-glyphdata": {"dfnID":"glyphpatches-glyphdata","dfnText":"glyphData","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphdata"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphdata"},
-"glyphpatches-glyphdataoffsets": {"dfnID":"glyphpatches-glyphdataoffsets","dfnText":"glyphDataOffsets","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphdataoffsets"}],"title":"5.6. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-glyphdataoffsets\u2460"},{"id":"ref-for-glyphpatches-glyphdataoffsets\u2461"},{"id":"ref-for-glyphpatches-glyphdataoffsets\u2462"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphdataoffsets"},
-"glyphpatches-glyphids": {"dfnID":"glyphpatches-glyphids","dfnText":"glyphIds","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphids"}],"title":"5.6. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-glyphids\u2460"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphids"},
-"glyphpatches-tables": {"dfnID":"glyphpatches-tables","dfnText":"tables","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-tables"},{"id":"ref-for-glyphpatches-tables\u2460"}],"title":"5.6. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-tables\u2461"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-tables"},
-"incremental-font": {"dfnID":"incremental-font","dfnText":"incremental font","external":false,"refSections":[{"refs":[{"id":"ref-for-incremental-font"},{"id":"ref-for-incremental-font\u2460"},{"id":"ref-for-incremental-font\u2461"},{"id":"ref-for-incremental-font\u2462"}],"title":"6. Extending a Font Subset"},{"refs":[{"id":"ref-for-incremental-font\u2463"}],"title":"6.1. Fully Expanding a Font"},{"refs":[{"id":"ref-for-incremental-font\u2464"},{"id":"ref-for-incremental-font\u2465"},{"id":"ref-for-incremental-font\u2466"},{"id":"ref-for-incremental-font\u2467"},{"id":"ref-for-incremental-font\u2468"},{"id":"ref-for-incremental-font\u2460\u24ea"},{"id":"ref-for-incremental-font\u2460\u2460"}],"title":"7. Encoder"}],"url":"#incremental-font"},
-"mapping-entries": {"dfnID":"mapping-entries","dfnText":"Mapping Entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries"}],"title":"4.2.2. Patch Map Table: Format 2"}],"url":"#mapping-entries"},
-"mapping-entries-entries": {"dfnID":"mapping-entries-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries-entries"},{"id":"ref-for-mapping-entries-entries\u2460"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2461"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entries-entries"},
-"mapping-entry": {"dfnID":"mapping-entry","dfnText":"Mapping Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry"},{"id":"ref-for-mapping-entry\u2460"},{"id":"ref-for-mapping-entry\u2461"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry\u2462"},{"id":"ref-for-mapping-entry\u2463"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry"},
-"mapping-entry-bias": {"dfnID":"mapping-entry-bias","dfnText":"bias","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-bias"},{"id":"ref-for-mapping-entry-bias\u2460"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-bias"},
-"mapping-entry-codepoints": {"dfnID":"mapping-entry-codepoints","dfnText":"codepoints","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-codepoints"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-codepoints"},
-"mapping-entry-copycount": {"dfnID":"mapping-entry-copycount","dfnText":"copyCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-copycount"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-copycount"},
-"mapping-entry-copyindices": {"dfnID":"mapping-entry-copyindices","dfnText":"copyIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-copyindices"},{"id":"ref-for-mapping-entry-copyindices\u2460"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-copyindices"},
-"mapping-entry-designspacecount": {"dfnID":"mapping-entry-designspacecount","dfnText":"designSpaceCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacecount"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacecount"},
-"mapping-entry-designspacesegments": {"dfnID":"mapping-entry-designspacesegments","dfnText":"designSpaceSegments","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacesegments"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacesegments"},
-"mapping-entry-entryiddelta": {"dfnID":"mapping-entry-entryiddelta","dfnText":"entryIdDelta","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryiddelta"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-entryiddelta\u2460"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-entryiddelta"},
-"mapping-entry-entryidstringlength": {"dfnID":"mapping-entry-entryidstringlength","dfnText":"entryIdStringLength","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryidstringlength"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-entryidstringlength\u2460"},{"id":"ref-for-mapping-entry-entryidstringlength\u2461"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-entryidstringlength"},
-"mapping-entry-featurecount": {"dfnID":"mapping-entry-featurecount","dfnText":"featureCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featurecount"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featurecount"},
-"mapping-entry-featuretags": {"dfnID":"mapping-entry-featuretags","dfnText":"featureTags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featuretags"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featuretags"},
-"mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"4.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"}],"title":"4.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"4.2.2.2. Remove Entries from Format 2"}],"url":"#mapping-entry-formatflags"},
-"mapping-entry-patchencoding": {"dfnID":"mapping-entry-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchencoding"}],"title":"4.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchencoding"},
-"no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"5.3. Formats Summary"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"6. Extending a Font Subset"}],"url":"#no-invalidation"},
-"partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"}],"title":"5.3. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2461"},{"id":"ref-for-partial-invalidation\u2462"}],"title":"6. Extending a Font Subset"}],"url":"#partial-invalidation"},
-"patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"5.4.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"5.5.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2461"}],"title":"5.6.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
-"patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"5.1. Definitions"}],"url":"#patch-format"},
-"patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"},{"id":"ref-for-patch-map-entries\u2460"},{"id":"ref-for-patch-map-entries\u2461"},{"id":"ref-for-patch-map-entries\u2462"}],"title":"4.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"}],"title":"4.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map-entries\u2466"},{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"}],"title":"6. Extending a Font Subset"}],"url":"#patch-map-entries"},
-"per-table-brotli-patch": {"dfnID":"per-table-brotli-patch","dfnText":"Per table brotli patch","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch"}],"title":"5.5.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch"},
-"per-table-brotli-patch-compatibilityid": {"dfnID":"per-table-brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-compatibilityid"}],"title":"5.5.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-compatibilityid"},
-"per-table-brotli-patch-format": {"dfnID":"per-table-brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-format"}],"title":"5.5.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-format"},
-"per-table-brotli-patch-patches": {"dfnID":"per-table-brotli-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-patches"}],"title":"5.5. Per Table Brotli"},{"refs":[{"id":"ref-for-per-table-brotli-patch-patches\u2460"},{"id":"ref-for-per-table-brotli-patch-patches\u2461"},{"id":"ref-for-per-table-brotli-patch-patches\u2462"},{"id":"ref-for-per-table-brotli-patch-patches\u2463"},{"id":"ref-for-per-table-brotli-patch-patches\u2464"}],"title":"5.5.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-patches"},
-"sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"4.2.2. Patch Map Table: Format 2"}],"url":"#sparse-bit-set"},
-"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"5.5. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"5.5.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch"},
-"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"5.5. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"5.5.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-brotlistream"},
-"tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"5.5.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-flags"},
-"tablepatch-tag": {"dfnID":"tablepatch-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-tag"},{"id":"ref-for-tablepatch-tag\u2460"},{"id":"ref-for-tablepatch-tag\u2461"},{"id":"ref-for-tablepatch-tag\u2462"},{"id":"ref-for-tablepatch-tag\u2463"}],"title":"5.5.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-tag"},
+"abstract-opdef-handle-errors": {"dfnID":"abstract-opdef-handle-errors","dfnText":"Handle errors","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-handle-errors"}],"title":"4.2. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-handle-errors"},
+"abstract-opdef-interpret-format-1-patch-map": {"dfnID":"abstract-opdef-interpret-format-1-patch-map","dfnText":"Interpret Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-1-patch-map"}],"title":"4.2. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-interpret-format-1-patch-map"},
+"abstract-opdef-interpret-format-2-patch-map": {"dfnID":"abstract-opdef-interpret-format-2-patch-map","dfnText":"Interpret Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2460"},{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2461"},{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2462"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#abstract-opdef-interpret-format-2-patch-map"},
+"abstract-opdef-interpret-format-2-patch-map-entry": {"dfnID":"abstract-opdef-interpret-format-2-patch-map-entry","dfnText":"Interpret Format 2 Patch Map Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2461"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#abstract-opdef-interpret-format-2-patch-map-entry"},
+"abstract-opdef-load-patch-file": {"dfnID":"abstract-opdef-load-patch-file","dfnText":"Load patch file","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file"}],"title":"4.2. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-load-patch-file"},
+"abstract-opdef-remove-entries-from-format-1-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-1-patch-map","dfnText":"Remove Entries from Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-1-patch-map"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-1-patch-map"},
+"abstract-opdef-remove-entries-from-format-2-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-2-patch-map","dfnText":"Remove Entries from Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-2-patch-map"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-2-patch-map"},
+"branch-factor-encoding": {"dfnID":"branch-factor-encoding","dfnText":"Branch Factor Encoding","external":false,"refSections":[{"refs":[{"id":"ref-for-branch-factor-encoding"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#branch-factor-encoding"},
+"brotli-patch": {"dfnID":"brotli-patch","dfnText":"Brotli patch","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch"},
+"brotli-patch-brotlistream": {"dfnID":"brotli-patch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-brotlistream"}],"title":"6.2. Brotli Patch"},{"refs":[{"id":"ref-for-brotli-patch-brotlistream\u2460"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch-brotlistream"},
+"brotli-patch-compatibilityid": {"dfnID":"brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-compatibilityid"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch-compatibilityid"},
+"brotli-patch-format": {"dfnID":"brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-format"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch-format"},
+"design-space-segment": {"dfnID":"design-space-segment","dfnText":"Design Space Segment","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#design-space-segment"},
+"design-space-segment-end": {"dfnID":"design-space-segment-end","dfnText":"end","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-end"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-end"},
+"design-space-segment-start": {"dfnID":"design-space-segment-start","dfnText":"start","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-start"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-start"},
+"design-space-segment-tag": {"dfnID":"design-space-segment-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-tag"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-tag"},
+"entrymaprecord": {"dfnID":"entrymaprecord","dfnText":"EntryMapRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord"},{"id":"ref-for-entrymaprecord\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-entrymaprecord\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord"},
+"entrymaprecord-firstentryindex": {"dfnID":"entrymaprecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-firstentryindex"},{"id":"ref-for-entrymaprecord-firstentryindex\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-firstentryindex"},
+"entrymaprecord-lastentryindex": {"dfnID":"entrymaprecord-lastentryindex","dfnText":"lastEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-lastentryindex"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-lastentryindex"},
+"feature-map": {"dfnID":"feature-map","dfnText":"Feature Map","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#feature-map"},
+"feature-map-entrymaprecords": {"dfnID":"feature-map-entrymaprecords","dfnText":"entryMapRecords","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map-entrymaprecords"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#feature-map-entrymaprecords"},
+"feature-map-featurerecords": {"dfnID":"feature-map-featurerecords","dfnText":"featureRecords","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map-featurerecords"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-feature-map-featurerecords\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#feature-map-featurerecords"},
+"featurerecord": {"dfnID":"featurerecord","dfnText":"FeatureRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord"},
+"featurerecord-entrymapcount": {"dfnID":"featurerecord-entrymapcount","dfnText":"entryMapCount","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-entrymapcount"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#featurerecord-entrymapcount"},
+"featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
+"featurerecord-firstentryindex": {"dfnID":"featurerecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstentryindex"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstentryindex"},
+"font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoder"}],"url":"#font-patch"},
+"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.3. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"},{"id":"ref-for-font-subset\u2460\u2465"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2466"}],"title":"6.2. Brotli Patch"},{"refs":[{"id":"ref-for-font-subset\u2460\u2467"},{"id":"ref-for-font-subset\u2460\u2468"},{"id":"ref-for-font-subset\u2461\u24ea"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2460"},{"id":"ref-for-font-subset\u2461\u2461"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"},{"id":"ref-for-font-subset\u2461\u2463"},{"id":"ref-for-font-subset\u2461\u2464"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2465"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u2466"},{"id":"ref-for-font-subset\u2461\u2467"},{"id":"ref-for-font-subset\u2461\u2468"}],"title":"6.4.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2462\u24ea"}],"title":"7. Encoder"},{"refs":[{"id":"ref-for-font-subset\u2462\u2460"}],"title":"7.1. Encoder Considerations"}],"url":"#font-subset"},
+"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"},{"id":"ref-for-font-subset-definition\u2463"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2464"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"},{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2468"}],"title":"7. Encoder"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u24ea"}],"title":"7.1. Encoder Considerations"}],"url":"#font-subset-definition"},
+"format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
+"format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
+"format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
+"format-1-patch-map-entrycount": {"dfnID":"format-1-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-entrycount"},{"id":"ref-for-format-1-patch-map-entrycount\u2460"},{"id":"ref-for-format-1-patch-map-entrycount\u2461"},{"id":"ref-for-format-1-patch-map-entrycount\u2462"},{"id":"ref-for-format-1-patch-map-entrycount\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-entrycount"},
+"format-1-patch-map-format": {"dfnID":"format-1-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-format"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-format\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-format"},
+"format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
+"format-1-patch-map-patchencoding": {"dfnID":"format-1-patch-map-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchencoding"},{"id":"ref-for-format-1-patch-map-patchencoding\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchencoding"},
+"format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
+"format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#format-2-patch-map"},
+"format-2-patch-map-compatibilityid": {"dfnID":"format-2-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-compatibilityid"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-compatibilityid"},
+"format-2-patch-map-defaultpatchencoding": {"dfnID":"format-2-patch-map-defaultpatchencoding","dfnText":"defaultPatchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchencoding"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchencoding\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-defaultpatchencoding"},
+"format-2-patch-map-entries": {"dfnID":"format-2-patch-map-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entries"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entries"},
+"format-2-patch-map-entrycount": {"dfnID":"format-2-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entrycount"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entrycount\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entrycount"},
+"format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
+"format-2-patch-map-format": {"dfnID":"format-2-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-format"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-format"},
+"format-2-patch-map-uritemplate": {"dfnID":"format-2-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-uritemplate"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-uritemplate"},
+"full-invalidation": {"dfnID":"full-invalidation","dfnText":"Full Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-full-invalidation"},{"id":"ref-for-full-invalidation\u2460"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-full-invalidation\u2461"},{"id":"ref-for-full-invalidation\u2462"}],"title":"6.1. Formats Summary"}],"url":"#full-invalidation"},
+"glyph-keyed-patch": {"dfnID":"glyph-keyed-patch","dfnText":"Glyph keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch"},
+"glyph-keyed-patch-brotlistream": {"dfnID":"glyph-keyed-patch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-brotlistream"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyph-keyed-patch-brotlistream\u2460"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-brotlistream"},
+"glyph-keyed-patch-compatibilityid": {"dfnID":"glyph-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-compatibilityid"},{"id":"ref-for-glyph-keyed-patch-compatibilityid\u2460"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-compatibilityid"},
+"glyph-keyed-patch-flags": {"dfnID":"glyph-keyed-patch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-flags"}],"title":"6.4. Glyph Keyed"}],"url":"#glyph-keyed-patch-flags"},
+"glyph-keyed-patch-format": {"dfnID":"glyph-keyed-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-format"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-format"},
+"glyph-map": {"dfnID":"glyph-map","dfnText":"Glyph Map","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map"},
+"glyph-map-entryindex": {"dfnID":"glyph-map-entryindex","dfnText":"entryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-entryindex"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-glyph-map-entryindex\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#glyph-map-entryindex"},
+"glyph-map-firstmappedglyph": {"dfnID":"glyph-map-firstmappedglyph","dfnText":"firstMappedGlyph","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-firstmappedglyph"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map-firstmappedglyph"},
+"glyphpatches": {"dfnID":"glyphpatches","dfnText":"GlyphPatches","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches"},{"id":"ref-for-glyphpatches\u2460"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches"},
+"glyphpatches-glyphcount": {"dfnID":"glyphpatches-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphcount"},{"id":"ref-for-glyphpatches-glyphcount\u2460"}],"title":"6.4. Glyph Keyed"}],"url":"#glyphpatches-glyphcount"},
+"glyphpatches-glyphdata": {"dfnID":"glyphpatches-glyphdata","dfnText":"glyphData","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphdata"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphdata"},
+"glyphpatches-glyphdataoffsets": {"dfnID":"glyphpatches-glyphdataoffsets","dfnText":"glyphDataOffsets","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphdataoffsets"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-glyphdataoffsets\u2460"},{"id":"ref-for-glyphpatches-glyphdataoffsets\u2461"},{"id":"ref-for-glyphpatches-glyphdataoffsets\u2462"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphdataoffsets"},
+"glyphpatches-glyphids": {"dfnID":"glyphpatches-glyphids","dfnText":"glyphIds","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphids"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-glyphids\u2460"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphids"},
+"glyphpatches-tables": {"dfnID":"glyphpatches-tables","dfnText":"tables","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-tables"},{"id":"ref-for-glyphpatches-tables\u2460"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-tables\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-tables"},
+"incremental-font": {"dfnID":"incremental-font","dfnText":"incremental font","external":false,"refSections":[{"refs":[{"id":"ref-for-incremental-font"}],"title":"1.2. Overview"},{"refs":[{"id":"ref-for-incremental-font\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-incremental-font\u2461"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-incremental-font\u2462"},{"id":"ref-for-incremental-font\u2463"},{"id":"ref-for-incremental-font\u2464"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-incremental-font\u2465"}],"title":"4.3. Fully Expanding a Font"},{"refs":[{"id":"ref-for-incremental-font\u2466"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-incremental-font\u2467"},{"id":"ref-for-incremental-font\u2468"},{"id":"ref-for-incremental-font\u2460\u24ea"},{"id":"ref-for-incremental-font\u2460\u2460"},{"id":"ref-for-incremental-font\u2460\u2461"},{"id":"ref-for-incremental-font\u2460\u2462"},{"id":"ref-for-incremental-font\u2460\u2463"}],"title":"7. Encoder"}],"url":"#incremental-font"},
+"mapping-entries": {"dfnID":"mapping-entries","dfnText":"Mapping Entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#mapping-entries"},
+"mapping-entries-entries": {"dfnID":"mapping-entries-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries-entries"},{"id":"ref-for-mapping-entries-entries\u2460"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2461"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entries-entries"},
+"mapping-entry": {"dfnID":"mapping-entry","dfnText":"Mapping Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry"},{"id":"ref-for-mapping-entry\u2460"},{"id":"ref-for-mapping-entry\u2461"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry\u2462"},{"id":"ref-for-mapping-entry\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry"},
+"mapping-entry-bias": {"dfnID":"mapping-entry-bias","dfnText":"bias","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-bias"},{"id":"ref-for-mapping-entry-bias\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-bias"},
+"mapping-entry-codepoints": {"dfnID":"mapping-entry-codepoints","dfnText":"codepoints","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-codepoints"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-codepoints"},
+"mapping-entry-copycount": {"dfnID":"mapping-entry-copycount","dfnText":"copyCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-copycount"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-copycount"},
+"mapping-entry-copyindices": {"dfnID":"mapping-entry-copyindices","dfnText":"copyIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-copyindices"},{"id":"ref-for-mapping-entry-copyindices\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-copyindices"},
+"mapping-entry-designspacecount": {"dfnID":"mapping-entry-designspacecount","dfnText":"designSpaceCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacecount"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacecount"},
+"mapping-entry-designspacesegments": {"dfnID":"mapping-entry-designspacesegments","dfnText":"designSpaceSegments","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacesegments"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacesegments"},
+"mapping-entry-entryiddelta": {"dfnID":"mapping-entry-entryiddelta","dfnText":"entryIdDelta","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryiddelta"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-entryiddelta\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-entryiddelta"},
+"mapping-entry-entryidstringlength": {"dfnID":"mapping-entry-entryidstringlength","dfnText":"entryIdStringLength","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryidstringlength"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-entryidstringlength\u2460"},{"id":"ref-for-mapping-entry-entryidstringlength\u2461"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-entryidstringlength"},
+"mapping-entry-featurecount": {"dfnID":"mapping-entry-featurecount","dfnText":"featureCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featurecount"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featurecount"},
+"mapping-entry-featuretags": {"dfnID":"mapping-entry-featuretags","dfnText":"featureTags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featuretags"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featuretags"},
+"mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#mapping-entry-formatflags"},
+"mapping-entry-patchencoding": {"dfnID":"mapping-entry-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchencoding"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchencoding"},
+"no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"6.1. Formats Summary"}],"url":"#no-invalidation"},
+"partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2461"},{"id":"ref-for-partial-invalidation\u2462"}],"title":"6.1. Formats Summary"}],"url":"#partial-invalidation"},
+"patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
+"patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
+"patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2461"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map"},
+"patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2460"},{"id":"ref-for-patch-map-entries\u2461"},{"id":"ref-for-patch-map-entries\u2462"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map-entries"},
+"per-table-brotli-patch": {"dfnID":"per-table-brotli-patch","dfnText":"Per table brotli patch","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch"},
+"per-table-brotli-patch-compatibilityid": {"dfnID":"per-table-brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-compatibilityid"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-compatibilityid"},
+"per-table-brotli-patch-format": {"dfnID":"per-table-brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-format"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-format"},
+"per-table-brotli-patch-patches": {"dfnID":"per-table-brotli-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-patches"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-per-table-brotli-patch-patches\u2460"},{"id":"ref-for-per-table-brotli-patch-patches\u2461"},{"id":"ref-for-per-table-brotli-patch-patches\u2462"},{"id":"ref-for-per-table-brotli-patch-patches\u2463"},{"id":"ref-for-per-table-brotli-patch-patches\u2464"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-patches"},
+"sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#sparse-bit-set"},
+"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch"},
+"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-brotlistream"},
+"tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-flags"},
+"tablepatch-tag": {"dfnID":"tablepatch-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-tag"},{"id":"ref-for-tablepatch-tag\u2460"},{"id":"ref-for-tablepatch-tag\u2461"},{"id":"ref-for-tablepatch-tag\u2462"},{"id":"ref-for-tablepatch-tag\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-tag"},
 };
 
 document.addEventListener("DOMContentLoaded", ()=>{
@@ -3232,7 +3263,7 @@ function genLinkingSyntaxes(dfn) {
 {
 let refsData = {
 "#abstract-opdef-check-entry-intersection": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Check entry intersection","type":"abstract-op","url":"#abstract-opdef-check-entry-intersection"},
-"#abstract-opdef-extend-a-font-subset": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Extend a Font Subset","type":"abstract-op","url":"#abstract-opdef-extend-a-font-subset"},
+"#abstract-opdef-extend-an-incremental-font-subset": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Extend an Incremental Font Subset","type":"abstract-op","url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "#abstract-opdef-fully-expand-a-font-subset": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Fully Expand a Font Subset","type":"abstract-op","url":"#abstract-opdef-fully-expand-a-font-subset"},
 "#abstract-opdef-handle-errors": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Handle errors","type":"abstract-op","url":"#abstract-opdef-handle-errors"},
 "#abstract-opdef-interpret-format-1-patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Interpret Format 1 Patch Map","type":"abstract-op","url":"#abstract-opdef-interpret-format-1-patch-map"},
@@ -3314,6 +3345,7 @@ let refsData = {
 "#partial-invalidation": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"partial invalidation","type":"dfn","url":"#partial-invalidation"},
 "#patch-application-algorithm": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch application algorithm","type":"dfn","url":"#patch-application-algorithm"},
 "#patch-format": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch format","type":"dfn","url":"#patch-format"},
+"#patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map","type":"dfn","url":"#patch-map"},
 "#patch-map-entries": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map entries","type":"dfn","url":"#patch-map-entries"},
 "#per-table-brotli-patch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"per table brotli patch","type":"dfn","url":"#per-table-brotli-patch"},
 "#per-table-brotli-patch-compatibilityid": {"export":true,"for_":["Per table brotli patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#per-table-brotli-patch-compatibilityid"},

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="1981855541cb3f3f32eadf103da0fcf1f31e613a" name="revision">
+  <meta content="5380efe853a26da4338a0a73e95e038b9f250766" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -938,7 +938,7 @@ in <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-
    <p>This section defines the algorithm that a client uses to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> to cover additional
 codepoints, layout features and/or design space.</p>
    <h3 class="heading settled" data-level="4.1" id="font-patch-invalidations"><span class="secno">4.1. </span><span class="content">Patch Invalidations</span><a class="self-link" href="#font-patch-invalidations"></a></h3>
-   <p>The application of a patch to an an incremental <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> may invalidate some or all of the other mapped patches, so that if
+   <p>The application of a patch to an incremental <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> may invalidate some or all of the other mapped patches, so that if
 one of those were to be applied the result would be a corrupt <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font</a>. Patch validity is tracked by the compatibility ID from the <a href="#patch-map-table">§ 5.2 Patch Map Table</a>. Every patch has a
 compatibility ID encoded within it which needs to match the compatibility ID from the <a href="#patch-map-table">§ 5.2 Patch Map Table</a> which lists that patch.
 Every patch is categorized into one of three types, depending on how it does or does not invalidate other patches in the map(s):</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="4a24a41b1b8d0b2a4f6190f92c39b4c5e3488950" name="revision">
+  <meta content="1981855541cb3f3f32eadf103da0fcf1f31e613a" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -607,7 +607,7 @@ var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBC
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-29">29 April 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-04-30">30 April 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -677,7 +677,7 @@ be loaded over multiple requests where each request incrementally adds additiona
       <li><a href="#font-subset-dfn"><span class="secno">3.1</span> <span class="content">Font Subset</span></a>
       <li><a href="#font-patch-definitions"><span class="secno">3.2</span> <span class="content">Font Patch</span></a>
       <li><a href="#patch-map-dfn"><span class="secno">3.3</span> <span class="content">Patch Map</span></a>
-      <li><a href="#data-types"><span class="secno">3.4</span> <span class="content">Data Types</span></a>
+      <li><a href="#data-types"><span class="secno">3.4</span> <span class="content">Explanation of Data Types</span></a>
      </ol>
     <li>
      <a href="#extending-font-subset"><span class="secno">4</span> <span class="content">Extending a Font Subset</span></a>
@@ -931,17 +931,17 @@ in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a>.</
          <p><a href="#font-patch-invalidations">compatibility ID</a></p>
        </ul>
    </table>
-   <h3 class="heading settled" data-level="3.4" id="data-types"><span class="secno">3.4. </span><span class="content">Data Types</span><a class="self-link" href="#data-types"></a></h3>
+   <h3 class="heading settled" data-level="3.4" id="data-types"><span class="secno">3.4. </span><span class="content">Explanation of Data Types</span><a class="self-link" href="#data-types"></a></h3>
    <p>Encoded data structures in the remainder of this specification are described in terms of the data types defined
 in <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types">OpenType Specification § otff#data-types</a>. As with the rest of OpenType, all fields use "big-endian" byte ordering.</p>
    <h2 class="heading settled" data-level="4" id="extending-font-subset"><span class="secno">4. </span><span class="content">Extending a Font Subset</span><a class="self-link" href="#extending-font-subset"></a></h2>
-   <p>This sections defines the algorithm that a client uses to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> to cover additional
+   <p>This section defines the algorithm that a client uses to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑤">font subset</a> to cover additional
 codepoints, layout features and/or design space.</p>
    <h3 class="heading settled" data-level="4.1" id="font-patch-invalidations"><span class="secno">4.1. </span><span class="content">Patch Invalidations</span><a class="self-link" href="#font-patch-invalidations"></a></h3>
-   <p>Patches in an incremental <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> when applied may invalidate other available patches, making them invalid to be applied
-to the extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a>. Patch validity is checked using the compatibility ID from the <a href="#patch-map-table">§ 5.2 Patch Map Table</a>. Every patch has a
+   <p>The application of a patch to an an incremental <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑥">font subset</a> may invalidate some or all of the other mapped patches, so that if
+one of those were to be applied the result would be a corrupt <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font</a>. Patch validity is tracked by the compatibility ID from the <a href="#patch-map-table">§ 5.2 Patch Map Table</a>. Every patch has a
 compatibility ID encoded within it which needs to match the compatibility ID from the <a href="#patch-map-table">§ 5.2 Patch Map Table</a> which lists that patch.
-Additionally to aid the client in determining what invalidations will occur, every patch is categorized into one of three categories:</p>
+Every patch is categorized into one of three types, depending on how it does or does not invalidate other patches in the map(s):</p>
    <ul>
     <li data-md>
      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="full-invalidation">Full Invalidation</dfn>: when this patch is applied all other patches currently listed in the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a> are invalidated.
@@ -953,7 +953,7 @@ The compatibility ID of only the <a href="#patch-map-table">§ 5.2 Patch Map T
      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="no-invalidation">No Invalidation</dfn>: no other patches will be invalidated by the application of this patch. The compatibility ID of the
 'IFT ' and 'IFTX' <a href="#patch-map-table">§ 5.2 Patch Map Table</a> will not change.</p>
    </ul>
-   <p>The invalidation behaviour of a specific patch is encoded in its format number which can be found in <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a>.</p>
+   <p>The invalidation behavior of a specific patch is encoded in its format number, which can be found in <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a>.</p>
    <h3 class="heading settled algorithm" data-algorithm="Incremental Font Extension Algorithm" data-level="4.2" id="extend-font-subset"><span class="secno">4.2. </span><span class="content">Incremental Font Extension Algorithm</span><a class="self-link" href="#extend-font-subset"></a></h3>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</dfn></p>
    <p>The inputs to this algorithm are:</p>
@@ -961,7 +961,8 @@ The compatibility ID of only the <a href="#patch-map-table">§ 5.2 Patch Map T
     <li data-md>
      <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font③">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑨">font subset</a>.</p>
     <li data-md>
-     <p><var>font subset URI</var>: an <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the location of <var>font subset</var>.</p>
+     <p><var>original font subset URI</var>: an <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">absolute URI</a> which identifies the location of the original incremental
+font that <var>font subset</var> was derived from.</p>
     <li data-md>
      <p><var>target subset definition</var>: the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a> that the client wants to extend <var>font subset</var> to cover.</p>
    </ul>
@@ -1000,7 +1001,8 @@ The criteria for selecting the single entry is left up to the implementation to 
 The criteria for selecting the single entry is left up to the implementation to decide.</p>
      </ul>
     <li data-md>
-     <p>Load <var>patch file</var> by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>font subset URI</var> as the incremental font URI and the <var>entry</var> patch URI as the patch URI.</p>
+     <p>Load <var>patch file</var> by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>original font subset URI</var> as the original font URI and
+the <var>entry</var> patch URI as the patch URI.</p>
     <li data-md>
      <p>Apply <var>patch file</var> using the appropriate application algorithm (matching the patches format in <var>entry</var>) from <a href="#font-patch-formats">§ 6 Font Patch Formats</a> to apply the <var>patch file</var> using the patch URI and the compatibility id from <var>entry</var> to <var>extended font subset</var>.</p>
     <li data-md>
@@ -1008,7 +1010,8 @@ The criteria for selecting the single entry is left up to the implementation to 
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> the algorithm here presents patch loads as being done one at a time; however, to improve performance client implementations are
 encouraged to pre-fetch patch files that will be applied in later iterations by the algorithm. The <a href="#font-patch-invalidations">invalidation categories</a> can be used to predict which intersecting patches from step 4 will remain be valid
-to be applied.</p>
+to be applied. For example: in a case where there are only "No Invalidation" intersecting patches the client could safely load all
+intersecting patches in parallel, since no patch application will invalidate any of the other intersecting patches.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-check-entry-intersection">Check entry intersection</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
@@ -1052,8 +1055,8 @@ to be applied.</p>
      <p><var>Patch URI</var>: A <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.1">URI Reference</a> identifying the patch file to load. As a URI reference this may be a
  relative path.</p>
     <li data-md>
-     <p><var>Incremental Font URI</var>: An <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">abslolute URI</a> which identifies the incremental font which contains
- the reference to <var>Patch URI</var>.</p>
+     <p><var>Original Font URI</var>: An <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">absolute URI</a> which identifies the original incremental font that the
+ patch URI was derived from.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1063,7 +1066,7 @@ to be applied.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Perform <a href="https://www.rfc-editor.org/rfc/rfc3986#section-5">reference resolution</a> on <var>Patch URI</var> using <var>Incremental Font URI</var> as the base URI to
+     <p>Perform <a href="https://www.rfc-editor.org/rfc/rfc3986#section-5">reference resolution</a> on <var>Patch URI</var> using <var>Original Font URI</var> as the base URI to
  produce the <var>target URI</var>.</p>
     <li data-md>
      <p>Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers, <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[fetch]</a> should be used. Return the retrieved contents as <var>patch file</var>, or an error if the fetch resulted in an error.</p>


### PR DESCRIPTION
This reorders several of the top level sections in order to make the specification easier to understand by an unfamiliar reader:
1. Move the 'Extending a Font Subset' section to before the patch map and patch formats section. This introduces the process which utilizes patch maps and patches before getting into the minute details of those.
2. In the common definitions section, add basic summaries of patch maps and patches. This is needed to introduce the basics on these concept before they are used in the 'Extending a Font Subset' algorithm.
3. Move the 'URI Templates' from the common definitions into the patch map table section, which is the only section that references it.
4. Move the 'Patch Invalidations' section from the patch map section and into the 'Extending a Font Subset Section' where it's needed to understand how the extension algorithm works.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/171.html" title="Last updated on Apr 30, 2024, 11:57 PM UTC (2cd6eb0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/171/7d7db59...2cd6eb0.html" title="Last updated on Apr 30, 2024, 11:57 PM UTC (2cd6eb0)">Diff</a>