### PR TITLE
Add more Normative Validation rules for Format 2

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1240,9 +1240,9 @@ The algorithm:
 
     *  Otherwise the bias is 0.
 
-    *  Read the sparse bit set [=Mapping Entry/codePoints=] from <var>entry bytes</var> following [[#sparse-bit-set-decoding]]. For each
-        code point add the bias value to it and then add the result to the code point set in <var>entry</var>. If there are not enough
-        bytes remaining to fully decode the sparse bit set then, this encoding is invalid return an error.
+    *  Read the sparse bit set [=Mapping Entry/codePoints=] from <var>entry bytes</var> with bias following [[#sparse-bit-set-decoding]].
+        Add the resulting code point set to <var>entry</var>. If the sparse bit set decoding failed then, this encoding is invalid return
+        an error.
 
 10. If [=Mapping Entry/formatFlags=] bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.
 
@@ -1335,11 +1335,9 @@ are invalid.
 
 The inputs to this algorithm are:
 
-* <var>H</var>: the tree height, <var>H</var>, from the header byte.
-
-* <var>B</var>: the branch factor, <var>B</var>, from the header byte.
-
 * <var>treeData</var>: array of bytes to be decoded.
+
+* <var>bias</var>: unsigned integer value added to each decoded set member.
 
 The algorithm outputs:
 
@@ -1347,41 +1345,44 @@ The algorithm outputs:
 
 The algorithm, using a FIFO (first in first out) queue <var>Q</var>:
 
-1.  If <var>H</var> is greater than the "Maximum Height" in the [=Branch Factor Encoding=] table in the row for <var>B</var> then,
+1.  Remove the first byte from <var>treeData</var>. This is the header byte. Determine <var>H</var> the tree height and <var>B</var> the
+     branch factor following [=Sparse Bit Set=].
+
+2.  If <var>H</var> is greater than the "Maximum Height" in the [=Branch Factor Encoding=] table in the row for <var>B</var> then,
      the encoding is invalid, return an error.
 
-2.  If <var>H</var> is equal to 0, then this is an empty set and no bytes of <var>treeData</var> are consumed. Return an empty set.
+3.  If <var>H</var> is equal to 0, then this is an empty set and no further bytes of <var>treeData</var> are consumed. Return an empty set.
 
-3.  Insert the tuple (0, 1) into <var>Q</var>.
+4.  Insert the tuple (0, 1) into <var>Q</var>.
 
-4.  Initialize <var>S</var> to an empty set.
+5.  Initialize <var>S</var> to an empty set.
 
-5.  <var>treeData</var> is interpreted as a string of bits where the least significant bit of <var>treeData</var>[0] is the first bit in
+6.  <var>treeData</var> is interpreted as a string of bits where the least significant bit of <var>treeData</var>[0] is the first bit in
      the string, the most significant bit of <var>treeData</var>[0] is the 8th bit, and so on.
 
-6.  If in the following steps a value is added to <var>S</var> which is larger than the maximum unicode code point value (0x10FFFF) then,
+7.  If in the following steps a value is added to <var>S</var> which is larger than the maximum unicode code point value (0x10FFFF) then,
      ignore the value and do not add it to <var>S</var>.
 
-7.  If <var>Q</var> is empty return <var>S</var>.
+8.  If <var>Q</var> is empty return <var>S</var>.
 
-8.  Extract the next tuple <var>t</var> from <var>Q</var>. The first value of
+9.  Extract the next tuple <var>t</var> from <var>Q</var>. The first value of
      in <var>t</var> is <var>start</var> and the second value is <var>depth</var>.
 
-9.  Remove the next <var>B</var> bits from the <var>treeData</var> bit string. The first removed bit is <i>v<sub>1</sub></i>,
+10.  Remove the next <var>B</var> bits from the <var>treeData</var> bit string. The first removed bit is <i>v<sub>1</sub></i>,
      the second is <i>v<sub>2</sub></i>, and so on until the last removed bit which is <i>v<sub>B</sub></i>. If prior to removal there
      were less than <var>B</var> bits left in <var>treeData</var>, then <var>treeData</var> is malformed, return an error.
 
-10.  If all bits <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i> are 0, then insert all integers in the interval
-    [<var>start</var>, <var>start</var> + <var>B</var><sup><var>H</var> - <var>depth</var> + 1</sup>)
+11.  If all bits <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i> are 0, then insert all integers in the interval
+    [<var>start</var> + <var>bias</var>, <var>start</var> + <var>bias</var> + <var>B</var><sup><var>H</var> - <var>depth</var> + 1</sup>)
     into <var>S</var>. Go to step 5.
 
-11.  For each <i>v<sub>i</sub></i> which is equal to 1 in <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i>:
+12.  For each <i>v<sub>i</sub></i> which is equal to 1 in <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i>:
      If <var>depth</var> is equal to <var>H</var> add
-     integer <var>start</var> + <i>i</i> - 1 to <var>S</var>. Otherwise, insert the tuple
+     integer <var>start</var> + <var>bias</var> + <i>i</i> - 1 to <var>S</var>. Otherwise, insert the tuple
      (<var>start</var> + (i - 1) * <var>B</var><sup><var>H</var> - <var>depth</var></sup>, <var>depth</var> + 1)
      into <var>Q</var>.
 
-12.  Go to step 7.
+13.  Go to step 8.
 
 Note: when encoding sparse bit sets the encoder can use any of the possible branching factors, but it is recommended to
 use 4 as that has <a href="https://github.com/w3c/PFE-analysis/blob/main/results/set_encoding_branch_factor.md">been shown</a>

--- a/Overview.bs
+++ b/Overview.bs
@@ -430,6 +430,8 @@ intersecting patches in parallel, since no patch application will invalidate any
 
 <dfn abstract-op>Check entry intersection</dfn>
 
+<!-- TODO: Explain how design spaces are intersected -->
+
 The inputs to this algorithm are:
 
 *   <var>mapping entry</var>: a [=patch map entries|patch map entry=].
@@ -911,8 +913,8 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Format 2 Patch Map">defaultPatchEncoding</dfn></td>
     <td>
-      Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry). Uses the ID numbers from the
-      [[#font-patch-formats-summary]] table.
+      Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
+      Must be set to one of the format numbers from the [[#font-patch-formats-summary]] table.
     </td>
   </tr>
   <tr>
@@ -945,6 +947,7 @@ The algorithm:
     <td><dfn for="Format 2 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
     <td>
       A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URIs associated with each entry.
+      Must be a valid [[!UTF-8]] sequence.
     </td>
   </tr>
 </table>
@@ -1020,8 +1023,8 @@ The algorithm:
     <td>uint24</td>
     <td><dfn for="Mapping Entry">copyIndices</dfn>[copyCount]</td>
     <td>
-      List of indices from the [=Mapping Entries/entries=] array whose [=font subset definition=] should be copied into this entry. All
-      values must be less than the index of this [=Mapping Entry=] in [=Mapping Entries/entries=]. Only present if
+      List of indices from the [=Mapping Entries/entries=] array whose [=font subset definition=] should be copied into this entry. May
+      only reference entries that occurred prior to this [=Mapping Entry=] in [=Mapping Entries/entries=]. Only present if
       [=Mapping Entry/formatFlags=] bit 1 is set.
     </td>
   </tr>
@@ -1131,7 +1134,7 @@ The algorithm outputs:
 The algorithm:
 
 1.  Check that the <var>patch map</var> has [=Format 2 Patch Map/format=] equal to 2 and is valid according to the requirements in
-     [[#patch-map-format-2]]. If it is not return an error.
+     [[#patch-map-format-2]] (requirements are marked with a "must"). If it is not return an error.
 
 2.  Initialize <var>last entry id</var> to 0, <var>current byte</var> to 0, and <var>current id string byte</var> to 0.
 
@@ -1201,6 +1204,8 @@ The algorithm:
     *  Read the design space segment list specified by [=Mapping Entry/designSpaceCount=] and [=Mapping Entry/designSpaceSegments=]
         from <var>entry bytes</var> and add the design space segments to <var>entry</var>. Each segment defines an interval from
         [=Design Space Segment/start=] to [=Design Space Segment/end=] inclusive for the axis identified by [=Design Space Segment/tag=].
+        If any segment has a [=Design Space Segment/start=] which is greater than [=Design Space Segment/end=] then, this encoding is
+        invalid return an error.
 
 6.  If [=Mapping Entry/formatFlags=] bit 1 is set, then the copy indices list is present:
 
@@ -1208,19 +1213,21 @@ The algorithm:
 
     *  The copy indices refer to previously loaded entries. 0 is the first [=Mapping Entry=] in [=Mapping Entries/entries=], 1 the second
          and so on. For each index in [=Mapping Entry/copyIndices=] locate the previously loaded entry with a matching index and
-         add all code points, feature tags, and design space segments from it to <var>entry</var>.
+         add all code points, feature tags, and design space segments from it to <var>entry</var>. If a [=Mapping Entry/copyIndices=]
+         is greater than or equal to the index of this entry then, this encoding is invalid return an error.
 
 7.  If [=Mapping Entry/formatFlags=] bit 2 is set, then an id delta or id string length is present:
 
     *  If <var>id string bytes</var> is not present then, read the id delta specified by [=Mapping Entry/entryIdDelta=]
-        from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
-        and the mapping is malformed.
+        from <var>entry bytes</var> and add the delta to <var>entry id</var>.
 
     *  Otherwise if <var>id string bytes</var> is present then, read [=Mapping Entry/entryIdStringLength=] bytes from
         <var>id string bytes</var> and set <var>entry id</var> to the result.
 
 8.  If [=Mapping Entry/formatFlags=] bit 3 is set, then a patch encoding is present. Read the encoding specified by
      [=Mapping Entry/patchEncoding=] from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.
+     If [=Mapping Entry/patchEncoding=] is not one of the values in [[#font-patch-formats-summary]] then, this encoding is invalid
+     return an error.
 
 9.  If one or both of [=Mapping Entry/formatFlags=] bit 4 and bit 5 are set, then a code point list is present:
 
@@ -1233,14 +1240,17 @@ The algorithm:
     *  Otherwise the bias is 0.
 
     *  Read the sparse bit set [=Mapping Entry/codePoints=] from <var>entry bytes</var> following [[#sparse-bit-set-decoding]]. For each
-        code point add the bias value to it and then add the result to the code point set in <var>entry</var>.
+        code point add the bias value to it and then add the result to the code point set in <var>entry</var>. If there are not enough
+        bytes remaining to fully decode the sparse bit set then, this encoding is invalid return an error.
 
 10. If [=Mapping Entry/formatFlags=] bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.
 
-11. Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]]. Set the patch uri of
+11. If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.
+
+12. Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]]. Set the patch uri of
      <var>entry</var> to the generated URI.
 
-12. Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, [=Mapping Entry/entryIdStringLength=] as
+13. Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, [=Mapping Entry/entryIdStringLength=] as
      <var>consumed id string bytes</var>, and <var>ignored</var>.
 
 <h5 algorithm id="remove-entries-format-2">Remove Entries from Format 2</h5>
@@ -1436,59 +1446,57 @@ to give the smallest encodings for most unicode code point sets typically encoun
 ### URI Templates ### {#uri-templates}
 
 URI templates [[!rfc6570]] are used to convert numeric or string IDs into URIs where patch files are located.
-A string ID is a sequence of [[!unicode|Unicode]] code point values obtained from decoding a
-[[UTF-8]] string (see [[rfc6570#section-1.6]]). Several variables are defined which are used to produce the
-expansion of the template:
+A string ID is a sequence of bytes. Several variables are defined which are used to produce the expansion of the template:
 
 <table>
   <tr><th>Variable</th><th>Value</th></tr>
   <tr>
-    <td>id</td>
+    <td><code>id</code></td>
     <td>
       The input id encoded as a [[rfc4648#section-7|base32hex]] string (using the digits 0-9, A-V) with padding
-      omitted.  When the id is an unsigned integer it must first be converted to a big endian 64 bit unsigned integer,
+      omitted.  When the id is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
       but then all leading bytes that are equal to 0 are removed before encoding.  (For example, when the
       integer is less than 256 only one byte is encoded.) When the input id is a string the raw bytes are
       encoded as base32hex.
     </td>
   </tr>
   <tr>
-    <td>d1</td>
+    <td><code>d1</code></td>
     <td>
-      The last character of the string in the id variable.
-      If id variable is empty then, the value is the character _ (U+005F).
+      The last character of the string in the <code>id</code> variable.
+      If <code>id</code> variable is empty then, the value is the character _ (U+005F).
     </td>
   </tr>
   <tr>
-    <td>d2</td>
+    <td><code>d2</code></td>
     <td>
-      The second last character of the string in the id variable.
-      If the id variable has less than 2 characters then, the value is the character _ (U+005F).
+      The second last character of the string in the <code>id</code> variable.
+      If the <code>id</code> variable has less than 2 characters then, the value is the character _ (U+005F).
     </td>
   </tr>
   <tr>
-    <td>d3</td>
+    <td><code>d3</code></td>
     <td>
-      The third last character of the string in the id variable.
-      If the id variable has less than 3 characters then, the value is the character _ (U+005F).
+      The third last character of the string in the <code>id</code> variable.
+      If the <code>id</code> variable has less than 3 characters then, the value is the character _ (U+005F).
     </td>
   </tr>
   <tr>
-    <td>d4</td>
+    <td><code>d4</code></td>
     <td>
-      The fourth last character of the string in the id variable.
-      If the id variable has less than 4 characters then, the value is the character _ (U+005F).
+      The fourth last character of the string in the <code>id</code> variable.
+      If the <code>id</code> variable has less than 4 characters then, the value is the character _ (U+005F).
     </td>
   </tr>
   <tr>
-    <td>id64</td>
+    <td><code>id64</code></td>
     <td>
       The input id encoded as a [[rfc4648#section-5|base64url]] string (using the digits A-Z, a-z, 0-9, -
       (minus) and _ (underline)) with padding included. Because the padding character is '=', it must
       be URL-encoded as "%3D'.  When the id is an unsigned integer it must first be converted to a big
-      endian 64 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding. 
+      endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding. 
       (For example, when the integer is less than 256 only one byte is encoded.) When the input id is
-      a string its raw bytes are encoded as base64url.
+      a string its raw bytes are encoded as [[rfc4648#section-5|base64url]].
     </td>
   </tr>
 </table>

--- a/Overview.bs
+++ b/Overview.bs
@@ -430,8 +430,6 @@ intersecting patches in parallel, since no patch application will invalidate any
 
 <dfn abstract-op>Check entry intersection</dfn>
 
-<!-- TODO: Explain how design spaces are intersected -->
-
 The inputs to this algorithm are:
 
 *   <var>mapping entry</var>: a [=patch map entries|patch map entry=].
@@ -458,6 +456,9 @@ The algorithm:
          <th>mapping entry set is not empty</th><td>false</td><td>true if the two sets intersect</td>
        </tr>
      </table>
+
+     When checking design space sets for intersection, they intersect if there is at least one pair of intersecting segments
+     (tags are equal and the ranges intersect).
 
 2. If all sets checked in step 1 intersect, then return true for <var>intersects</var> otherwise false.
 

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="2b99efa12d92d726fd6e59fb89085110cdf4e111" name="revision">
+  <meta content="78f986b4c55080e704b601c67bd3f0a431d9fb44" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1441,7 +1441,8 @@ change the number of bytes.</p>
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</dfn>
-      <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry). Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
+      <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
+      Must be set to one of the format numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entrycount">entryCount</dfn>
@@ -1462,7 +1463,8 @@ change the number of bytes.</p>
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.2.3 URI Templates</a> which is used to produce URIs associated with each entry. 
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.2.3 URI Templates</a> which is used to produce URIs associated with each entry.
+      Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entries">Mapping Entries</dfn> encoding:</p>
    <table>
@@ -1512,8 +1514,8 @@ change the number of bytes.</p>
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices</dfn>[copyCount]
-      <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> should be copied into this entry. All
-      values must be less than the index of this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
+      <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> should be copied into this entry. May
+      only reference entries that occurred prior to this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
      <tr>
       <td>int24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>
@@ -1584,7 +1586,7 @@ being requested.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 5.2.2 Patch Map Table: Format 2</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 5.2.2 Patch Map Table: Format 2</a> (requirements are marked with a "must"). If it is not return an error.</p>
     <li data-md>
      <p>Initialize <var>last entry id</var> to 0, <var>current byte</var> to 0, and <var>current id string byte</var> to 0.</p>
     <li data-md>
@@ -1651,7 +1653,9 @@ being requested.</p>
       <li data-md>
        <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to <var>entry</var>.</p>
       <li data-md>
-       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to <var>entry</var>. Each segment defines an interval from <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start">start</a> to <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end">end</a> inclusive for the axis identified by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-space-segment-tag">tag</a>.</p>
+       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to <var>entry</var>. Each segment defines an interval from <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start">start</a> to <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end">end</a> inclusive for the axis identified by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-space-segment-tag">tag</a>.
+If any segment has a <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start①">start</a> which is greater than <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end①">end</a> then, this encoding is
+invalid return an error.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①②">formatFlags</a> bit 1 is set, then the copy indices list is present:</p>
@@ -1661,19 +1665,20 @@ being requested.</p>
       <li data-md>
        <p>The copy indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry④">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries②">entries</a>, 1 the second
  and so on. For each index in <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices①">copyIndices</a> locate the previously loaded entry with a matching index and
- add all code points, feature tags, and design space segments from it to <var>entry</var>.</p>
+ add all code points, feature tags, and design space segments from it to <var>entry</var>. If a <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices②">copyIndices</a> is greater than or equal to the index of this entry then, this encoding is invalid return an error.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①③">formatFlags</a> bit 2 is set, then an id delta or id string length is present:</p>
      <ul>
       <li data-md>
-       <p>If <var>id string bytes</var> is not present then, read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta①">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>. If <var>entry id</var> is negative this is an error
-and the mapping is malformed.</p>
+       <p>If <var>id string bytes</var> is not present then, read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta①">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>.</p>
       <li data-md>
        <p>Otherwise if <var>id string bytes</var> is present then, read <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength">entryIdStringLength</a> bytes from <var>id string bytes</var> and set <var>entry id</var> to the result.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①④">formatFlags</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①④">formatFlags</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.
+ If <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding①">patchEncoding</a> is not one of the values in <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> then, this encoding is invalid
+ return an error.</p>
     <li data-md>
      <p>If one or both of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑤">formatFlags</a> bit 4 and bit 5 are set, then a code point list is present:</p>
      <ul>
@@ -1687,10 +1692,13 @@ from <var>entry bytes</var>.</p>
        <p>Otherwise the bias is 0.</p>
       <li data-md>
        <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codePoints</a> from <var>entry bytes</var> following <a href="#sparse-bit-set-decoding">§ 5.2.2.3 Sparse Bit Set</a>. For each
-code point add the bias value to it and then add the result to the code point set in <var>entry</var>.</p>
+code point add the bias value to it and then add the result to the code point set in <var>entry</var>. If there are not enough
+bytes remaining to fully decode the sparse bit set then, this encoding is invalid return an error.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑧">formatFlags</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
+    <li data-md>
+     <p>If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
     <li data-md>
      <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>. Set the patch uri of <var>entry</var> to the generated URI.</p>
     <li data-md>
@@ -1878,44 +1886,43 @@ byte string:
    </div>
    <h4 class="heading settled" data-level="5.2.3" id="uri-templates"><span class="secno">5.2.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h4>
    <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URIs where patch files are located.
-A string ID is a sequence of <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">Unicode</a> code point values obtained from decoding a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> string (see <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.6">URI Template § section-1.6</a>). Several variables are defined which are used to produce the
-expansion of the template:</p>
+A string ID is a sequence of bytes. Several variables are defined which are used to produce the expansion of the template:</p>
    <table>
     <tbody>
      <tr>
       <th>Variable
       <th>Value
      <tr>
-      <td>id
+      <td><code>id</code>
       <td> The input id encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a> string (using the digits 0-9, A-V) with padding
-      omitted.  When the id is an unsigned integer it must first be converted to a big endian 64 bit unsigned integer,
+      omitted.  When the id is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
       but then all leading bytes that are equal to 0 are removed before encoding.  (For example, when the
       integer is less than 256 only one byte is encoded.) When the input id is a string the raw bytes are
       encoded as base32hex. 
      <tr>
-      <td>d1
-      <td> The last character of the string in the id variable.
-      If id variable is empty then, the value is the character _ (U+005F). 
+      <td><code>d1</code>
+      <td> The last character of the string in the <code>id</code> variable.
+      If <code>id</code> variable is empty then, the value is the character _ (U+005F). 
      <tr>
-      <td>d2
-      <td> The second last character of the string in the id variable.
-      If the id variable has less than 2 characters then, the value is the character _ (U+005F). 
+      <td><code>d2</code>
+      <td> The second last character of the string in the <code>id</code> variable.
+      If the <code>id</code> variable has less than 2 characters then, the value is the character _ (U+005F). 
      <tr>
-      <td>d3
-      <td> The third last character of the string in the id variable.
-      If the id variable has less than 3 characters then, the value is the character _ (U+005F). 
+      <td><code>d3</code>
+      <td> The third last character of the string in the <code>id</code> variable.
+      If the <code>id</code> variable has less than 3 characters then, the value is the character _ (U+005F). 
      <tr>
-      <td>d4
-      <td> The fourth last character of the string in the id variable.
-      If the id variable has less than 4 characters then, the value is the character _ (U+005F). 
+      <td><code>d4</code>
+      <td> The fourth last character of the string in the <code>id</code> variable.
+      If the <code>id</code> variable has less than 4 characters then, the value is the character _ (U+005F). 
      <tr>
-      <td>id64
+      <td><code>id64</code>
       <td> The input id encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a> string (using the digits A-Z, a-z, 0-9, -
       (minus) and _ (underline)) with padding included. Because the padding character is '=', it must
       be URL-encoded as "%3D'.  When the id is an unsigned integer it must first be converted to a big
-      endian 64 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding. 
+      endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding. 
       (For example, when the integer is less than 256 only one byte is encoded.) When the input id is
-      a string its raw bytes are encoded as base64url. 
+      a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
    </table>
    <div class="example" id="example-73881657">
     <a class="self-link" href="#example-73881657"></a> 
@@ -3068,8 +3075,8 @@ let dfnPanelData = {
 "brotli-patch-compatibilityid": {"dfnID":"brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-compatibilityid"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch-compatibilityid"},
 "brotli-patch-format": {"dfnID":"brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-format"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch-format"},
 "design-space-segment": {"dfnID":"design-space-segment","dfnText":"Design Space Segment","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#design-space-segment"},
-"design-space-segment-end": {"dfnID":"design-space-segment-end","dfnText":"end","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-end"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-end"},
-"design-space-segment-start": {"dfnID":"design-space-segment-start","dfnText":"start","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-start"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-start"},
+"design-space-segment-end": {"dfnID":"design-space-segment-end","dfnText":"end","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-end"},{"id":"ref-for-design-space-segment-end\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-end"},
+"design-space-segment-start": {"dfnID":"design-space-segment-start","dfnText":"start","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-start"},{"id":"ref-for-design-space-segment-start\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-start"},
 "design-space-segment-tag": {"dfnID":"design-space-segment-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-tag"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-tag"},
 "entrymaprecord": {"dfnID":"entrymaprecord","dfnText":"EntryMapRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord"},{"id":"ref-for-entrymaprecord\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-entrymaprecord\u2461"},{"id":"ref-for-entrymaprecord\u2462"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord"},
 "entrymaprecord-firstentryindex": {"dfnID":"entrymaprecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-firstentryindex"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-firstentryindex"},
@@ -3124,7 +3131,7 @@ let dfnPanelData = {
 "mapping-entry-bias": {"dfnID":"mapping-entry-bias","dfnText":"bias","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-bias"},{"id":"ref-for-mapping-entry-bias\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-bias"},
 "mapping-entry-codepoints": {"dfnID":"mapping-entry-codepoints","dfnText":"codePoints","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-codepoints"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-codepoints"},
 "mapping-entry-copycount": {"dfnID":"mapping-entry-copycount","dfnText":"copyCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-copycount"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-copycount"},
-"mapping-entry-copyindices": {"dfnID":"mapping-entry-copyindices","dfnText":"copyIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-copyindices"},{"id":"ref-for-mapping-entry-copyindices\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-copyindices"},
+"mapping-entry-copyindices": {"dfnID":"mapping-entry-copyindices","dfnText":"copyIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-copyindices"},{"id":"ref-for-mapping-entry-copyindices\u2460"},{"id":"ref-for-mapping-entry-copyindices\u2461"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-copyindices"},
 "mapping-entry-designspacecount": {"dfnID":"mapping-entry-designspacecount","dfnText":"designSpaceCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacecount"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacecount"},
 "mapping-entry-designspacesegments": {"dfnID":"mapping-entry-designspacesegments","dfnText":"designSpaceSegments","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacesegments"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacesegments"},
 "mapping-entry-entryiddelta": {"dfnID":"mapping-entry-entryiddelta","dfnText":"entryIdDelta","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryiddelta"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-entryiddelta\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-entryiddelta"},
@@ -3132,7 +3139,7 @@ let dfnPanelData = {
 "mapping-entry-featurecount": {"dfnID":"mapping-entry-featurecount","dfnText":"featureCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featurecount"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featurecount"},
 "mapping-entry-featuretags": {"dfnID":"mapping-entry-featuretags","dfnText":"featureTags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featuretags"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featuretags"},
 "mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#mapping-entry-formatflags"},
-"mapping-entry-patchencoding": {"dfnID":"mapping-entry-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchencoding"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchencoding"},
+"mapping-entry-patchencoding": {"dfnID":"mapping-entry-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchencoding"},{"id":"ref-for-mapping-entry-patchencoding\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchencoding"},
 "no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-no-invalidation\u2461"}],"title":"7.1. Encoding Considerations"}],"url":"#no-invalidation"},
 "partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"},{"id":"ref-for-partial-invalidation\u2461"}],"title":"4.2. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2463"},{"id":"ref-for-partial-invalidation\u2464"},{"id":"ref-for-partial-invalidation\u2465"},{"id":"ref-for-partial-invalidation\u2466"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
 "patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="78f986b4c55080e704b601c67bd3f0a431d9fb44" name="revision">
+  <meta content="3aeaf3cbaa5ce1392268e6747e9ae1363a6409e7" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1076,6 +1076,8 @@ intersecting patches in parallel, since no patch application will invalidate any
         <td>false
         <td>true if the two sets intersect
      </table>
+     <p>When checking design space sets for intersection, they intersect if there is at least one pair of intersecting segments
+ (tags are equal and the ranges intersect).</p>
     <li data-md>
      <p>If all sets checked in step 1 intersect, then return true for <var>intersects</var> otherwise false.</p>
    </ol>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="3aeaf3cbaa5ce1392268e6747e9ae1363a6409e7" name="revision">
+  <meta content="58ea5038ead513a784305fc7fb6d1b359f388785" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1693,9 +1693,9 @@ from <var>entry bytes</var>.</p>
       <li data-md>
        <p>Otherwise the bias is 0.</p>
       <li data-md>
-       <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codePoints</a> from <var>entry bytes</var> following <a href="#sparse-bit-set-decoding">§ 5.2.2.3 Sparse Bit Set</a>. For each
-code point add the bias value to it and then add the result to the code point set in <var>entry</var>. If there are not enough
-bytes remaining to fully decode the sparse bit set then, this encoding is invalid return an error.</p>
+       <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codePoints</a> from <var>entry bytes</var> with bias following <a href="#sparse-bit-set-decoding">§ 5.2.2.3 Sparse Bit Set</a>.
+Add the resulting code point set to <var>entry</var>. If the sparse bit set decoding failed then, this encoding is invalid return
+an error.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑧">formatFlags</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
@@ -1787,11 +1787,9 @@ are invalid.</p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>H</var>: the tree height, <var>H</var>, from the header byte.</p>
-    <li data-md>
-     <p><var>B</var>: the branch factor, <var>B</var>, from the header byte.</p>
-    <li data-md>
      <p><var>treeData</var>: array of bytes to be decoded.</p>
+    <li data-md>
+     <p><var>bias</var>: unsigned integer value added to each decoded set member.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1801,10 +1799,13 @@ are invalid.</p>
    <p>The algorithm, using a FIFO (first in first out) queue <var>Q</var>:</p>
    <ol>
     <li data-md>
+     <p>Remove the first byte from <var>treeData</var>. This is the header byte. Determine <var>H</var> the tree height and <var>B</var> the
+ branch factor following <a data-link-type="dfn" href="#sparse-bit-set" id="ref-for-sparse-bit-set①">Sparse Bit Set</a>.</p>
+    <li data-md>
      <p>If <var>H</var> is greater than the "Maximum Height" in the <a data-link-type="dfn" href="#branch-factor-encoding" id="ref-for-branch-factor-encoding①">Branch Factor Encoding</a> table in the row for <var>B</var> then,
  the encoding is invalid, return an error.</p>
     <li data-md>
-     <p>If <var>H</var> is equal to 0, then this is an empty set and no bytes of <var>treeData</var> are consumed. Return an empty set.</p>
+     <p>If <var>H</var> is equal to 0, then this is an empty set and no further bytes of <var>treeData</var> are consumed. Return an empty set.</p>
     <li data-md>
      <p>Insert the tuple (0, 1) into <var>Q</var>.</p>
     <li data-md>
@@ -1826,16 +1827,16 @@ are invalid.</p>
  were less than <var>B</var> bits left in <var>treeData</var>, then <var>treeData</var> is malformed, return an error.</p>
     <li data-md>
      <p>If all bits <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i> are 0, then insert all integers in the interval
-[<var>start</var>, <var>start</var> + <var>B</var><sup><var>H</var> - <var>depth</var> + 1</sup>)
+[<var>start</var> + <var>bias</var>, <var>start</var> + <var>bias</var> + <var>B</var><sup><var>H</var> - <var>depth</var> + 1</sup>)
 into <var>S</var>. Go to step 5.</p>
     <li data-md>
      <p>For each <i>v<sub>i</sub></i> which is equal to 1 in <i>v<sub>1</sub></i> through <i>v<sub>B</sub></i>:
  If <var>depth</var> is equal to <var>H</var> add
- integer <var>start</var> + <i>i</i> - 1 to <var>S</var>. Otherwise, insert the tuple
+ integer <var>start</var> + <var>bias</var> + <i>i</i> - 1 to <var>S</var>. Otherwise, insert the tuple
  (<var>start</var> + (i - 1) * <var>B</var><sup><var>H</var> - <var>depth</var></sup>, <var>depth</var> + 1)
  into <var>Q</var>.</p>
     <li data-md>
-     <p>Go to step 7.</p>
+     <p>Go to step 8.</p>
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> when encoding sparse bit sets the encoder can use any of the possible branching factors, but it is recommended to
 use 4 as that has <a href="https://github.com/w3c/PFE-analysis/blob/main/results/set_encoding_branch_factor.md">been shown</a> to give the smallest encodings for most unicode code point sets typically encountered.</p>
@@ -3152,7 +3153,7 @@ let dfnPanelData = {
 "per-table-brotli-patch-compatibilityid": {"dfnID":"per-table-brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-compatibilityid"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-compatibilityid"},
 "per-table-brotli-patch-format": {"dfnID":"per-table-brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-format"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-format"},
 "per-table-brotli-patch-patches": {"dfnID":"per-table-brotli-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-patches"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-per-table-brotli-patch-patches\u2460"},{"id":"ref-for-per-table-brotli-patch-patches\u2461"},{"id":"ref-for-per-table-brotli-patch-patches\u2462"},{"id":"ref-for-per-table-brotli-patch-patches\u2463"},{"id":"ref-for-per-table-brotli-patch-patches\u2464"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-patches"},
-"sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#sparse-bit-set"},
+"sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
 "tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch"},
 "tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-brotlistream"},
 "tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-flags"},


### PR DESCRIPTION
Based on experience of implementing format 2 parsing this adds some additional validation:
- Format number must be one of the valid formats
- URI template must be utf8
- design space start < end
- limit max numeric entry id to 32 bits.
- Move bias into the sparse bit set decoding algorithm so the max set value limit (unicode max 0x10FFFF) applies to the post bias values.
- Added some clarification on how to intersect design spaces.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/203.html" title="Last updated on Aug 22, 2024, 7:41 PM UTC (5665f0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/203/78f986b...5665f0d.html" title="Last updated on Aug 22, 2024, 7:41 PM UTC (5665f0d)">Diff</a>