### PR TITLE
Make Some Adjustments to Format 1 Patch Map

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -791,6 +791,9 @@ The algorithm:
 
 2.  For each unique <var>entry index</var> in [=Glyph Map/entryIndex=]:
 
+    *  If <var>entry index</var> is 0 then, this is a special entry used to mark glyphs which are already in the font. Skip this index
+        and do not build an entry for it.
+
     *  If the <var>entry index</var> is larger than [=Format 1 Patch Map/maxEntryIndex=] this table is invalid,
         return an error.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -619,8 +619,8 @@ the encoded bytes at the start of every iteration to pick up any changes made in
   </tr>
   <tr>
     <td>Offset32</td>
-    <td>featureMapOffset</td>
-    <td>Offset to a [=Feature Map=] sub table. Offset is from the start of this table.</td>
+    <td><dfn for="Format 1 Patch Map">featureMapOffset</dfn></td>
+    <td>Offset to a [=Feature Map=] sub table. Offset is from the start of this table. May be null (0).</td>
   </tr>
   <tr>
     <td>uint8</td>
@@ -725,7 +725,7 @@ A feature map table associates combinations of [[open-type/featuretags|feature t
   </tr>
   <tr>
     <td>uint8/uint16</td>
-    <td><dfn for="FeatureRecord">firstEntryIndex</dfn></td>
+    <td><dfn for="FeatureRecord">firstNewEntryIndex</dfn></td>
     <td>
       uint8 if [=Format 1 Patch Map/entryCount=] is less than 256, otherwise uint16.
       The first entry index this record maps too.
@@ -751,7 +751,8 @@ A feature map table associates combinations of [[open-type/featuretags|feature t
     <td>uint8/uint16</td>
     <td><dfn for="EntryMapRecord">firstEntryIndex</dfn></td>
     <td>
-      uint8 if [=Format 1 Patch Map/entryCount=] is less than 256, otherwise uint16.
+      uint8 if [=Format 1 Patch Map/entryCount=] is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
+      the set of [=Glyph Map=] entries which form the subset definitions for the entries created by this mapping.
     </td>
   </tr>
     <tr>
@@ -803,14 +804,16 @@ The algorithm:
         maps to the generated URI, the patch encoding specified by [=Format 1 Patch Map/patchEncoding=], and
         [=Format 1 Patch Map/compatibilityId=].
 
-3.  For each [=FeatureRecord=] and associated [=EntryMapRecord=] in [=Feature Map/featureRecords=] and [=Feature Map/entryMapRecords=]:
+3.  If [=Format 1 Patch Map/featureMapOffset=] is not null then, for each [=FeatureRecord=] and associated [=EntryMapRecord=] in
+        [=Feature Map/featureRecords=] and [=Feature Map/entryMapRecords=]:
 
-    *  For each <var>entry index</var> between [=EntryMapRecord/firstEntryIndex=] (inclusive) and [=EntryMapRecord/lastEntryIndex=]
+    *  For each <var>entry index</var> between [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] (inclusive) and
+        [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=]
         (inclusive), find the set of unicode codepoints associated with that entry index using the same process as in step 2b through
         2c.
 
         *  Compute <var>mapped entry index</var> =
-            [=FeatureRecord/firstEntryIndex|FeatureRecord::firstEntryIndex=] +
+            [=FeatureRecord/firstNewEntryIndex|FeatureRecord::firstNewEntryIndex=] +
             <var>entry index</var> - [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=].
             
         *  Convert <var>mapped entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
@@ -820,7 +823,9 @@ The algorithm:
 
         *  Add an [=patch map entries|entry=] to <var>entry list</var> whose subset definition contains the unicode code point set and
             a feature tag set containing only [=FeatureRecord/featureTag=]. The entry  maps to the generated URI, the patch encoding
-            specified by [=Format 1 Patch Map/patchEncoding=], and [=Format 1 Patch Map/compatibilityId=].
+            specified by [=Format 1 Patch Map/patchEncoding=], and [=Format 1 Patch Map/compatibilityId=]. If there is an existing
+	    [=patch map entries|entry=] in <var>entry list</var> which has the same patch URI as the generated URI then
+	    instead add [=FeatureRecord/featureTag=] and the computed unicode code point set to the existing entry's subset definition.
 
 4.  Return <var>entry list</var>.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -381,6 +381,7 @@ The algorithm:
 3.  For each of [[open-type/otff#table-directory|tables]] 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
     invoking [$Interpret Format 1 Patch Map$] or [$Interpret Format 2 Patch Map$]. Concatenate the returned entry lists into a single list,
     <var>entry list</var>.
+    
 
 4.  For each <var>entry</var> in <var>entry list</var> invoke [$Check entry intersection$] with <var>entry</var> and
     <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var>
@@ -603,9 +604,9 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     </td>
   </tr>
   <tr>
-    <td>uint32</td>
-    <td><dfn for="Format 1 Patch Map">entryCount</dfn></td>
-    <td>Number of entries encoded in this table.</td>
+    <td>uint16</td>
+    <td><dfn for="Format 1 Patch Map">maxEntryIndex</dfn></td>
+    <td>The largest entry index encoded in this table.</td>
   </tr>
   <tr>
     <td>uint32</td>
@@ -624,7 +625,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">appliedEntriesBitMap</dfn>[(entryCount + 7)/8]</td>
+    <td><dfn for="Format 1 Patch Map">appliedEntriesBitMap</dfn>[(maxEntryIndex + 8)/8]</td>
     <td>
       A bit map which tracks which entries have been applied. If bit <code>i</code> is set that indicates the patch for entry
       <code>i</code> has been applied to this font. Bit 0 is the least significant bit of appliedEntriesBitMap[0], while bit 7 is
@@ -672,7 +673,7 @@ A glyph map table associates each glyph index in the font with an entry index.
     <td><dfn for="Glyph Map">entryIndex</dfn>[[=Format 1 Patch Map/glyphCount=] - firstMappedGlyph]</td>
     <td>
       The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - [=Glyph Map/firstMappedGlyph=]]. Array members
-      are uint8 if [=Format 1 Patch Map/entryCount=] is less than 256, otherwise they are uint16.
+      are uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise they are uint16.
     </td>
   </tr>
 </table>
@@ -727,7 +728,7 @@ A feature map table associates combinations of [[open-type/featuretags|feature t
     <td>uint8/uint16</td>
     <td><dfn for="FeatureRecord">firstNewEntryIndex</dfn></td>
     <td>
-      uint8 if [=Format 1 Patch Map/entryCount=] is less than 256, otherwise uint16.
+      uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise uint16.
       The first entry index this record maps too.
     </td>
   </tr>
@@ -735,7 +736,7 @@ A feature map table associates combinations of [[open-type/featuretags|feature t
     <td>uint8/uint16</td>
     <td><dfn for="FeatureRecord">entryMapCount</dfn></td>
     <td>
-      uint8 if [=Format 1 Patch Map/entryCount=] is less than 256, otherwise uint16.
+      uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise uint16.
       The number of [=EntryMapRecord=]s associated with this feature.
     </td>
   </tr>
@@ -751,7 +752,7 @@ A feature map table associates combinations of [[open-type/featuretags|feature t
     <td>uint8/uint16</td>
     <td><dfn for="EntryMapRecord">firstEntryIndex</dfn></td>
     <td>
-      uint8 if [=Format 1 Patch Map/entryCount=] is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
+      uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
       the set of [=Glyph Map=] entries which form the subset definitions for the entries created by this mapping.
     </td>
   </tr>
@@ -759,7 +760,7 @@ A feature map table associates combinations of [[open-type/featuretags|feature t
     <td>uint8/uint16</td>
     <td><dfn for="EntryMapRecord">lastEntryIndex</dfn></td>
     <td>
-      uint8 if [=Format 1 Patch Map/entryCount=] is less than 256, otherwise uint16.
+      uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise uint16.
       Must be greater than or equal to firstEntryIndex.
     </td>
   </tr>
@@ -790,6 +791,9 @@ The algorithm:
 
 2.  For each unique <var>entry index</var> in [=Glyph Map/entryIndex=]:
 
+    *  If the <var>entry index</var> is larger than [=Format 1 Patch Map/maxEntryIndex=] this table is invalid,
+        return an error.
+
     *  If the bit for <var>entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this
         <var>entry index</var>.
 
@@ -809,12 +813,17 @@ The algorithm:
 
     *  For each <var>entry index</var> between [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] (inclusive) and
         [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=]
-        (inclusive), find the set of unicode codepoints associated with that entry index using the same process as in step 2b through
-        2c.
+        (inclusive):
+
+        *  Find the set of unicode code points associated with <var>entry index</var> that was computed in step 2. If
+            <var>entry index</var> was not processed in step 2 this table is invalid, return an error.
 
         *  Compute <var>mapped entry index</var> =
             [=FeatureRecord/firstNewEntryIndex|FeatureRecord::firstNewEntryIndex=] +
             <var>entry index</var> - [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=].
+
+        *  If the computed <var>mapped entry index</var> is larger than [=Format 1 Patch Map/maxEntryIndex=] this table is invalid,
+            return an error.
             
         *  Convert <var>mapped entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
 
@@ -824,8 +833,8 @@ The algorithm:
         *  Add an [=patch map entries|entry=] to <var>entry list</var> whose subset definition contains the unicode code point set and
             a feature tag set containing only [=FeatureRecord/featureTag=]. The entry  maps to the generated URI, the patch encoding
             specified by [=Format 1 Patch Map/patchEncoding=], and [=Format 1 Patch Map/compatibilityId=]. If there is an existing
-	    [=patch map entries|entry=] in <var>entry list</var> which has the same patch URI as the generated URI then
-	    instead add [=FeatureRecord/featureTag=] and the computed unicode code point set to the existing entry's subset definition.
+            [=patch map entries|entry=] in <var>entry list</var> which has the same patch URI as the generated URI then
+            instead add [=FeatureRecord/featureTag=] and the computed unicode code point set to the existing entry's subset definition.
 
 4.  Return <var>entry list</var>.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -838,6 +838,9 @@ The algorithm:
 
 4.  Return <var>entry list</var>.
 
+Note: while an encoding is not required to include entries for all entry indices in [0, [=Format 1 Patch Map/maxEntryIndex=]], it is
+recommended that it do so for maximum compactness.
+
 <h5 algorithm id="remove-entries-format-1">Remove Entries from Format 1</h5>
 
 This algorithm is used to remove entries from a format 1 patch map. This removal modifies the bytes of the patch map but does not

--- a/Overview.bs
+++ b/Overview.bs
@@ -804,6 +804,7 @@ The algorithm:
 
     *  Convert the set of glyph indices to a set of unicode code points using the code point to glyph mapping in the
         [[open-type/cmap|cmap]] table of <var>font subset</var>. Ignore any glyph indices that are not mapped by [[open-type/cmap|cmap]].
+        Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.
 
     *  Convert <var>entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
 

--- a/Overview.html
+++ b/Overview.html
@@ -4,9 +4,10 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Incremental Font Transfer</title>
   <meta content="WD" name="w3c-status">
-  <meta content="Bikeshed version d5d58a306, updated Fri Jan 26 16:12:28 2024 -0800" name="generator">
+  <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="eff06a3a4931e18ccc7efd34b6e21379470c239d" name="revision">
+  <meta content="f0acde97c553d0b3a449e6d58b5f852cc676e327" name="revision">
+  <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
 .conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
@@ -601,6 +602,7 @@ var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DD
 var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-WD" rel="stylesheet">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
@@ -646,16 +648,17 @@ be loaded over multiple requests where each request incrementally adds additiona
   current W3C publications and the latest revision of this technical report
   can be found in the <a href="https://www.w3.org/TR/">W3C technical reports
   index at https://www.w3.org/TR/.</a></em> </p>
-  <p>This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
-  <p>Publication as a Working Draft does not imply endorsement by W3C and its Members.</p>
    <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Working Draft using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation
       track</a>. This document is intended to become a W3C Recommendation. </p>
    <p> If you wish to make comments regarding this document, please <a href="https://github.com/w3c/PFE/issues/new">file an issue on the specification repository</a>. </p>
-   <p> This document was produced by a group operating under
-  the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
+   <p> Publication as a Working Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. This is a draft document and may be updated, replaced or
+  obsoleted by other documents at any time. It is inappropriate to cite this
+  document as other than work in progress. </p>
+   <p> This document was produced by groups operating under
+  the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
   W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
-  An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/policies/patent-policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
+  An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
    <p> This document is governed by the <a href="https://www.w3.org/policies/process/20231103/" id="w3c_process_revision">03 November 2023 W3C Process Document</a>. </p>
    <p></p>
   </div>
@@ -1207,8 +1210,8 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td>Offset to a <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map">Glyph Map</a> sub table. Offset is from the start of this table.
      <tr>
       <td>Offset32
-      <td>featureMapOffset
-      <td>Offset to a <a data-link-type="dfn" href="#feature-map" id="ref-for-feature-map">Feature Map</a> sub table. Offset is from the start of this table.
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-featuremapoffset">featureMapOffset</dfn>
+      <td>Offset to a <a data-link-type="dfn" href="#feature-map" id="ref-for-feature-map">Feature Map</a> sub table. Offset is from the start of this table. May be null (0).
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</dfn>[(entryCount + 7)/8]
@@ -1283,7 +1286,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td>The <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tag</a> this mapping is for.
      <tr>
       <td>uint8/uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="FeatureRecord" data-dfn-type="dfn" data-noexport id="featurerecord-firstentryindex">firstEntryIndex</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="FeatureRecord" data-dfn-type="dfn" data-noexport id="featurerecord-firstnewentryindex">firstNewEntryIndex</dfn>
       <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-entrycount" id="ref-for-format-1-patch-map-entrycount①">entryCount</a> is less than 256, otherwise uint16.
       The first entry index this record maps too. 
      <tr>
@@ -1302,7 +1305,8 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-firstentryindex">firstEntryIndex</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-entrycount" id="ref-for-format-1-patch-map-entrycount③">entryCount</a> is less than 256, otherwise uint16. 
+      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-entrycount" id="ref-for-format-1-patch-map-entrycount③">entryCount</a> is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
+      the set of <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map①">Glyph Map</a> entries which form the subset definitions for the entries created by this mapping. 
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-lastentryindex">lastEntryIndex</dfn>
@@ -1345,14 +1349,14 @@ the encoded bytes at the start of every iteration to pick up any changes made in
 maps to the generated URI, the patch encoding specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
      </ul>
     <li data-md>
-     <p>For each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords①">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
+     <p>If <a data-link-type="dfn" href="#format-1-patch-map-featuremapoffset" id="ref-for-format-1-patch-map-featuremapoffset">featureMapOffset</a> is not null then, for each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords①">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
      <ul>
       <li data-md>
-       <p>For each <var>entry index</var> between <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">firstEntryIndex</a> (inclusive) and <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">lastEntryIndex</a> (inclusive), find the set of unicode codepoints associated with that entry index using the same process as in step 2b through
+       <p>For each <var>entry index</var> between <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> (inclusive) and <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> (inclusive), find the set of unicode codepoints associated with that entry index using the same process as in step 2b through
 2c.</p>
        <ul>
         <li data-md>
-         <p>Compute <var>mapped entry index</var> = <a data-link-type="dfn" href="#featurerecord-firstentryindex" id="ref-for-featurerecord-firstentryindex">FeatureRecord::firstEntryIndex</a> + <var>entry index</var> - <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex①">EntryMapRecord::firstEntryIndex</a>.</p>
+         <p>Compute <var>mapped entry index</var> = <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex">FeatureRecord::firstNewEntryIndex</a> + <var>entry index</var> - <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex①">EntryMapRecord::firstEntryIndex</a>.</p>
         <li data-md>
          <p>Convert <var>mapped entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
         <li data-md>
@@ -2628,7 +2632,7 @@ number of requests:</p>
     Implementers are encouraged to optimize. </p>
    </section>
   </div>
-<script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
@@ -2687,17 +2691,14 @@ number of requests:</p>
    <li><a href="#abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</a><span>, in § 4.2</span>
    <li><a href="#mapping-entry-featurecount">featureCount</a><span>, in § 5.2.2</span>
    <li><a href="#feature-map">Feature Map</a><span>, in § 5.2.1</span>
+   <li><a href="#format-1-patch-map-featuremapoffset">featureMapOffset</a><span>, in § 5.2.1</span>
    <li><a href="#featurerecord">FeatureRecord</a><span>, in § 5.2.1</span>
    <li><a href="#feature-map-featurerecords">featureRecords</a><span>, in § 5.2.1</span>
    <li><a href="#featurerecord-featuretag">featureTag</a><span>, in § 5.2.1</span>
    <li><a href="#mapping-entry-featuretags">featureTags</a><span>, in § 5.2.2</span>
-   <li>
-    firstEntryIndex
-    <ul>
-     <li><a href="#entrymaprecord-firstentryindex">dfn for EntryMapRecord</a><span>, in § 5.2.1</span>
-     <li><a href="#featurerecord-firstentryindex">dfn for FeatureRecord</a><span>, in § 5.2.1</span>
-    </ul>
+   <li><a href="#entrymaprecord-firstentryindex">firstEntryIndex</a><span>, in § 5.2.1</span>
    <li><a href="#glyph-map-firstmappedglyph">firstMappedGlyph</a><span>, in § 5.2.1</span>
+   <li><a href="#featurerecord-firstnewentryindex">firstNewEntryIndex</a><span>, in § 5.2.1</span>
    <li>
     flags
     <ul>
@@ -3047,7 +3048,7 @@ let dfnPanelData = {
 "featurerecord": {"dfnID":"featurerecord","dfnText":"FeatureRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord"},
 "featurerecord-entrymapcount": {"dfnID":"featurerecord-entrymapcount","dfnText":"entryMapCount","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-entrymapcount"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#featurerecord-entrymapcount"},
 "featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
-"featurerecord-firstentryindex": {"dfnID":"featurerecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstentryindex"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstentryindex"},
+"featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
 "font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.3. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"}],"title":"6.2. Brotli Patch"},{"refs":[{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"},{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2461\u2461"},{"id":"ref-for-font-subset\u2461\u2462"},{"id":"ref-for-font-subset\u2461\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2464"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u2465"},{"id":"ref-for-font-subset\u2461\u2466"},{"id":"ref-for-font-subset\u2461\u2467"}],"title":"6.4.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2468"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2462\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
 "font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"},{"id":"ref-for-font-subset-definition\u2463"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2464"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"},{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2468"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u24ea"},{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"},{"id":"ref-for-font-subset-definition\u2460\u2462"},{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
@@ -3055,6 +3056,7 @@ let dfnPanelData = {
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
 "format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
 "format-1-patch-map-entrycount": {"dfnID":"format-1-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-entrycount"},{"id":"ref-for-format-1-patch-map-entrycount\u2460"},{"id":"ref-for-format-1-patch-map-entrycount\u2461"},{"id":"ref-for-format-1-patch-map-entrycount\u2462"},{"id":"ref-for-format-1-patch-map-entrycount\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-entrycount"},
+"format-1-patch-map-featuremapoffset": {"dfnID":"format-1-patch-map-featuremapoffset","dfnText":"featureMapOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-featuremapoffset"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-featuremapoffset"},
 "format-1-patch-map-format": {"dfnID":"format-1-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-format"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-format\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-format"},
 "format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
 "format-1-patch-map-patchencoding": {"dfnID":"format-1-patch-map-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchencoding"},{"id":"ref-for-format-1-patch-map-patchencoding\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchencoding"},
@@ -3074,7 +3076,7 @@ let dfnPanelData = {
 "glyph-keyed-patch-compatibilityid": {"dfnID":"glyph-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-compatibilityid"},{"id":"ref-for-glyph-keyed-patch-compatibilityid\u2460"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-compatibilityid"},
 "glyph-keyed-patch-flags": {"dfnID":"glyph-keyed-patch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-flags"}],"title":"6.4. Glyph Keyed"}],"url":"#glyph-keyed-patch-flags"},
 "glyph-keyed-patch-format": {"dfnID":"glyph-keyed-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-format"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-format"},
-"glyph-map": {"dfnID":"glyph-map","dfnText":"Glyph Map","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map"},
+"glyph-map": {"dfnID":"glyph-map","dfnText":"Glyph Map","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map"},{"id":"ref-for-glyph-map\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map"},
 "glyph-map-entryindex": {"dfnID":"glyph-map-entryindex","dfnText":"entryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-entryindex"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-glyph-map-entryindex\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#glyph-map-entryindex"},
 "glyph-map-firstmappedglyph": {"dfnID":"glyph-map-firstmappedglyph","dfnText":"firstMappedGlyph","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-firstmappedglyph"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map-firstmappedglyph"},
 "glyphpatches": {"dfnID":"glyphpatches","dfnText":"GlyphPatches","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches"},{"id":"ref-for-glyphpatches\u2460"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches"},
@@ -3530,7 +3532,7 @@ let refsData = {
 "#featurerecord": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featurerecord","type":"dfn","url":"#featurerecord"},
 "#featurerecord-entrymapcount": {"export":true,"for_":["FeatureRecord"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrymapcount","type":"dfn","url":"#featurerecord-entrymapcount"},
 "#featurerecord-featuretag": {"export":true,"for_":["FeatureRecord"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featuretag","type":"dfn","url":"#featurerecord-featuretag"},
-"#featurerecord-firstentryindex": {"export":true,"for_":["FeatureRecord"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"firstentryindex","type":"dfn","url":"#featurerecord-firstentryindex"},
+"#featurerecord-firstnewentryindex": {"export":true,"for_":["FeatureRecord"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"firstnewentryindex","type":"dfn","url":"#featurerecord-firstnewentryindex"},
 "#font-patch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"font patch","type":"dfn","url":"#font-patch"},
 "#font-subset": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"font subset","type":"dfn","url":"#font-subset"},
 "#font-subset-definition": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"font subset definition","type":"dfn","url":"#font-subset-definition"},
@@ -3538,6 +3540,7 @@ let refsData = {
 "#format-1-patch-map-appliedentriesbitmap": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"appliedentriesbitmap","type":"dfn","url":"#format-1-patch-map-appliedentriesbitmap"},
 "#format-1-patch-map-compatibilityid": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#format-1-patch-map-compatibilityid"},
 "#format-1-patch-map-entrycount": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrycount","type":"dfn","url":"#format-1-patch-map-entrycount"},
+"#format-1-patch-map-featuremapoffset": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featuremapoffset","type":"dfn","url":"#format-1-patch-map-featuremapoffset"},
 "#format-1-patch-map-format": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#format-1-patch-map-format"},
 "#format-1-patch-map-glyphcount": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyphcount","type":"dfn","url":"#format-1-patch-map-glyphcount"},
 "#format-1-patch-map-patchencoding": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchencoding","type":"dfn","url":"#format-1-patch-map-patchencoding"},
@@ -3847,7 +3850,7 @@ function findAlgoContainer(el) {
     return null;
 }
 function nameFromVar(el) {
-    return el.textContent.replace(/(\s|\xa0)+/, " ").trim();
+    return el.textContent.replace(/(\s|\xa0)+/g, " ").trim();
 }
 function colorCountsFromContainer(container) {
     const namesFromColor = Array.from({length:COLOR_COUNT}, x=>new Set());

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="1ab8a106367fee11de3a83c212c00556d0c5632a" name="revision">
+  <meta content="ec98129f282437041103b8261eff8ee403b80c32" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1336,6 +1336,9 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <li data-md>
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex">entryIndex</a>:</p>
      <ul>
+      <li data-md>
+       <p>If <var>entry index</var> is 0 then, this is a special entry used to mark glyphs which are already in the font. Skip this index
+and do not build an entry for it.</p>
       <li data-md>
        <p>If the <var>entry index</var> is larger than <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑤">maxEntryIndex</a> this table is invalid,
 return an error.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="a4995d0b45f7b27c15ed7f6d15dc5082a274e19a" name="revision">
+  <meta content="1ab8a106367fee11de3a83c212c00556d0c5632a" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1378,6 +1378,8 @@ instead add <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for
     <li data-md>
      <p>Return <var>entry list</var>.</p>
    </ol>
+   <p class="note" role="note"><span class="marker">Note:</span> while an encoding is not required to include entries for all entry indices in [0, <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑦">maxEntryIndex</a>], it is
+recommended that it do so for maximum compactness.</p>
    <h5 class="heading settled algorithm" data-algorithm="Remove Entries from Format 1" data-level="5.2.1.2" id="remove-entries-format-1"><span class="secno">5.2.1.2. </span><span class="content">Remove Entries from Format 1</span><a class="self-link" href="#remove-entries-format-1"></a></h5>
    <p>This algorithm is used to remove entries from a format 1 patch map. This removal modifies the bytes of the patch map but does not
 change the number of bytes.</p>
@@ -3062,7 +3064,7 @@ let dfnPanelData = {
 "format-1-patch-map-featuremapoffset": {"dfnID":"format-1-patch-map-featuremapoffset","dfnText":"featureMapOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-featuremapoffset"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-featuremapoffset"},
 "format-1-patch-map-format": {"dfnID":"format-1-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-format"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-format\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-format"},
 "format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
-"format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
+"format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2466"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
 "format-1-patch-map-patchencoding": {"dfnID":"format-1-patch-map-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchencoding"},{"id":"ref-for-format-1-patch-map-patchencoding\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchencoding"},
 "format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
 "format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#format-2-patch-map"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="ec98129f282437041103b8261eff8ee403b80c32" name="revision">
+  <meta content="7dd61c696ae8b6636f60cdc6f94fb6ea91c3ae06" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -654,7 +654,7 @@ be loaded over multiple requests where each request incrementally adds additiona
    <p> Publication as a Working Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. This is a draft document and may be updated, replaced or
   obsoleted by other documents at any time. It is inappropriate to cite this
   document as other than work in progress. </p>
-   <p> This document was produced by groups operating under
+   <p> This document was produced by a group operating under
   the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
   W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
@@ -1347,7 +1347,8 @@ return an error.</p>
       <li data-md>
        <p>Collect the set of glyph indices that map to the <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert the set of glyph indices to a set of unicode code points using the code point to glyph mapping in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.</p>
+       <p>Convert the set of glyph indices to a set of unicode code points using the code point to glyph mapping in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
+Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
       <li data-md>
        <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
       <li data-md>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="f0acde97c553d0b3a449e6d58b5f852cc676e327" name="revision">
+  <meta content="a4995d0b45f7b27c15ed7f6d15dc5082a274e19a" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1197,9 +1197,9 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td> Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>). The encoder chooses this
       value. The encoder should set it to a random value which has not previously been used while encoding the IFT font. 
      <tr>
-      <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-entrycount">entryCount</dfn>
-      <td>Number of entries encoded in this table.
+      <td>uint16
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-maxentryindex">maxEntryIndex</dfn>
+      <td>The largest entry index encoded in this table.
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-glyphcount">glyphCount</dfn>
@@ -1214,7 +1214,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td>Offset to a <a data-link-type="dfn" href="#feature-map" id="ref-for-feature-map">Feature Map</a> sub table. Offset is from the start of this table. May be null (0).
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</dfn>[(entryCount + 7)/8]
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</dfn>[(maxEntryIndex + 8)/8]
       <td> A bit map which tracks which entries have been applied. If bit <code>i</code> is set that indicates the patch for entry <code>i</code> has been applied to this font. Bit 0 is the least significant bit of appliedEntriesBitMap[0], while bit 7 is
       the most significant bit. Bit 8 is the least significant bit of appliedEntriesBitMap[1] and so on. 
      <tr>
@@ -1246,7 +1246,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-entryindex">entryIndex</dfn>[<a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> - firstMappedGlyph]
       <td> The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - <a data-link-type="dfn" href="#glyph-map-firstmappedglyph" id="ref-for-glyph-map-firstmappedglyph">firstMappedGlyph</a>]. Array members
-      are uint8 if <a data-link-type="dfn" href="#format-1-patch-map-entrycount" id="ref-for-format-1-patch-map-entrycount">entryCount</a> is less than 256, otherwise they are uint16. 
+      are uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex">maxEntryIndex</a> is less than 256, otherwise they are uint16. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="feature-map">Feature Map</dfn> encoding:</p>
    <p>A feature map table associates combinations of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> and glyphs with an entry index.</p>
@@ -1287,12 +1287,12 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="FeatureRecord" data-dfn-type="dfn" data-noexport id="featurerecord-firstnewentryindex">firstNewEntryIndex</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-entrycount" id="ref-for-format-1-patch-map-entrycount①">entryCount</a> is less than 256, otherwise uint16.
+      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex①">maxEntryIndex</a> is less than 256, otherwise uint16.
       The first entry index this record maps too. 
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="FeatureRecord" data-dfn-type="dfn" data-noexport id="featurerecord-entrymapcount">entryMapCount</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-entrycount" id="ref-for-format-1-patch-map-entrycount②">entryCount</a> is less than 256, otherwise uint16.
+      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex②">maxEntryIndex</a> is less than 256, otherwise uint16.
       The number of <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord①">EntryMapRecord</a>s associated with this feature. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="entrymaprecord">EntryMapRecord</dfn> encoding:</p>
@@ -1305,12 +1305,12 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-firstentryindex">firstEntryIndex</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-entrycount" id="ref-for-format-1-patch-map-entrycount③">entryCount</a> is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
+      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex③">maxEntryIndex</a> is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
       the set of <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map①">Glyph Map</a> entries which form the subset definitions for the entries created by this mapping. 
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-lastentryindex">lastEntryIndex</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-entrycount" id="ref-for-format-1-patch-map-entrycount④">entryCount</a> is less than 256, otherwise uint16.
+      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex④">maxEntryIndex</a> is less than 256, otherwise uint16.
       Must be greater than or equal to firstEntryIndex. 
    </table>
    <p>An entry map record matches any entry indices that are greater than or equal to firstEntryIndex and less than or equal to  lastEntryIndex.</p>
@@ -1337,6 +1337,9 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex">entryIndex</a>:</p>
      <ul>
       <li data-md>
+       <p>If the <var>entry index</var> is larger than <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑤">maxEntryIndex</a> this table is invalid,
+return an error.</p>
+      <li data-md>
        <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
        <p>Collect the set of glyph indices that map to the <var>entry index</var>.</p>
@@ -1352,11 +1355,15 @@ maps to the generated URI, the patch encoding specified by <a data-link-type="df
      <p>If <a data-link-type="dfn" href="#format-1-patch-map-featuremapoffset" id="ref-for-format-1-patch-map-featuremapoffset">featureMapOffset</a> is not null then, for each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords①">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
      <ul>
       <li data-md>
-       <p>For each <var>entry index</var> between <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> (inclusive) and <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> (inclusive), find the set of unicode codepoints associated with that entry index using the same process as in step 2b through
-2c.</p>
+       <p>For each <var>entry index</var> between <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> (inclusive) and <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> (inclusive):</p>
        <ul>
         <li data-md>
+         <p>Find the set of unicode code points associated with <var>entry index</var> that was computed in step 2. If <var>entry index</var> was not processed in step 2 this table is invalid, return an error.</p>
+        <li data-md>
          <p>Compute <var>mapped entry index</var> = <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex">FeatureRecord::firstNewEntryIndex</a> + <var>entry index</var> - <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex①">EntryMapRecord::firstEntryIndex</a>.</p>
+        <li data-md>
+         <p>If the computed <var>mapped entry index</var> is larger than <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑥">maxEntryIndex</a> this table is invalid,
+return an error.</p>
         <li data-md>
          <p>Convert <var>mapped entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
         <li data-md>
@@ -1364,7 +1371,8 @@ maps to the generated URI, the patch encoding specified by <a data-link-type="df
         <li data-md>
          <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> to <var>entry list</var> whose subset definition contains the unicode code point set and
 a feature tag set containing only <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag①">featureTag</a>. The entry  maps to the generated URI, the patch encoding
-specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding①">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>.</p>
+specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding①">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>. If there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">entry</a> in <var>entry list</var> which has the same patch URI as the generated URI then
+instead add <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag②">featureTag</a> and the computed unicode code point set to the existing entry’s subset definition.</p>
        </ul>
      </ul>
     <li data-md>
@@ -1548,7 +1556,7 @@ being requested.</p>
       <td> End (inclusive) of the segment. Must be greater than or equal to start. This value uses the user axis scale: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
    </table>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="5.2.2.1" id="interpreting-patch-map-format-2"><span class="secno">5.2.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
-   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map③">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
+   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map③">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑨">patch map entries</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
@@ -1558,7 +1566,7 @@ being requested.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑨">patch map entries</a>.</p>
+     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①⓪">patch map entries</a>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1605,7 +1613,7 @@ being requested.</p>
     <li data-md>
      <p><var>entry id</var>: the numeric or string id of this entry.</p>
     <li data-md>
-     <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①⓪">entry</a>.</p>
+     <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①①">entry</a>.</p>
     <li data-md>
      <p><var>consumed bytes</var>: the number of bytes used to encode the entry.</p>
     <li data-md>
@@ -2675,12 +2683,7 @@ number of requests:</p>
      <li><a href="#format-2-patch-map-entries">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
      <li><a href="#mapping-entries-entries">dfn for Mapping Entries</a><span>, in § 5.2.2</span>
     </ul>
-   <li>
-    entryCount
-    <ul>
-     <li><a href="#format-1-patch-map-entrycount">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
-     <li><a href="#format-2-patch-map-entrycount">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
-    </ul>
+   <li><a href="#format-2-patch-map-entrycount">entryCount</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-entryiddelta">entryIdDelta</a><span>, in § 5.2.2</span>
    <li><a href="#format-2-patch-map-entryidstringdata">entryIdStringData</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-entryidstringlength">entryIdStringLength</a><span>, in § 5.2.2</span>
@@ -2744,6 +2747,7 @@ number of requests:</p>
    <li><a href="#abstract-opdef-load-patch-file">Load patch file</a><span>, in § 4.2</span>
    <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 5.2.2</span>
+   <li><a href="#format-1-patch-map-maxentryindex">maxEntryIndex</a><span>, in § 5.2.1</span>
    <li><a href="#no-invalidation">No Invalidation</a><span>, in § 4.1</span>
    <li><a href="#partial-invalidation">Partial Invalidation</a><span>, in § 4.1</span>
    <li><a href="#patch-application-algorithm">patch application algorithm</a><span>, in § 3.2</span>
@@ -3047,7 +3051,7 @@ let dfnPanelData = {
 "feature-map-featurerecords": {"dfnID":"feature-map-featurerecords","dfnText":"featureRecords","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map-featurerecords"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-feature-map-featurerecords\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#feature-map-featurerecords"},
 "featurerecord": {"dfnID":"featurerecord","dfnText":"FeatureRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord"},
 "featurerecord-entrymapcount": {"dfnID":"featurerecord-entrymapcount","dfnText":"entryMapCount","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-entrymapcount"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#featurerecord-entrymapcount"},
-"featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
+"featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"},{"id":"ref-for-featurerecord-featuretag\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
 "featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
 "font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.3. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"}],"title":"6.2. Brotli Patch"},{"refs":[{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"},{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2461\u2461"},{"id":"ref-for-font-subset\u2461\u2462"},{"id":"ref-for-font-subset\u2461\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2464"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u2465"},{"id":"ref-for-font-subset\u2461\u2466"},{"id":"ref-for-font-subset\u2461\u2467"}],"title":"6.4.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2468"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2462\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
@@ -3055,10 +3059,10 @@ let dfnPanelData = {
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
 "format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
-"format-1-patch-map-entrycount": {"dfnID":"format-1-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-entrycount"},{"id":"ref-for-format-1-patch-map-entrycount\u2460"},{"id":"ref-for-format-1-patch-map-entrycount\u2461"},{"id":"ref-for-format-1-patch-map-entrycount\u2462"},{"id":"ref-for-format-1-patch-map-entrycount\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-entrycount"},
 "format-1-patch-map-featuremapoffset": {"dfnID":"format-1-patch-map-featuremapoffset","dfnText":"featureMapOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-featuremapoffset"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-featuremapoffset"},
 "format-1-patch-map-format": {"dfnID":"format-1-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-format"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-format\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-format"},
 "format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
+"format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
 "format-1-patch-map-patchencoding": {"dfnID":"format-1-patch-map-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchencoding"},{"id":"ref-for-format-1-patch-map-patchencoding\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchencoding"},
 "format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
 "format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#format-2-patch-map"},
@@ -3106,7 +3110,7 @@ let dfnPanelData = {
 "patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
 "patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2461"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map"},
-"patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2460"},{"id":"ref-for-patch-map-entries\u2461"},{"id":"ref-for-patch-map-entries\u2462"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map-entries"},
+"patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2460"},{"id":"ref-for-patch-map-entries\u2461"},{"id":"ref-for-patch-map-entries\u2462"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"},{"id":"ref-for-patch-map-entries\u2467"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"},{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map-entries"},
 "per-table-brotli-patch": {"dfnID":"per-table-brotli-patch","dfnText":"Per table brotli patch","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch"},
 "per-table-brotli-patch-compatibilityid": {"dfnID":"per-table-brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-compatibilityid"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-compatibilityid"},
 "per-table-brotli-patch-format": {"dfnID":"per-table-brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-format"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-format"},
@@ -3539,10 +3543,10 @@ let refsData = {
 "#format-1-patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 1 patch map","type":"dfn","url":"#format-1-patch-map"},
 "#format-1-patch-map-appliedentriesbitmap": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"appliedentriesbitmap","type":"dfn","url":"#format-1-patch-map-appliedentriesbitmap"},
 "#format-1-patch-map-compatibilityid": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#format-1-patch-map-compatibilityid"},
-"#format-1-patch-map-entrycount": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrycount","type":"dfn","url":"#format-1-patch-map-entrycount"},
 "#format-1-patch-map-featuremapoffset": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featuremapoffset","type":"dfn","url":"#format-1-patch-map-featuremapoffset"},
 "#format-1-patch-map-format": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#format-1-patch-map-format"},
 "#format-1-patch-map-glyphcount": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyphcount","type":"dfn","url":"#format-1-patch-map-glyphcount"},
+"#format-1-patch-map-maxentryindex": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxentryindex","type":"dfn","url":"#format-1-patch-map-maxentryindex"},
 "#format-1-patch-map-patchencoding": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchencoding","type":"dfn","url":"#format-1-patch-map-patchencoding"},
 "#format-1-patch-map-uritemplate": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-1-patch-map-uritemplate"},
 "#format-2-patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 2 patch map","type":"dfn","url":"#format-2-patch-map"},


### PR DESCRIPTION
I've been working on implementing a format 1 patch map parser and in the process found some issues and areas that were underspecified. This makes some changes to address those:
- Explicitly allow the feature map offset to be null.
- Change entry count from u32 -> u16. All entry index fields in the remainder of the table are at most u16 so no need for this to be u32.
- Rename "entry count" to "max entry index": an entry count of 0 is always invalid (entry 0 always exists). So changing this to "max entry index" avoids that. Additionally allows entry indices up to the max of u16 to be used.
- Specifically mention that entry 0 should be ignored (used to mark glyphs already in the font).
- Specifically mention entry indices greater than max entry index are invalid.
- Note that not all entry indices from 0 up to max entry index need to be encoded.
- Note that a single glyph may have multiple associated code points.

Note: this currently undoes the manual edits from https://github.com/w3c/IFT/pull/189, will need to fix that before it can be merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/190.html" title="Last updated on Jul 22, 2024, 7:56 PM UTC (4aae108)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/190/f0acde9...4aae108.html" title="Last updated on Jul 22, 2024, 7:56 PM UTC (4aae108)">Diff</a>