### PR TITLE
Updates for publication as WD on 2024 07 09

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -50,7 +50,7 @@ spec:fetch; type:dfn; for:/; text:response
     ],
     "status": "Internet Draft",
     "title": "Shared Brotli Compressed Data Format",
-    "date": "27 Jul 2021"
+    "date": "Sep 2022"
   },
 
   "open-type": {
@@ -59,7 +59,7 @@ spec:fetch; type:dfn; for:/; text:response
     "status": "Note",
     "publisher": "Microsoft",
     "title": "OpenType Specification",
-    "date": "December 2021"
+    "date": "May 2024"
   },
 
   "fetch": {
@@ -68,7 +68,7 @@ spec:fetch; type:dfn; for:/; text:response
     "status": "Living Standard",
     "publisher": "What WG",
     "title": "Fetch Standard",
-    "date": "22 May 2023"
+    "date": "17 June 2024"
   }
 }
 </pre>

--- a/Overview.html
+++ b/Overview.html
@@ -6,9 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d5d58a306, updated Fri Jan 26 16:12:28 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="024b91e5ab58162d4a867147fc4acd474c778bd6" name="revision">
-  <meta content="dark light" name="color-scheme">
-  <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
+  <meta content="eff06a3a4931e18ccc7efd34b6e21379470c239d" name="revision">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -648,15 +646,16 @@ be loaded over multiple requests where each request incrementally adds additiona
   current W3C publications and the latest revision of this technical report
   can be found in the <a href="https://www.w3.org/TR/">W3C technical reports
   index at https://www.w3.org/TR/.</a></em> </p>
+  <p>This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
+  <p>Publication as a Working Draft does not imply endorsement by W3C and its Members.</p>
    <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Working Draft using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation
       track</a>. This document is intended to become a W3C Recommendation. </p>
    <p> If you wish to make comments regarding this document, please <a href="https://github.com/w3c/PFE/issues/new">file an issue on the specification repository</a>. </p>
-   <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> </p>
-   <p> This document was produced by groups operating under
-  the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
+   <p> This document was produced by a group operating under
+  the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
   W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
-  An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
+  An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/policies/patent-policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
    <p> This document is governed by the <a href="https://www.w3.org/policies/process/20231103/" id="w3c_process_revision">03 November 2023 W3C Process Document</a>. </p>
    <p></p>
   </div>
@@ -2785,7 +2784,7 @@ number of requests:</p>
    <dt id="biblio-iso14496-22">[ISO14496-22]
    <dd><a href="https://www.iso.org/standard/87621.html"><cite>Information technology — Coding of audio-visual objects — Part 22: Open Font Format</cite></a>. Under development. URL: <a href="https://www.iso.org/standard/87621.html">https://www.iso.org/standard/87621.html</a>
    <dt id="biblio-open-type">[OPEN-TYPE]
-   <dd><a href="https://docs.microsoft.com/en-us/typography/opentype/spec"><cite>OpenType Specification</cite></a>. December 2021. Note. URL: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec">https://docs.microsoft.com/en-us/typography/opentype/spec</a>
+   <dd><a href="https://docs.microsoft.com/en-us/typography/opentype/spec"><cite>OpenType Specification</cite></a>. May 2024. Note. URL: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec">https://docs.microsoft.com/en-us/typography/opentype/spec</a>
    <dt id="biblio-pfe-report">[PFE-report]
    <dd>Chris Lilley. <a href="https://www.w3.org/TR/PFE-evaluation/"><cite>Progressive Font Enrichment: Evaluation Report</cite></a>. 15 October 2020. Note. URL: <a href="https://www.w3.org/TR/PFE-evaluation/">https://www.w3.org/TR/PFE-evaluation/</a>
    <dt id="biblio-rfc2119">[RFC2119]
@@ -2799,7 +2798,7 @@ number of requests:</p>
    <dt id="biblio-rfc7932">[RFC7932]
    <dd>J. Alakuijala; Z. Szabadka. <a href="https://www.rfc-editor.org/rfc/rfc7932"><cite>Brotli Compressed Data Format</cite></a>. July 2016. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc7932">https://www.rfc-editor.org/rfc/rfc7932</a>
    <dt id="biblio-shared-brotli">[Shared-Brotli]
-   <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09"><cite>Shared Brotli Compressed Data Format</cite></a>. 27 Jul 2021. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09</a>
+   <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09"><cite>Shared Brotli Compressed Data Format</cite></a>. Sep 2022. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09</a>
    <dt id="biblio-unicode">[UNICODE]
    <dd><a href="https://www.unicode.org/versions/latest/"><cite>The Unicode Standard</cite></a>. URL: <a href="https://www.unicode.org/versions/latest/">https://www.unicode.org/versions/latest/</a>
    <dt id="biblio-utf-8">[UTF-8]
@@ -2810,7 +2809,7 @@ number of requests:</p>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-fetch">[FETCH]
-   <dd><a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. 22 May 2023. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dd><a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. 17 June 2024. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-rfc9113">[RFC9113]
    <dd>M. Thomson, Ed.; C. Benfield, Ed.. <a href="https://httpwg.org/specs/rfc9113.html"><cite>HTTP/2</cite></a>. June 2022. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc9113.html">https://httpwg.org/specs/rfc9113.html</a>
    <dt id="biblio-rfc9114">[RFC9114]


### PR DESCRIPTION
- updates to local bibliography
- format as WD not ED
- sadly, some manual edits to the generated HTML to make it pass pubrules

Longer term this should be fixed by updating the bikeshed boilerplate files


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/189.html" title="Last updated on Jul 5, 2024, 5:49 PM UTC (c3946cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/189/a8d734d...c3946cd.html" title="Last updated on Jul 5, 2024, 5:49 PM UTC (c3946cd)">Diff</a>