### PR TITLE
Remove (non-per-table) brotli partial invalidation patch format number

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1501,7 +1501,7 @@ The following patch formats are defined by this specification:
 <table>
   <tr>
     <th>Name</th>
-    <th>ID</th>
+    <th>Format Number</th>
     <th>Invalidation</th>
     <th>Description</th>
   </tr>
@@ -1511,30 +1511,23 @@ The following patch formats are defined by this specification:
     <td>[=Full Invalidation=]</td>
     <td>A brotli encoded binary diff that uses the entire [=font subset=] as a base.</td>
   </tr>
-  <tr>
-    <td>[[#brotli]]</td>
-    <td>2</td>
-    <td>[=Partial Invalidation=]</td>
-    <td>A brotli encoded binary diff that uses the entire [=font subset=] as a base.</td>
-  </tr>
-
 
   <tr>
     <td>[[#per-table-brotli]]</td>
-    <td>3</td>
+    <td>2</td>
     <td>[=Full Invalidation=]</td>
     <td>A collection of brotli encoded binary diffs that use tables from the [=font subset=] as bases.</td>
   </tr>
   <tr>
     <td>[[#per-table-brotli]]</td>
-    <td>4</td>
+    <td>3</td>
     <td>[=Partial Invalidation=]</td>
     <td>A collection of brotli encoded binary diffs that use tables from the [=font subset=] as bases.</td>
   </tr>
 
   <tr>
     <td>[[#glyph-keyed]]</td>
-    <td>5</td>
+    <td>4</td>
     <td>[=No Invalidation=]</td>
     <td>Contains a collection of opaque binary blobs, each associated with a glyph id and table.</td>
   </tr>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="3a16873baa41e9fc8b2b5da567e61df599a27f88" name="revision">
+  <meta content="bcb93fd5c909171e15f96d6ee03abc89685c2b51" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -607,7 +607,7 @@ var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBC
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-05-14">14 May 2024</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2024-05-22">22 May 2024</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1896,7 +1896,7 @@ encoding can make use of more than one patch format.</p>
     <tbody>
      <tr>
       <th>Name
-      <th>ID
+      <th>Format Number
       <th>Invalidation
       <th>Description
      <tr>
@@ -1905,23 +1905,18 @@ encoding can make use of more than one patch format.</p>
       <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation②">Full Invalidation</a>
       <td>A brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as a base.
      <tr>
-      <td><a href="#brotli">§ 6.2 Brotli Patch</a>
+      <td><a href="#per-table-brotli">§ 6.3 Per Table Brotli</a>
       <td>2
-      <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation②">Partial Invalidation</a>
-      <td>A brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> as a base.
+      <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation③">Full Invalidation</a>
+      <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> as bases.
      <tr>
       <td><a href="#per-table-brotli">§ 6.3 Per Table Brotli</a>
       <td>3
-      <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation③">Full Invalidation</a>
+      <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation②">Partial Invalidation</a>
       <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> as bases.
      <tr>
-      <td><a href="#per-table-brotli">§ 6.3 Per Table Brotli</a>
-      <td>4
-      <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation③">Partial Invalidation</a>
-      <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> as bases.
-     <tr>
       <td><a href="#glyph-keyed">§ 6.4 Glyph Keyed</a>
-      <td>5
+      <td>4
       <td><a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation①">No Invalidation</a>
       <td>Contains a collection of opaque binary blobs, each associated with a glyph id and table.
    </table>
@@ -1948,7 +1943,7 @@ of a short header followed by brotli encoded data.</p>
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
+      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint32
       <td>length
@@ -1959,13 +1954,13 @@ of a short header followed by brotli encoded data.</p>
       <td>Brotli encoded byte stream.
    </table>
    <h4 class="heading settled algorithm" data-algorithm="Applying Brotli Patches" data-level="6.2.1" id="apply-brotli"><span class="secno">6.2.1. </span><span class="content">Applying Brotli Patches</span><a class="self-link" href="#apply-brotli"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> to cover additional codepoints,
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-brotli-patch">Apply brotli patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#brotli-patch" id="ref-for-brotli-patch">brotli patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -1974,7 +1969,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1994,7 +1989,7 @@ result as the <var>extended font subset</var></p>
    <h3 class="heading settled" data-level="6.3" id="per-table-brotli"><span class="secno">6.3. </span><span class="content">Per Table Brotli</span><a class="self-link" href="#per-table-brotli"></a></h3>
    <p>A per table brotli patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A per table brotli encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
-or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>.</p>
+or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch">Per table brotli patch</dfn> encoding:</p>
    <table>
     <tbody>
@@ -2013,7 +2008,7 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
+      <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint16
       <td>patchesCount
@@ -2050,13 +2045,13 @@ of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">Ta
       <td>Brotli encoded byte stream.
    </table>
    <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Brotli Patches" data-level="6.3.1" id="apply-per-table-brotli"><span class="secno">6.3.1. </span><span class="content">Applying Per Table Brotli Patches</span><a class="self-link" href="#apply-per-table-brotli"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm①">patch application algorithm</a> is used to apply a per table brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> to cover additional codepoints,
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm①">patch application algorithm</a> is used to apply a per table brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#per-table-brotli-patch" id="ref-for-per-table-brotli-patch">per table brotli patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -2065,7 +2060,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑤">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -2129,7 +2124,7 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Glyph keyed patch" data-dfn-type="dfn" data-noexport id="glyph-keyed-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑥">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
+      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑤">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint32
       <td>length
@@ -2175,13 +2170,13 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
    <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets">glyphDataOffsets</a> array gives the size
 of that glyph data.</p>
    <h4 class="heading settled algorithm" data-algorithm="Applying Glyph Keyed Patches" data-level="6.4.1" id="apply-glyph-keyed"><span class="secno">6.4.1. </span><span class="content">Applying Glyph Keyed Patches</span><a class="self-link" href="#apply-glyph-keyed"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm②">patch application algorithm</a> is used to apply a glyph keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑦">font subset</a> to cover additional codepoints,
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm②">patch application algorithm</a> is used to apply a glyph keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑥">font subset</a> to cover additional codepoints,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑦">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#glyph-keyed-patch" id="ref-for-glyph-keyed-patch">glyph keyed patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -2192,7 +2187,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑨">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -2250,7 +2245,7 @@ The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-fon
 of patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset③">Extend an Incremental Font Subset</a>.</p>
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font, that is:
- given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset④">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> and the minimal subset definition covering that content should
+ given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑨">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset④">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
     <li data-md>
      <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
@@ -2280,7 +2275,7 @@ guidance that encoder implementations may want to consider.</p>
    <p>As discussed in <a href="#encoder">§ 7 Encoder</a> a high quality encoder should preserve the functionality of the original font. One way to
 achieve this is to leverage an existing font subsetter implementation to produce font subsets that retain the functionality
 of the original font. The IFT patches can then be derived from these subsets.</p>
-   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③①">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a>. The practice of reliably
+   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a>. The practice of reliably
 subsetting a font is well understood and has multiple open-source implementations (a full formal description is
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
@@ -2877,7 +2872,7 @@ let dfnPanelData = {
 "featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
 "featurerecord-firstentryindex": {"dfnID":"featurerecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstentryindex"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoder"}],"url":"#font-patch"},
-"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.3. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"},{"id":"ref-for-font-subset\u2460\u2465"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2466"}],"title":"6.2. Brotli Patch"},{"refs":[{"id":"ref-for-font-subset\u2460\u2467"},{"id":"ref-for-font-subset\u2460\u2468"},{"id":"ref-for-font-subset\u2461\u24ea"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2460"},{"id":"ref-for-font-subset\u2461\u2461"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"},{"id":"ref-for-font-subset\u2461\u2463"},{"id":"ref-for-font-subset\u2461\u2464"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2465"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u2466"},{"id":"ref-for-font-subset\u2461\u2467"},{"id":"ref-for-font-subset\u2461\u2468"}],"title":"6.4.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2462\u24ea"}],"title":"7. Encoder"},{"refs":[{"id":"ref-for-font-subset\u2462\u2460"}],"title":"7.1. Encoder Considerations"}],"url":"#font-subset"},
+"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.3. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"}],"title":"6.2. Brotli Patch"},{"refs":[{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"},{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2461\u2461"},{"id":"ref-for-font-subset\u2461\u2462"},{"id":"ref-for-font-subset\u2461\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2464"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u2465"},{"id":"ref-for-font-subset\u2461\u2466"},{"id":"ref-for-font-subset\u2461\u2467"}],"title":"6.4.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2468"}],"title":"7. Encoder"},{"refs":[{"id":"ref-for-font-subset\u2462\u24ea"}],"title":"7.1. Encoder Considerations"}],"url":"#font-subset"},
 "font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"},{"id":"ref-for-font-subset-definition\u2463"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2464"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"},{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2468"}],"title":"7. Encoder"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u24ea"}],"title":"7.1. Encoder Considerations"}],"url":"#font-subset-definition"},
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
@@ -2927,7 +2922,7 @@ let dfnPanelData = {
 "mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#mapping-entry-formatflags"},
 "mapping-entry-patchencoding": {"dfnID":"mapping-entry-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchencoding"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchencoding"},
 "no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"6.1. Formats Summary"}],"url":"#no-invalidation"},
-"partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2461"},{"id":"ref-for-partial-invalidation\u2462"}],"title":"6.1. Formats Summary"}],"url":"#partial-invalidation"},
+"partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2461"}],"title":"6.1. Formats Summary"}],"url":"#partial-invalidation"},
 "patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
 "patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2461"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map"},


### PR DESCRIPTION
As discussed in #177 . 

I think we settled on "format number" instead of "ID a while back to reduce the overloading of "identifier" in the spec. So this updates the column heading to reflect that. (If I'm wrong I can back that out.)

Closes #177


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/skef/IFT/pull/179.html" title="Last updated on May 22, 2024, 9:10 AM UTC (684925c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/179/bcb93fd...skef:684925c.html" title="Last updated on May 22, 2024, 9:10 AM UTC (684925c)">Diff</a>