### PR TITLE
In format 1 ignore most invalid data instead of failing with an error.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -618,8 +618,11 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td>uint24</td>
     <td><dfn for="Format 1 Patch Map">glyphCount</dfn></td>
     <td>Number of glyphs that mappings are provided for.
-        Must match the numGlyphs field from [[open-type/maxp|maxp]] if present, or if numGlyphs is 65,535 then glyphCount
-        must be greater than or equal to 65,535.</td>
+        Must match the number of glyphs in the the font file.
+
+        Note: the number of glyphs in the font is encoded in the font file. At the time of writing, this value is listed in the
+        [[open-type/maxp|maxp]] table; however, future font format extensions may use alternate tables to encode the value for number of
+        glyphs.
   </tr>
   <tr>
     <td>Offset32</td>

--- a/Overview.bs
+++ b/Overview.bs
@@ -581,8 +581,6 @@ the encoded bytes at the start of every iteration to pick up any changes made in
 
 ### Patch Map Table: Format 1 ### {#patch-map-format-1}
 
-<!-- TODO: provide normative validation requirements for each encoding -->
-
 <dfn>Format 1 Patch Map</dfn> encoding:
 <table>
   <tr>
@@ -612,9 +610,16 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td>The largest entry index encoded in this table.</td>
   </tr>
   <tr>
+    <td>uint16</td>
+    <td><dfn for="Format 1 Patch Map">maxGlyphMapEntryIndex</dfn></td>
+    <td>The largest [=Glyph Map=] entry index encoded in this table. Must be less than or equal to maxEntryIndex.</td>
+  </tr>
+  <tr>
     <td>uint32</td>
     <td><dfn for="Format 1 Patch Map">glyphCount</dfn></td>
     <td>Number of glyphs that mappings are provided for. Must match the numGlyphs field from [[open-type/maxp|maxp]].</td>
+    <!-- TODO(garretrieger): make this compatible with beyond64k
+         (https://github.com/harfbuzz/boring-expansion-spec/blob/main/beyond-64k.md) -->
   </tr>
   <tr>
     <td>Offset32</td>
@@ -699,8 +704,9 @@ A feature map table associates combinations of [[open-type/featuretags|feature t
     <td>[=FeatureRecord=]</td>
     <td><dfn for="Feature Map">featureRecords</dfn>[featureCount]</td>
     <td>
-      Provides mappings for a specific  [[open-type/featuretags|feature tag]]. Must be sorted by [=FeatureRecord/featureTag=]
-      with any feature tag occurring at most once.
+      Provides mappings for a specific  [[open-type/featuretags|feature tag]]. [=Feature Map/featureRecords=] are sorted by
+      [=FeatureRecord/featureTag=] in ascending order with any feature tag occurring at most once. For sorting tag values are interpreted
+      as a 4 byte big endian unsigned integer and sorted by the integer value.
     </td>
   </tr>
   <tr>
@@ -716,8 +722,7 @@ A feature map table associates combinations of [[open-type/featuretags|feature t
   </tr>
 </table>
 
-[=Feature Map/featureRecords=] must be sorted by [=FeatureRecord/featureTag=] in ascending order with any feature tag occurring at most
-once. For sorting tag values are interpreted as a 4 byte big endian unsigned integer and sorted by the integer value.
+
 
 <dfn>FeatureRecord</dfn> encoding:
 
@@ -767,7 +772,6 @@ once. For sorting tag values are interpreted as a 4 byte big endian unsigned int
     <td><dfn for="EntryMapRecord">lastEntryIndex</dfn></td>
     <td>
       uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise uint16.
-      Must be greater than or equal to firstEntryIndex.
     </td>
   </tr>
 </table>
@@ -793,63 +797,73 @@ The algorithm outputs:
 The algorithm:
 
 1.  Check that the <var>patch map</var> has [=Format 1 Patch Map/format=] equal to 1 and is valid according to the requirements in
-     [[#patch-map-format-1]]. If it is not return an error.
+     [[#patch-map-format-1]] (requirements are marked with a "must"). If it is not return an error.
 
 2.  For each unique <var>entry index</var> in [=Glyph Map/entryIndex=]:
 
-    *  If <var>entry index</var> is 0 then, this is a special entry used to mark glyphs which are already in the font. Skip this index
-        and do not build an entry for it.
+    *  If <var>entry index</var> is 0 then, this is a special entry used to mark glyphs which are already in the initial font. Skip this
+        index and do not build an entry for it.
 
-    *  If the <var>entry index</var> is larger than [=Format 1 Patch Map/maxEntryIndex=] this table is invalid,
-        return an error.
+    *  If the <var>entry index</var> is larger than [=Format 1 Patch Map/maxGlyphMapEntryIndex=] this entry is invalid, skip this
+        <var>entry index</var>.
 
     *  If the bit for <var>entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this
         <var>entry index</var>.
 
     *  Collect the set of glyph indices that map to the <var>entry index</var>.
 
-    *  Convert the set of glyph indices to a set of unicode code points using the code point to glyph mapping in the
+    *  Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the
         [[open-type/cmap|cmap]] table of <var>font subset</var>. Ignore any glyph indices that are not mapped by [[open-type/cmap|cmap]].
         Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.
 
     *  Convert <var>entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
 
-    *  Add an [=patch map entries|entry=] to <var>entry list</var> whose subset definition contains only the unicode code point set and
+    *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
+
+    *  Add an [=patch map entries|entry=] to <var>entry list</var> whose subset definition contains only the Unicode code point set and
         maps to the generated URI, the patch encoding specified by [=Format 1 Patch Map/patchEncoding=], and
         [=Format 1 Patch Map/compatibilityId=].
 
 3.  If [=Format 1 Patch Map/featureMapOffset=] is not null then, for each [=FeatureRecord=] and associated [=EntryMapRecord=] in
         [=Feature Map/featureRecords=] and [=Feature Map/entryMapRecords=]:
 
+    *  Any [=FeatureRecord|FeatureRecord's=] whose [=FeatureRecord/featureTag=] is less than or equal to a [=FeatureRecord/featureTag=]
+        of any [=FeatureRecord=]  which occurred earlier in the list are invalid. All associated [=EntryMapRecord|EntryMapRecord's=] are
+        skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigned integer and ordered by the integer value.
+
     *  Compute <var>mapped entry index</var>, the first [=EntryMapRecord=] associated with a [=FeatureRecord=] is
         [=FeatureRecord/firstNewEntryIndex|FeatureRecord::firstNewEntryIndex=], the second
         [=FeatureRecord/firstNewEntryIndex|FeatureRecord::firstNewEntryIndex=] + 1, and so on. The last will be
         [=FeatureRecord/firstNewEntryIndex|FeatureRecord::firstNewEntryIndex=] + [=FeatureRecord/entryMapCount=] - 1.
 
-    *  If the computed <var>mapped entry index</var> is larger than [=Format 1 Patch Map/maxEntryIndex=] this table is invalid,
-        return an error.
+    *  If the computed <var>mapped entry index</var> is less than or equal to [=Format 1 Patch Map/maxGlyphMapEntryIndex=] or larger than
+        [=Format 1 Patch Map/maxEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
 
-    *  If <var>mapped entry index</var> matches an entry index present in the [=Glyph Map=] this table is invalid,
-        return an error.
+    *  If [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] is greater than
+        [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
 
     *  Convert <var>mapped entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
 
     *  If the bit for <var>mapped entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this entry.
 
+    *  Construct a set of Unicode code points. For each <var>entry index</var> between
+        [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] (inclusive) and
+        [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] (inclusive):
+
+        *  If <var>entry index</var> is greater than [=Format 1 Patch Map/maxGlyphMapEntryIndex=] then, this [=EntryMapRecord=] is invalid
+            skip it.
+
+        *  Add the set of Unicode code points associated with <var>entry index</var> that was computed in step 2 to the set. If the
+            <var>entry index</var> was skipped because it was 0 or [=Format 1 Patch Map/appliedEntriesBitMap=] compute the set of
+            associated code points as if it wasn't skipped.
+
+    *  If the constructed set of Unicode code points is empty then, this [=EntryMapRecord=] is invalid skip it.
+
     *  Add an [=patch map entries|entry=] to <var>entry list</var> which  maps to the generated URI, the patch encoding
         specified by [=Format 1 Patch Map/patchEncoding=], and [=Format 1 Patch Map/compatibilityId=]; or if there is an existing
         [=patch map entries|entry=] in <var>entry list</var> which has the same patch URI as the generated URI then
-        instead modify the existing entry. Add [=FeatureRecord/featureTag=] to the new or existing entry's subset definition.
-
-    *  For each <var>entry index</var> between [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] (inclusive) and
-        [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=]
-        (inclusive):
-
-        *  Find the set of unicode code points associated with <var>entry index</var> that was computed in step 2. If the
-            <var>entry index</var> was skipped because of [=Format 1 Patch Map/appliedEntriesBitMap=] compute the set of associated
-            code points as if it wasn't skipped. If <var>entry index</var> was not processed in step 2 this table is invalid, return an
-            error. Entries processed in step 2 that were marked as skipped by [=Format 1 Patch Map/appliedEntriesBitMap=] are valid to be
-            referenced here. Union the produced set of code points to the new or existing entry's subset definition.
+        instead modify the existing entry. Add the constructed set of Unicode code points and [=FeatureRecord/featureTag=] to the new or
+        existing entry's subset definition.
 
 4.  Return <var>entry list</var>.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -615,11 +615,9 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td>The largest [=Glyph Map=] entry index encoded in this table. Must be less than or equal to maxEntryIndex.</td>
   </tr>
   <tr>
-    <td>uint32</td>
+    <td>uint24</td>
     <td><dfn for="Format 1 Patch Map">glyphCount</dfn></td>
-    <td>Number of glyphs that mappings are provided for. Must match the numGlyphs field from [[open-type/maxp|maxp]].</td>
-    <!-- TODO(garretrieger): make this compatible with beyond64k
-         (https://github.com/harfbuzz/boring-expansion-spec/blob/main/beyond-64k.md) -->
+    <td>Number of glyphs that mappings are provided for. Must match the numGlyphs field from either [[open-type/maxp|maxp]] or MAXP (if present). If both maxp and MAXP are present then, it must match the numGlyphs field in MAXP.</td>
   </tr>
   <tr>
     <td>Offset32</td>
@@ -798,6 +796,8 @@ The algorithm:
 
 1.  Check that the <var>patch map</var> has [=Format 1 Patch Map/format=] equal to 1 and is valid according to the requirements in
      [[#patch-map-format-1]] (requirements are marked with a "must"). If it is not return an error.
+     <!-- TODO also mention validating there is enough data to fit all of the structures, error if not. -->
+     <!-- TODO also mention validating uri template (valid unicode) and the patch encoding format # -->
 
 2.  For each unique <var>entry index</var> in [=Glyph Map/entryIndex=]:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -650,13 +650,15 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td><dfn for="Format 1 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
     <td>
       A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URIs associated with each entry.
+      Must be a valid [[!UTF-8]] sequence.
     </td>
   </tr>
   <tr>
     <td>uint8</td>
     <td><dfn for="Format 1 Patch Map">patchEncoding</dfn></td>
     <td>
-      Specifies the format of the patches linked to by uriTemplate. Using the ID number from the [[#font-patch-formats-summary]] table.
+      Specifies the format of the patches linked to by uriTemplate.
+      Must be set to one of the format numbers from  the [[#font-patch-formats-summary]] table.
     </td>
   </tr>
 </table>
@@ -794,10 +796,8 @@ The algorithm outputs:
 
 The algorithm:
 
-1.  Check that the <var>patch map</var> has [=Format 1 Patch Map/format=] equal to 1 and is valid according to the requirements in
-     [[#patch-map-format-1]] (requirements are marked with a "must"). If it is not return an error.
-     <!-- TODO also mention validating there is enough data to fit all of the structures, error if not. -->
-     <!-- TODO also mention validating uri template (valid unicode) and the patch encoding format # -->
+1.  Check that the <var>patch map</var> data is: complete and not truncated, has [=Format 1 Patch Map/format=] equal to 1, and is valid
+     according to the requirements in [[#patch-map-format-1]] (requirements are marked with a "must"). If it is not return an error.
 
 2.  For each unique <var>entry index</var> in [=Glyph Map/entryIndex=]:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -617,7 +617,9 @@ the encoded bytes at the start of every iteration to pick up any changes made in
   <tr>
     <td>uint24</td>
     <td><dfn for="Format 1 Patch Map">glyphCount</dfn></td>
-    <td>Number of glyphs that mappings are provided for. Must match the numGlyphs field from either [[open-type/maxp|maxp]] or MAXP (if present). If both maxp and MAXP are present then, it must match the numGlyphs field in MAXP.</td>
+    <td>Number of glyphs that mappings are provided for.
+        Must match the numGlyphs field from [[open-type/maxp|maxp]] if present, or if numGlyphs is 65,535 then glyphCount
+        must be greater than or equal to 65,535.</td>
   </tr>
   <tr>
     <td>Offset32</td>
@@ -662,6 +664,10 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     </td>
   </tr>
 </table>
+
+Note: [=Format 1 Patch Map/glyphCount=] is designed to be compatible with the
+      proposed <a href="https://github.com/harfbuzz/boring-expansion-spec/tree/main">future font format extension</a> to allow for more
+      than 65,535 glyphs.
 
 <dfn>Glyph Map</dfn> encoding:
 

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="0cc7e36d9b6aaf65e1fd7bb226727b785ac3f771" name="revision">
+  <meta content="c99782a24b108d251c0542f0e9d9c62294bf8291" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1230,11 +1230,13 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.2.3 URI Templates</a> which is used to produce URIs associated with each entry. 
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.2.3 URI Templates</a> which is used to produce URIs associated with each entry.
+      Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchencoding">patchEncoding</dfn>
-      <td> Specifies the format of the patches linked to by uriTemplate. Using the ID number from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
+      <td> Specifies the format of the patches linked to by uriTemplate.
+      Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-map">Glyph Map</dfn> encoding:</p>
    <p>A glyph map table associates each glyph index in the font with an entry index.</p>
@@ -1338,7 +1340,8 @@ the encoded bytes at the start of every iteration to pick up any changes made in
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 5.2.1 Patch Map Table: Format 1</a> (requirements are marked with a "must"). If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> data is: complete and not truncated, has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1, and is valid
+ according to the requirements in <a href="#patch-map-format-1">§ 5.2.1 Patch Map Table: Format 1</a> (requirements are marked with a "must"). If it is not return an error.</p>
     <li data-md>
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex">entryIndex</a>:</p>
      <ul>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="a56c6eafa3ec9e31981c22807c08a777842b571a" name="revision">
+  <meta content="06f26256d87d90ac40082fe0185a436ddd3790c5" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1203,13 +1203,17 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-maxentryindex">maxEntryIndex</dfn>
       <td>The largest entry index encoded in this table.
      <tr>
+      <td>uint16
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</dfn>
+      <td>The largest <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map">Glyph Map</a> entry index encoded in this table. Must be less than or equal to maxEntryIndex.
+     <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-glyphcount">glyphCount</dfn>
       <td>Number of glyphs that mappings are provided for. Must match the numGlyphs field from <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a>.
      <tr>
       <td>Offset32
       <td>glyphMapOffset
-      <td>Offset to a <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map">Glyph Map</a> sub table. Offset is from the start of this table.
+      <td>Offset to a <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map①">Glyph Map</a> sub table. Offset is from the start of this table.
      <tr>
       <td>Offset32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-featuremapoffset">featureMapOffset</dfn>
@@ -1265,18 +1269,17 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td><a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord">FeatureRecord</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Feature Map" data-dfn-type="dfn" data-noexport id="feature-map-featurerecords">featureRecords</dfn>[featureCount]
-      <td> Provides mappings for a specific <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tag</a>. Must be sorted by <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag">featureTag</a> with any feature tag occurring at most once. 
+      <td> Provides mappings for a specific <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tag</a>. <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords">featureRecords</a> are sorted by <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag">featureTag</a> in ascending order with any feature tag occurring at most once. For sorting tag values are interpreted
+      as a 4 byte big endian unsigned integer and sorted by the integer value. 
      <tr>
       <td><a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord">EntryMapRecord</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Feature Map" data-dfn-type="dfn" data-noexport id="feature-map-entrymaprecords">entryMapRecords</dfn>[variable]
       <td> Provides the key (entry index) for each feature mapping. The entryMapRecords array contains as many entries as the sum of
-      the <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount">entryMapCount</a> fields in the <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords">featureRecords</a> array, with entryMapRecords[0] corresponding
+      the <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount">entryMapCount</a> fields in the <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords①">featureRecords</a> array, with entryMapRecords[0] corresponding
       to the first entry of featureRecords[0], entryMapRecords[featureRecord[0].entryMapCount] corresponding to the first entry of
       featureRecords[1], entryMapRecords[featureRecords[0].entryMapCount + featureRecord[1].entryMapCount]] corresponding to the
       first entry of featureRecords[2], and so on. 
    </table>
-   <p><a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords①">featureRecords</a> must be sorted by <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag①">featureTag</a> in ascending order with any feature tag occurring at most
-once. For sorting tag values are interpreted as a 4 byte big endian unsigned integer and sorted by the integer value.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="featurerecord">FeatureRecord</dfn> encoding:</p>
    <table>
     <tbody>
@@ -1310,12 +1313,11 @@ once. For sorting tag values are interpreted as a 4 byte big endian unsigned int
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-firstentryindex">firstEntryIndex</dfn>
       <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex③">maxEntryIndex</a> is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
-      the set of <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map①">Glyph Map</a> entries which form the subset definitions for the entries created by this mapping. 
+      the set of <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map②">Glyph Map</a> entries which form the subset definitions for the entries created by this mapping. 
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-lastentryindex">lastEntryIndex</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex④">maxEntryIndex</a> is less than 256, otherwise uint16.
-      Must be greater than or equal to firstEntryIndex. 
+      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex④">maxEntryIndex</a> is less than 256, otherwise uint16. 
    </table>
    <p>An entry map record matches any entry indices that are greater than or equal to firstEntryIndex and less than or equal to  lastEntryIndex.</p>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 1" data-level="5.2.1.1" id="interpreting-patch-map-format-1"><span class="secno">5.2.1.1. </span><span class="content">Interpreting Format 1</span><a class="self-link" href="#interpreting-patch-map-format-1"></a></h5>
@@ -1336,62 +1338,68 @@ once. For sorting tag values are interpreted as a 4 byte big endian unsigned int
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 5.2.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 5.2.1 Patch Map Table: Format 1</a> (requirements are marked with a "must"). If it is not return an error.</p>
     <li data-md>
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex">entryIndex</a>:</p>
      <ul>
       <li data-md>
-       <p>If <var>entry index</var> is 0 then, this is a special entry used to mark glyphs which are already in the font. Skip this index
-and do not build an entry for it.</p>
+       <p>If <var>entry index</var> is 0 then, this is a special entry used to mark glyphs which are already in the initial font. Skip this
+index and do not build an entry for it.</p>
       <li data-md>
-       <p>If the <var>entry index</var> is larger than <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑤">maxEntryIndex</a> this table is invalid,
-return an error.</p>
+       <p>If the <var>entry index</var> is larger than <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</a> this entry is invalid, skip this <var>entry index</var>.</p>
       <li data-md>
        <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
        <p>Collect the set of glyph indices that map to the <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert the set of glyph indices to a set of unicode code points using the code point to glyph mapping in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
+       <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
 Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
       <li data-md>
        <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
       <li data-md>
-       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> to <var>entry list</var> whose subset definition contains only the unicode code point set and
+       <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
+      <li data-md>
+       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> to <var>entry list</var> whose subset definition contains only the Unicode code point set and
 maps to the generated URI, the patch encoding specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#format-1-patch-map-featuremapoffset" id="ref-for-format-1-patch-map-featuremapoffset">featureMapOffset</a> is not null then, for each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords②">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
      <ul>
       <li data-md>
-       <p>Compute <var>mapped entry index</var>, the first <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord③">EntryMapRecord</a> associated with a <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord②">FeatureRecord</a> is <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex">FeatureRecord::firstNewEntryIndex</a>, the second <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex①">FeatureRecord::firstNewEntryIndex</a> + 1, and so on. The last will be <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex②">FeatureRecord::firstNewEntryIndex</a> + <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount①">entryMapCount</a> - 1.</p>
+       <p>Any <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord②">FeatureRecord’s</a> whose <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag①">featureTag</a> is less than or equal to a <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag②">featureTag</a> of any <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord③">FeatureRecord</a> which occurred earlier in the list are invalid. All associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord③">EntryMapRecord’s</a> are
+skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigned integer and ordered by the integer value.</p>
       <li data-md>
-       <p>If the computed <var>mapped entry index</var> is larger than <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑥">maxEntryIndex</a> this table is invalid,
-return an error.</p>
+       <p>Compute <var>mapped entry index</var>, the first <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord④">EntryMapRecord</a> associated with a <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord④">FeatureRecord</a> is <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex">FeatureRecord::firstNewEntryIndex</a>, the second <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex①">FeatureRecord::firstNewEntryIndex</a> + 1, and so on. The last will be <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex②">FeatureRecord::firstNewEntryIndex</a> + <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount①">entryMapCount</a> - 1.</p>
       <li data-md>
-       <p>If <var>mapped entry index</var> matches an entry index present in the <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map②">Glyph Map</a> this table is invalid,
-return an error.</p>
+       <p>If the computed <var>mapped entry index</var> is less than or equal to <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex①">maxGlyphMapEntryIndex</a> or larger than <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑤">maxEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑤">EntryMapRecord</a> is invalid, skip it.</p>
+      <li data-md>
+       <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
       <li data-md>
        <p>Convert <var>mapped entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
       <li data-md>
        <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this entry.</p>
       <li data-md>
-       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> to <var>entry list</var> which  maps to the generated URI, the patch encoding
-specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding①">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">entry</a> in <var>entry list</var> which has the same patch URI as the generated URI then
-instead modify the existing entry. Add <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag②">featureTag</a> to the new or existing entry’s subset definition.</p>
-      <li data-md>
-       <p>For each <var>entry index</var> between <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> (inclusive) and <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> (inclusive):</p>
+       <p>Construct a set of Unicode code points. For each <var>entry index</var> between <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex①">EntryMapRecord::firstEntryIndex</a> (inclusive) and <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex①">EntryMapRecord::lastEntryIndex</a> (inclusive):</p>
        <ul>
         <li data-md>
-         <p>Find the set of unicode code points associated with <var>entry index</var> that was computed in step 2. If the <var>entry index</var> was skipped because of <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap②">appliedEntriesBitMap</a> compute the set of associated
-code points as if it wasn’t skipped. If <var>entry index</var> was not processed in step 2 this table is invalid, return an
-error. Entries processed in step 2 that were marked as skipped by <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> are valid to be
-referenced here. Union the produced set of code points to the new or existing entry’s subset definition.</p>
+         <p>If <var>entry index</var> is greater than <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex②">maxGlyphMapEntryIndex</a> then, this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑦">EntryMapRecord</a> is invalid
+skip it.</p>
+        <li data-md>
+         <p>Add the set of Unicode code points associated with <var>entry index</var> that was computed in step 2 to the set. If the <var>entry index</var> was skipped because it was 0 or <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap②">appliedEntriesBitMap</a> compute the set of
+associated code points as if it wasn’t skipped.</p>
        </ul>
+      <li data-md>
+       <p>If the constructed set of Unicode code points is empty then, this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑧">EntryMapRecord</a> is invalid skip it.</p>
+      <li data-md>
+       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> to <var>entry list</var> which  maps to the generated URI, the patch encoding
+specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding①">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">entry</a> in <var>entry list</var> which has the same patch URI as the generated URI then
+instead modify the existing entry. Add the constructed set of Unicode code points and <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag③">featureTag</a> to the new or
+existing entry’s subset definition.</p>
      </ul>
     <li data-md>
      <p>Return <var>entry list</var>.</p>
    </ol>
-   <p class="note" role="note"><span class="marker">Note:</span> while an encoding is not required to include entries for all entry indices in [0, <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑦">maxEntryIndex</a>], it is
+   <p class="note" role="note"><span class="marker">Note:</span> while an encoding is not required to include entries for all entry indices in [0, <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑥">maxEntryIndex</a>], it is
 recommended that it do so for maximum compactness.</p>
    <h5 class="heading settled algorithm" data-algorithm="Remove Entries from Format 1" data-level="5.2.1.2" id="remove-entries-format-1"><span class="secno">5.2.1.2. </span><span class="content">Remove Entries from Format 1</span><a class="self-link" href="#remove-entries-format-1"></a></h5>
    <p>This algorithm is used to remove entries from a format 1 patch map. This removal modifies the bytes of the patch map but does not
@@ -1412,11 +1420,11 @@ change the number of bytes.</p>
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex①">entryIndex</a> of <var>patch map</var>:</p>
      <ul>
       <li data-md>
-       <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
+       <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
        <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate②">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
       <li data-md>
-       <p>If the generated URI is equal to <var>patch URI</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap⑤">appliedEntriesBitMap</a> to 1.</p>
+       <p>If the generated URI is equal to <var>patch URI</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
      </ul>
    </ol>
    <h4 class="heading settled" data-level="5.2.2" id="patch-map-format-2"><span class="secno">5.2.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
@@ -2787,6 +2795,7 @@ number of requests:</p>
    <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 5.2.2</span>
    <li><a href="#format-1-patch-map-maxentryindex">maxEntryIndex</a><span>, in § 5.2.1</span>
+   <li><a href="#format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</a><span>, in § 5.2.1</span>
    <li><a href="#no-invalidation">No Invalidation</a><span>, in § 4.1</span>
    <li><a href="#partial-invalidation">Partial Invalidation</a><span>, in § 4.1</span>
    <li><a href="#patch-application-algorithm">patch application algorithm</a><span>, in § 3.2</span>
@@ -3082,26 +3091,27 @@ let dfnPanelData = {
 "design-space-segment-end": {"dfnID":"design-space-segment-end","dfnText":"end","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-end"},{"id":"ref-for-design-space-segment-end\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-end"},
 "design-space-segment-start": {"dfnID":"design-space-segment-start","dfnText":"start","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-start"},{"id":"ref-for-design-space-segment-start\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-start"},
 "design-space-segment-tag": {"dfnID":"design-space-segment-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-tag"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-tag"},
-"entrymaprecord": {"dfnID":"entrymaprecord","dfnText":"EntryMapRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord"},{"id":"ref-for-entrymaprecord\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-entrymaprecord\u2461"},{"id":"ref-for-entrymaprecord\u2462"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord"},
-"entrymaprecord-firstentryindex": {"dfnID":"entrymaprecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-firstentryindex"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-firstentryindex"},
-"entrymaprecord-lastentryindex": {"dfnID":"entrymaprecord-lastentryindex","dfnText":"lastEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-lastentryindex"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-lastentryindex"},
+"entrymaprecord": {"dfnID":"entrymaprecord","dfnText":"EntryMapRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord"},{"id":"ref-for-entrymaprecord\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-entrymaprecord\u2461"},{"id":"ref-for-entrymaprecord\u2462"},{"id":"ref-for-entrymaprecord\u2463"},{"id":"ref-for-entrymaprecord\u2464"},{"id":"ref-for-entrymaprecord\u2465"},{"id":"ref-for-entrymaprecord\u2466"},{"id":"ref-for-entrymaprecord\u2467"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord"},
+"entrymaprecord-firstentryindex": {"dfnID":"entrymaprecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-firstentryindex"},{"id":"ref-for-entrymaprecord-firstentryindex\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-firstentryindex"},
+"entrymaprecord-lastentryindex": {"dfnID":"entrymaprecord-lastentryindex","dfnText":"lastEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-lastentryindex"},{"id":"ref-for-entrymaprecord-lastentryindex\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-lastentryindex"},
 "feature-map": {"dfnID":"feature-map","dfnText":"Feature Map","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#feature-map"},
 "feature-map-entrymaprecords": {"dfnID":"feature-map-entrymaprecords","dfnText":"entryMapRecords","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map-entrymaprecords"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#feature-map-entrymaprecords"},
 "feature-map-featurerecords": {"dfnID":"feature-map-featurerecords","dfnText":"featureRecords","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map-featurerecords"},{"id":"ref-for-feature-map-featurerecords\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-feature-map-featurerecords\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#feature-map-featurerecords"},
-"featurerecord": {"dfnID":"featurerecord","dfnText":"FeatureRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord\u2460"},{"id":"ref-for-featurerecord\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord"},
+"featurerecord": {"dfnID":"featurerecord","dfnText":"FeatureRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord\u2460"},{"id":"ref-for-featurerecord\u2461"},{"id":"ref-for-featurerecord\u2462"},{"id":"ref-for-featurerecord\u2463"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord"},
 "featurerecord-entrymapcount": {"dfnID":"featurerecord-entrymapcount","dfnText":"entryMapCount","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-entrymapcount"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-entrymapcount\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-entrymapcount"},
-"featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"},{"id":"ref-for-featurerecord-featuretag\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
+"featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"},{"id":"ref-for-featurerecord-featuretag\u2461"},{"id":"ref-for-featurerecord-featuretag\u2462"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
 "featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"},{"id":"ref-for-featurerecord-firstnewentryindex\u2460"},{"id":"ref-for-featurerecord-firstnewentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
 "font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.3. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"}],"title":"6.2. Brotli Patch"},{"refs":[{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"},{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2461\u2461"},{"id":"ref-for-font-subset\u2461\u2462"},{"id":"ref-for-font-subset\u2461\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2464"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u2465"},{"id":"ref-for-font-subset\u2461\u2466"},{"id":"ref-for-font-subset\u2461\u2467"}],"title":"6.4.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2468"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2462\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
 "font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"},{"id":"ref-for-font-subset-definition\u2463"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2464"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"},{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2468"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u24ea"},{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"},{"id":"ref-for-font-subset-definition\u2460\u2462"},{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
-"format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2464"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
+"format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
 "format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
 "format-1-patch-map-featuremapoffset": {"dfnID":"format-1-patch-map-featuremapoffset","dfnText":"featureMapOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-featuremapoffset"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-featuremapoffset"},
 "format-1-patch-map-format": {"dfnID":"format-1-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-format"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-format\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-format"},
 "format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
-"format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2466"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
+"format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
+"format-1-patch-map-maxglyphmapentryindex": {"dfnID":"format-1-patch-map-maxglyphmapentryindex","dfnText":"maxGlyphMapEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxglyphmapentryindex"},
 "format-1-patch-map-patchencoding": {"dfnID":"format-1-patch-map-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchencoding"},{"id":"ref-for-format-1-patch-map-patchencoding\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchencoding"},
 "format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
 "format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.2.2.2. Remove Entries from Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2461"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#format-2-patch-map"},
@@ -3119,7 +3129,7 @@ let dfnPanelData = {
 "glyph-keyed-patch-compatibilityid": {"dfnID":"glyph-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-compatibilityid"},{"id":"ref-for-glyph-keyed-patch-compatibilityid\u2460"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-compatibilityid"},
 "glyph-keyed-patch-flags": {"dfnID":"glyph-keyed-patch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-flags"}],"title":"6.4. Glyph Keyed"}],"url":"#glyph-keyed-patch-flags"},
 "glyph-keyed-patch-format": {"dfnID":"glyph-keyed-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-format"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-format"},
-"glyph-map": {"dfnID":"glyph-map","dfnText":"Glyph Map","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map"},{"id":"ref-for-glyph-map\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-glyph-map\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#glyph-map"},
+"glyph-map": {"dfnID":"glyph-map","dfnText":"Glyph Map","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map"},{"id":"ref-for-glyph-map\u2460"},{"id":"ref-for-glyph-map\u2461"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map"},
 "glyph-map-entryindex": {"dfnID":"glyph-map-entryindex","dfnText":"entryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-entryindex"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-glyph-map-entryindex\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#glyph-map-entryindex"},
 "glyph-map-firstmappedglyph": {"dfnID":"glyph-map-firstmappedglyph","dfnText":"firstMappedGlyph","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-firstmappedglyph"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map-firstmappedglyph"},
 "glyphpatches": {"dfnID":"glyphpatches","dfnText":"GlyphPatches","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches"},{"id":"ref-for-glyphpatches\u2460"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches"},
@@ -3586,6 +3596,7 @@ let refsData = {
 "#format-1-patch-map-format": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#format-1-patch-map-format"},
 "#format-1-patch-map-glyphcount": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyphcount","type":"dfn","url":"#format-1-patch-map-glyphcount"},
 "#format-1-patch-map-maxentryindex": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxentryindex","type":"dfn","url":"#format-1-patch-map-maxentryindex"},
+"#format-1-patch-map-maxglyphmapentryindex": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxglyphmapentryindex","type":"dfn","url":"#format-1-patch-map-maxglyphmapentryindex"},
 "#format-1-patch-map-patchencoding": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchencoding","type":"dfn","url":"#format-1-patch-map-patchencoding"},
 "#format-1-patch-map-uritemplate": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-1-patch-map-uritemplate"},
 "#format-2-patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 2 patch map","type":"dfn","url":"#format-2-patch-map"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="c99782a24b108d251c0542f0e9d9c62294bf8291" name="revision">
+  <meta content="8bc90930185a4cad076e9f94b8a30951a9745b02" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1209,7 +1209,9 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-glyphcount">glyphCount</dfn>
-      <td>Number of glyphs that mappings are provided for. Must match the numGlyphs field from either <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a> or MAXP (if present). If both maxp and MAXP are present then, it must match the numGlyphs field in MAXP.
+      <td>Number of glyphs that mappings are provided for.
+        Must match the numGlyphs field from <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a> if present, or if numGlyphs is 65,535 then glyphCount
+        must be greater than or equal to 65,535.
      <tr>
       <td>Offset32
       <td>glyphMapOffset
@@ -1238,6 +1240,9 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td> Specifies the format of the patches linked to by uriTemplate.
       Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
    </table>
+   <p class="note" role="note"><span class="marker">Note:</span> <a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> is designed to be compatible with the
+      proposed <a href="https://github.com/harfbuzz/boring-expansion-spec/tree/main">future font format extension</a> to allow for more
+      than 65,535 glyphs.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-map">Glyph Map</dfn> encoding:</p>
    <p>A glyph map table associates each glyph index in the font with an entry index.</p>
    <table>
@@ -1252,7 +1257,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td>All glyph indices less than firstMappedGlyph are implicitly mapped to entry index 0.
      <tr>
       <td>uint8/uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-entryindex">entryIndex</dfn>[<a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> - firstMappedGlyph]
+      <td><dfn class="dfn-paneled" data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-entryindex">entryIndex</dfn>[<a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount①">glyphCount</a> - firstMappedGlyph]
       <td> The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - <a data-link-type="dfn" href="#glyph-map-firstmappedglyph" id="ref-for-glyph-map-firstmappedglyph">firstMappedGlyph</a>]. Array members
       are uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex">maxEntryIndex</a> is less than 256, otherwise they are uint16. 
    </table>
@@ -3112,7 +3117,7 @@ let dfnPanelData = {
 "format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
 "format-1-patch-map-featuremapoffset": {"dfnID":"format-1-patch-map-featuremapoffset","dfnText":"featureMapOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-featuremapoffset"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-featuremapoffset"},
 "format-1-patch-map-format": {"dfnID":"format-1-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-format"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-format\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-format"},
-"format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
+"format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"},{"id":"ref-for-format-1-patch-map-glyphcount\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
 "format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
 "format-1-patch-map-maxglyphmapentryindex": {"dfnID":"format-1-patch-map-maxglyphmapentryindex","dfnText":"maxGlyphMapEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxglyphmapentryindex"},
 "format-1-patch-map-patchencoding": {"dfnID":"format-1-patch-map-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchencoding"},{"id":"ref-for-format-1-patch-map-patchencoding\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchencoding"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="06f26256d87d90ac40082fe0185a436ddd3790c5" name="revision">
+  <meta content="0cc7e36d9b6aaf65e1fd7bb226727b785ac3f771" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1207,9 +1207,9 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</dfn>
       <td>The largest <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map">Glyph Map</a> entry index encoded in this table. Must be less than or equal to maxEntryIndex.
      <tr>
-      <td>uint32
+      <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-glyphcount">glyphCount</dfn>
-      <td>Number of glyphs that mappings are provided for. Must match the numGlyphs field from <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a>.
+      <td>Number of glyphs that mappings are provided for. Must match the numGlyphs field from either <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a> or MAXP (if present). If both maxp and MAXP are present then, it must match the numGlyphs field in MAXP.
      <tr>
       <td>Offset32
       <td>glyphMapOffset

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="8bc90930185a4cad076e9f94b8a30951a9745b02" name="revision">
+  <meta content="88022e4975c403c00cdf2f4d0f9457bcd9cb55cf" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1209,9 +1209,11 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-glyphcount">glyphCount</dfn>
-      <td>Number of glyphs that mappings are provided for.
-        Must match the numGlyphs field from <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a> if present, or if numGlyphs is 65,535 then glyphCount
-        must be greater than or equal to 65,535.
+      <td>
+       Number of glyphs that mappings are provided for.
+        Must match the number of glyphs in the the font file. 
+       <p class="note" role="note"><span class="marker">Note:</span> the number of glyphs in the font is encoded in the font file. At the time of writing, this value is listed in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a> table; however, future font format extensions may use alternate tables to encode the value for number of
+        glyphs.</p>
      <tr>
       <td>Offset32
       <td>glyphMapOffset


### PR DESCRIPTION
This allows a conformat client implementation to optimize format 1 entry intersection by only checking the relevant parts of the table. See #198 for more context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/199.html" title="Last updated on Aug 27, 2024, 10:22 PM UTC (72967a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/199/06f2625...72967a4.html" title="Last updated on Aug 27, 2024, 10:22 PM UTC (72967a4)">Diff</a>