### PR TITLE
Remove the pure brotli patch type, rename remaining brotli patch type to "Table Keyed"

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -579,7 +579,7 @@ Incremental Font Transfer and WOFF2 {#ift-and-woff2}
 is taken. If an incremental font will be encoded by WOFF2 for transfer:
 
 1.  If the WOFF2 encoding will include a transformed glyf and loca table ([[WOFF2#glyf_table_format]]) then, the incremental
-     font should not contain [[#per-table-brotli]] patches which modify either the glyf or loca table. The WOFF2 format does not
+     font should not contain [[#per-table]] patches which modify either the glyf or loca table. The WOFF2 format does not
      guarantee the specific bytes that result from decoding a transformed glyf and loca table. [[#glyph-keyed]] patches may be used
      in conjunction with a transformed glyf and loca table.
 
@@ -1617,7 +1617,7 @@ Formats Summary {#font-patch-formats-summary}
 
 The following patch formats are defined by this specification:
 
-* [[#per-table-brotli]]: a collection of brotli encoded binary diffs that use tables from a [=font subset=] as bases.
+* [[#per-table]]: a collection of brotli encoded binary diffs that use tables from a [=font subset=] as bases.
 
 * [[#glyph-keyed]]: a collection of opaque binary blobs, each associated with a glyph id and table.
 
@@ -1634,12 +1634,12 @@ The following format numbers are used to identify the patch format and invalidat
 
   <tr>
     <td>1</td>
-    <td>[[#per-table-brotli]]</td>
+    <td>[[#per-table]]</td>
     <td>[=Full Invalidation=]</td>
   </tr>
   <tr>
     <td>2</td>
-    <td>[[#per-table-brotli]]</td>
+    <td>[[#per-table]]</td>
     <td>[=Partial Invalidation=]</td>
   </tr>
 
@@ -1650,25 +1650,25 @@ The following format numbers are used to identify the patch format and invalidat
   </tr>
 </table>
 
-Per Table Brotli {#per-table-brotli}
+Per Table {#per-table}
 --------------------------------------------------
 
-A per table brotli patch contains a collection of patches which are applied to the individual
+A per table patch contains a collection of patches which are applied to the individual
 [[open-type/otff#table-directory|font tables]] in the input font file. Each table patch is encoded with
 [[!RFC7932|brotli compression]] using the corresponding table from the input font file as a
-[[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. A per table brotli encoded patch consists of a short header followed
+[[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. A per table encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
 or remove tables in a [=font subset=].
 
-<dfn>Per table brotli patch</dfn> encoding:
+<dfn>Per table patch</dfn> encoding:
 <table>
   <tr>
     <th>Type</th><th>Name</th><th>Description</th>
   </tr>
   <tr>
     <td>Tag</td>
-    <td><dfn for="Per table brotli patch">format</dfn></td>
-    <td>Identifies the encoding as per table brotli, set to 'ifbt'</td>
+    <td><dfn for="Per table patch">format</dfn></td>
+    <td>Identifies the encoding as per table, set to 'ifpt'</td>
   </tr>
   <tr>
     <td>uint32</td>
@@ -1677,7 +1677,7 @@ or remove tables in a [=font subset=].
   </tr>
   <tr>
     <td>uint32</td>
-    <td><dfn for="Per table brotli patch">compatibilityId</dfn>[4]</td>
+    <td><dfn for="Per table patch">compatibilityId</dfn>[4]</td>
     <td>The id of the [=font subset=] which this patch can be applied too. See [[#font-patch-invalidations]].</td>
   </tr>
   <tr>
@@ -1687,12 +1687,12 @@ or remove tables in a [=font subset=].
   </tr>
   <tr>
     <td>Offset32</td>
-    <td><dfn for="Per table brotli patch">patches</dfn>[patchesCount+1]</td>
+    <td><dfn for="Per table patch">patches</dfn>[patchesCount+1]</td>
     <td>Each entry is an offset from the start of this table to a [=TablePatch=]. Offsets must be sorted in ascending order.</td>
   </tr>
 </table>
 
-The difference between two consecutive offsets in the [=Per table brotli patch/patches=] array gives the size
+The difference between two consecutive offsets in the [=Per table patch/patches=] array gives the size
 of that [=TablePatch=].
 
 <dfn>TablePatch</dfn> encoding:
@@ -1722,18 +1722,18 @@ of that [=TablePatch=].
   </tr>
 </table>
 
-<h4 algorithm id="apply-per-table-brotli">Applying Per Table Brotli Patches</h4>
+<h4 algorithm id="apply-per-table">Applying Per Table Patches</h4>
 
-This [=patch application algorithm=] is used to apply a per table brotli patch to extend a [=font subset=] to cover additional code points,
+This [=patch application algorithm=] is used to apply a per table patch to extend a [=font subset=] to cover additional code points,
 features, and/or design-variation space.
 
-<dfn abstract-op>Apply per table brotli patch</dfn>
+<dfn abstract-op>Apply per table patch</dfn>
 
 The inputs to this algorithm are:
 
 * <var>base font subset</var>: a [=font subset=] which is to be extended.
 
-* <var>patch</var>: a [=per table brotli patch=] to be applied to <var>base font subset</var>.
+* <var>patch</var>: a [=per table patch=] to be applied to <var>base font subset</var>.
 
 * <var>compatibility id</var>: The ID number from the 'IFT ' or 'IFTX' table of <var>base font subset</var> which listed this patch.
 
@@ -1745,11 +1745,11 @@ The algorithm:
 
 1. Initialize <var>extended font subset</var> to be an empty font with no tables.
 
-2. Check that the [=Per table brotli patch/format=] field in <var>patch</var> is equal to 'ifbt', if it is
+2. Check that the [=Per table patch/format=] field in <var>patch</var> is equal to 'ifpt', if it is
     not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
     an error.
 
-3. Check that the [=Per table brotli patch/compatibilityId=] field in <var>patch</var> is equal to <var>compatibility id</var>.
+3. Check that the [=Per table patch/compatibilityId=] field in <var>patch</var> is equal to <var>compatibility id</var>.
     If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
     has failed, return an error.
 
@@ -1758,16 +1758,16 @@ The algorithm:
     type specification. That entry includes a checksum for the table data. When an existing table is copied unmodified, the client
     can re-use the checksum from the entry in the source font. Otherwise a new checksum will need to be computed.
 
-5. For each entry in [=Per table brotli patch/patches=], with index <var>i</var>:
+5. For each entry in [=Per table patch/patches=], with index <var>i</var>:
 
     *  Find the [=TablePatch=] associated with index <var>i</var>. The object starts at the offset
-        [=Per table brotli patch/patches|patches[i]=] (inclusive) and ends at the offset
-        [=Per table brotli patch/patches|patches[i+1]=] (exclusive). Both offsets are relative to the start of
+        [=Per table patch/patches|patches[i]=] (inclusive) and ends at the offset
+        [=Per table patch/patches|patches[i+1]=] (exclusive). Both offsets are relative to the start of
         the <var>patch</var>.
 
-    *  If an entry in [=Per table brotli patch/patches=] was previously applied that has the same [=TablePatch/tag=] as
+    *  If an entry in [=Per table patch/patches=] was previously applied that has the same [=TablePatch/tag=] as
         this entry, then ignore this entry and continue the iteration to the next one. Entries are processed in same order as they
-        are listed in the [=Per table brotli patch/patches=] array.
+        are listed in the [=Per table patch/patches=] array.
 
 
     *  If bit 0 (least significant bit) of [=TablePatch/flags=] is set, then decode [=TablePatch/brotliStream=] following
@@ -2009,20 +2009,20 @@ is based on the experience of building an encoder implementation during developm
 understanding (at the time of writing) of how to generate a high performance encoding which meets requirements 1 through 4 of
 [[#encoding]] and thus preserves all functionality/behavior of the original font being encoded.
 
-<b>About [[#per-table-brotli]] patches</b>
+<b>About [[#per-table]] patches</b>
 
-A [[#per-table-brotli]] patch can change the contents of some font tables and not others. Each patched table typically needs to be
-relative to a specific table content, but other tables can have different contents. Therefore as long as a [[#per-table-brotli]]
+A [[#per-table]] patch can change the contents of some font tables and not others. Each patched table typically needs to be
+relative to a specific table content, but other tables can have different contents. Therefore as long as a [[#per-table]]
 patch does not alter the tables containing glyph data it can be compatible with [[#glyph-keyed]] patches and therefore be only
-[=Partial Invalidation|Partially Invalidating=] (in that it will invalidate other [[#per-table-brotli]] patches but not
-[[#glyph-keyed]] patches. Additionally two sets of [[#per-table-brotli]] patches can be independent of each other if they do not
-modify any of the same tables.  For example, one could use [[#per-table-brotli]] patches for all
-content other than the glyph tables but then use another set of [[#per-table-brotli]] patches for those tables rather than
+[=Partial Invalidation|Partially Invalidating=] (in that it will invalidate other [[#per-table]] patches but not
+[[#glyph-keyed]] patches. Additionally two sets of [[#per-table]] patches can be independent of each other if they do not
+modify any of the same tables.  For example, one could use [[#per-table]] patches for all
+content other than the glyph tables but then use another set of [[#per-table]] patches for those tables rather than
 [[#glyph-keyed]] patches, and each of these could in theory be [=Partial Invalidation|Partially Invalidating=]—leaving them
 mutually dependent but independent of one another.
 
-An application of a [[#per-table-brotli]] patch will typically alter the IFT or IFTX table it was was listed in to add a new set
-of patches to further extend the font. This means that the total set of [[#per-table-brotli]] patches forms a graph,
+An application of a [[#per-table]] patch will typically alter the IFT or IFTX table it was was listed in to add a new set
+of patches to further extend the font. This means that the total set of [[#per-table]] patches forms a graph,
 in which each font subset in the segmentation is a node and each patch is an edge. This also means that patches of these types
 are typically downloaded and applied in series, which has implications for the performance of this patch type relative to latency.
 
@@ -2036,7 +2036,7 @@ which can significantly reduce the number of round trips needed relative to the 
 
 <b>Choosing patch formats for an encoding</b>
 
-All encodings must chose one or more patch types to use. [[#per-table-brotli]] patches allow
+All encodings must chose one or more patch types to use. [[#per-table]] patches allow
 all types of data in the font to be patched, but because this type is at least [=Partial Invalidation|Partially Invalidating=],
 the total number of patches needed increases exponentially with the number of segments rather than linearly. [[#glyph-keyed]] patches
 are limited to updating outline and variation delta data but the number needed scales linearly with number of segments.
@@ -2046,21 +2046,21 @@ get patches for typical content. For invalidating patch types it is necessary to
 content requires multiple segments then, multiple network round trips may be needed. Glyph keyed patches on the other hand are not
 invalidating and the patches can be fetched in parallel, needing only a single round trip.
 
-At the extremes the two types of Brotli patches are most appropriate for fonts with sizable non-outline data that only require a
-small number of patches. Glyph keyed patches are most appropriate for fonts where the vast majority of data consists of glyph outlines,
-which is true of many existing CJK fonts.
+At the extremes of the two types of [[#per-table]] patches are most appropriate for fonts with sizable non-outline data that only require a
+small number of patches. [[#glyph-keyed]] patches are most appropriate for fonts where the vast majority of data consists of glyph
+outlines, which is true of many existing CJK fonts.
 
 For fonts that are in-between, or in cases where fine-grained segmentation of glyph data is desired but segmentation of data
-in other tables is still needed, it can be desirable to mix the [[#per-table-brotli]] and [[#glyph-keyed]] patch types in this
+in other tables is still needed, it can be desirable to mix the [[#per-table]] and [[#glyph-keyed]] patch types in this
 way:
 
-1. Keep all brotli patch entries in one mapping table and all glyph keyed entries in the other mapping table.
+1. Keep all per table patch entries in one mapping table and all glyph keyed entries in the other mapping table.
 
-2. Use per-table brotli patches to update all tables except for the tables touched by the glyph keyed patches (outline,
+2. Use per table patches to update all tables except for the tables touched by the glyph keyed patches (outline,
     variation deltas, and the glyph keyed patch mapping table). These patches should use a small number of large segments to keep
     the patch count reasonable.
 
-3. Because glyph keyed patches reference the specific glyph IDs that are updated, the per-table brotli patches must not change
+3. Because glyph keyed patches reference the specific glyph IDs that are updated, the per table patches must not change
     the glyph to glyph ID assignments used in the original font; otherwise, the glyph IDs listed in the glyph keyed patches may
     become incorrect. In font subsetters this is often available as an option called "retain glyph IDs".
 
@@ -2080,7 +2080,7 @@ patches needed.
 
 <b>Managing the number of patches</b>
 
-Using brotli patches along side a large number of segments can result in a very large number of patches needed, which can have two
+Using [[#per-table]] patches along side a large number of segments can result in a very large number of patches needed, which can have two
 negative effects. First, the storage space needed for all of the pre-generated patches could be undesirably large. Second, more 
 patches will generally mean lower CDN cache performance, because a higher number of patches represents a higher number of paths
 from a given subset to a given subset, with different paths being taken by different users depending on the content they access.
@@ -2124,9 +2124,9 @@ As discussed in [[#encoding]] an encoder should preserve the functionality of th
 and often contain interactions between code points so maintaining functional equivalence with a partial copy of the font can be tricky.
 The next two subsections discuss maintaining functional equivalent using the different patch types.
 
-<b>Brotli patches</b>
+<b>Per table patches</b>
 
-When preparing [[#per-table-brotli]] patches, one means of achieving functional equivalence is to leverage an
+When preparing [[#per-table]] patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.
 
@@ -2136,7 +2136,7 @@ beyond the scope of this document). It typically involves a reachability analysi
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
 Any reachable data is retained in the generated font subset, while any unreachable data may be removed.
 
-In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only Brotli patches:
+In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only per table patches:
 
 ```
 # Encode a font (full_font) into an incremental font that starts at base_subset_def
@@ -2164,7 +2164,7 @@ encode_node(full_font, base_font, cur_def, subset_definitions):
     next_fonts += (next_font, next_def, patch_url)
 
   for each (next_font, next_def, patch_url) in next_fonts:
-    patch = brotli_patch_diff(base_font, next_font)
+    patch = per_table_patch_diff(base_font, next_font)
     patches += (patch, patch_url)
   
   return base_font, patches
@@ -2243,7 +2243,7 @@ the file. Encoders should consider placing the mapping tables (IFT and IFTX) plu
 mapping tables (cmap) as early as possible in the file. This will allow optimized client implementations to access the 
 patch mapping prior to receiving all of the font data and potentially initiate requests for any required patches earlier.
 
-Likewise per table brotli patches have a separate brotli stream for each patched table and the format allows these streams to be placed
+Likewise per table patches have a separate brotli stream for each patched table and the format allows these streams to be placed
 in any order in the patch file. So for the same reasons encoders should consider placing updates to the mapping tables plus any
 additional tables needed to decode the mapping tables as early as possible in the patch file.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -2015,7 +2015,7 @@ A [[#table-keyed]] patch can change the contents of some font tables and not oth
 relative to a specific table content, but other tables can have different contents. Therefore as long as a [[#table-keyed]]
 patch does not alter the tables containing glyph data it can be compatible with [[#glyph-keyed]] patches and therefore be only
 [=Partial Invalidation|Partially Invalidating=] (in that it will invalidate other [[#table-keyed]] patches but not
-[[#glyph-keyed]] patches. Additionally two sets of [[#table-keyed]] patches can be independent of each other if they do not
+[[#glyph-keyed]] patches). Additionally two sets of [[#table-keyed]] patches can be independent of each other if they do not
 modify any of the same tables.  For example, one could use [[#table-keyed]] patches for all
 content other than the glyph tables but then use another set of [[#table-keyed]] patches for those tables rather than
 [[#glyph-keyed]] patches, and each of these could in theory be [=Partial Invalidation|Partially Invalidating=]—leaving them
@@ -2046,8 +2046,8 @@ get patches for typical content. For invalidating patch types it is necessary to
 content requires multiple segments then, multiple network round trips may be needed. Glyph keyed patches on the other hand are not
 invalidating and the patches can be fetched in parallel, needing only a single round trip.
 
-At the extremes of the two types of [[#table-keyed]] patches are most appropriate for fonts with sizable non-outline data that only require a
-small number of patches. [[#glyph-keyed]] patches are most appropriate for fonts where the vast majority of data consists of glyph
+At the extremes of the two types, [[#table-keyed]] patches, are most appropriate for fonts with sizable non-outline data that only require
+a small number of patches. [[#glyph-keyed]] patches are most appropriate for fonts where the vast majority of data consists of glyph
 outlines, which is true of many existing CJK fonts.
 
 For fonts that are in-between, or in cases where fine-grained segmentation of glyph data is desired but segmentation of data

--- a/Overview.bs
+++ b/Overview.bs
@@ -579,7 +579,7 @@ Incremental Font Transfer and WOFF2 {#ift-and-woff2}
 is taken. If an incremental font will be encoded by WOFF2 for transfer:
 
 1.  If the WOFF2 encoding will include a transformed glyf and loca table ([[WOFF2#glyf_table_format]]) then, the incremental
-     font should not contain [[#per-table]] patches which modify either the glyf or loca table. The WOFF2 format does not
+     font should not contain [[#table-keyed]] patches which modify either the glyf or loca table. The WOFF2 format does not
      guarantee the specific bytes that result from decoding a transformed glyf and loca table. [[#glyph-keyed]] patches may be used
      in conjunction with a transformed glyf and loca table.
 
@@ -1617,7 +1617,7 @@ Formats Summary {#font-patch-formats-summary}
 
 The following patch formats are defined by this specification:
 
-* [[#per-table]]: a collection of brotli encoded binary diffs that use tables from a [=font subset=] as bases.
+* [[#table-keyed]]: a collection of brotli encoded binary diffs that use tables from a [=font subset=] as bases.
 
 * [[#glyph-keyed]]: a collection of opaque binary blobs, each associated with a glyph id and table.
 
@@ -1634,12 +1634,12 @@ The following format numbers are used to identify the patch format and invalidat
 
   <tr>
     <td>1</td>
-    <td>[[#per-table]]</td>
+    <td>[[#table-keyed]]</td>
     <td>[=Full Invalidation=]</td>
   </tr>
   <tr>
     <td>2</td>
-    <td>[[#per-table]]</td>
+    <td>[[#table-keyed]]</td>
     <td>[=Partial Invalidation=]</td>
   </tr>
 
@@ -1650,25 +1650,25 @@ The following format numbers are used to identify the patch format and invalidat
   </tr>
 </table>
 
-Per Table {#per-table}
+Table Keyed {#table-keyed}
 --------------------------------------------------
 
-A per table patch contains a collection of patches which are applied to the individual
+A table keyed patch contains a collection of patches which are applied to the individual
 [[open-type/otff#table-directory|font tables]] in the input font file. Each table patch is encoded with
 [[!RFC7932|brotli compression]] using the corresponding table from the input font file as a
-[[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. A per table encoded patch consists of a short header followed
+[[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. A table keyed encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
 or remove tables in a [=font subset=].
 
-<dfn>Per table patch</dfn> encoding:
+<dfn>Table keyed patch</dfn> encoding:
 <table>
   <tr>
     <th>Type</th><th>Name</th><th>Description</th>
   </tr>
   <tr>
     <td>Tag</td>
-    <td><dfn for="Per table patch">format</dfn></td>
-    <td>Identifies the encoding as per table, set to 'ifpt'</td>
+    <td><dfn for="Table keyed patch">format</dfn></td>
+    <td>Identifies the encoding as table keyed, set to 'iftk'</td>
   </tr>
   <tr>
     <td>uint32</td>
@@ -1677,7 +1677,7 @@ or remove tables in a [=font subset=].
   </tr>
   <tr>
     <td>uint32</td>
-    <td><dfn for="Per table patch">compatibilityId</dfn>[4]</td>
+    <td><dfn for="Table keyed patch">compatibilityId</dfn>[4]</td>
     <td>The id of the [=font subset=] which this patch can be applied too. See [[#font-patch-invalidations]].</td>
   </tr>
   <tr>
@@ -1687,12 +1687,12 @@ or remove tables in a [=font subset=].
   </tr>
   <tr>
     <td>Offset32</td>
-    <td><dfn for="Per table patch">patches</dfn>[patchesCount+1]</td>
+    <td><dfn for="Table keyed patch">patches</dfn>[patchesCount+1]</td>
     <td>Each entry is an offset from the start of this table to a [=TablePatch=]. Offsets must be sorted in ascending order.</td>
   </tr>
 </table>
 
-The difference between two consecutive offsets in the [=Per table patch/patches=] array gives the size
+The difference between two consecutive offsets in the [=Table keyed patch/patches=] array gives the size
 of that [=TablePatch=].
 
 <dfn>TablePatch</dfn> encoding:
@@ -1722,18 +1722,18 @@ of that [=TablePatch=].
   </tr>
 </table>
 
-<h4 algorithm id="apply-per-table">Applying Per Table Patches</h4>
+<h4 algorithm id="apply-table-keyed">Applying Table Keyed Patches</h4>
 
-This [=patch application algorithm=] is used to apply a per table patch to extend a [=font subset=] to cover additional code points,
+This [=patch application algorithm=] is used to apply a table keyed patch to extend a [=font subset=] to cover additional code points,
 features, and/or design-variation space.
 
-<dfn abstract-op>Apply per table patch</dfn>
+<dfn abstract-op>Apply table keyed patch</dfn>
 
 The inputs to this algorithm are:
 
 * <var>base font subset</var>: a [=font subset=] which is to be extended.
 
-* <var>patch</var>: a [=per table patch=] to be applied to <var>base font subset</var>.
+* <var>patch</var>: a [=table keyed patch=] to be applied to <var>base font subset</var>.
 
 * <var>compatibility id</var>: The ID number from the 'IFT ' or 'IFTX' table of <var>base font subset</var> which listed this patch.
 
@@ -1745,11 +1745,11 @@ The algorithm:
 
 1. Initialize <var>extended font subset</var> to be an empty font with no tables.
 
-2. Check that the [=Per table patch/format=] field in <var>patch</var> is equal to 'ifpt', if it is
+2. Check that the [=Table keyed patch/format=] field in <var>patch</var> is equal to 'iftk', if it is
     not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
     an error.
 
-3. Check that the [=Per table patch/compatibilityId=] field in <var>patch</var> is equal to <var>compatibility id</var>.
+3. Check that the [=Table keyed patch/compatibilityId=] field in <var>patch</var> is equal to <var>compatibility id</var>.
     If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
     has failed, return an error.
 
@@ -1758,16 +1758,16 @@ The algorithm:
     type specification. That entry includes a checksum for the table data. When an existing table is copied unmodified, the client
     can re-use the checksum from the entry in the source font. Otherwise a new checksum will need to be computed.
 
-5. For each entry in [=Per table patch/patches=], with index <var>i</var>:
+5. For each entry in [=Table keyed patch/patches=], with index <var>i</var>:
 
     *  Find the [=TablePatch=] associated with index <var>i</var>. The object starts at the offset
-        [=Per table patch/patches|patches[i]=] (inclusive) and ends at the offset
-        [=Per table patch/patches|patches[i+1]=] (exclusive). Both offsets are relative to the start of
+        [=Table keyed patch/patches|patches[i]=] (inclusive) and ends at the offset
+        [=Table keyed patch/patches|patches[i+1]=] (exclusive). Both offsets are relative to the start of
         the <var>patch</var>.
 
-    *  If an entry in [=Per table patch/patches=] was previously applied that has the same [=TablePatch/tag=] as
+    *  If an entry in [=Table keyed patch/patches=] was previously applied that has the same [=TablePatch/tag=] as
         this entry, then ignore this entry and continue the iteration to the next one. Entries are processed in same order as they
-        are listed in the [=Per table patch/patches=] array.
+        are listed in the [=Table keyed patch/patches=] array.
 
 
     *  If bit 0 (least significant bit) of [=TablePatch/flags=] is set, then decode [=TablePatch/brotliStream=] following
@@ -2009,20 +2009,20 @@ is based on the experience of building an encoder implementation during developm
 understanding (at the time of writing) of how to generate a high performance encoding which meets requirements 1 through 4 of
 [[#encoding]] and thus preserves all functionality/behavior of the original font being encoded.
 
-<b>About [[#per-table]] patches</b>
+<b>About [[#table-keyed]] patches</b>
 
-A [[#per-table]] patch can change the contents of some font tables and not others. Each patched table typically needs to be
-relative to a specific table content, but other tables can have different contents. Therefore as long as a [[#per-table]]
+A [[#table-keyed]] patch can change the contents of some font tables and not others. Each patched table typically needs to be
+relative to a specific table content, but other tables can have different contents. Therefore as long as a [[#table-keyed]]
 patch does not alter the tables containing glyph data it can be compatible with [[#glyph-keyed]] patches and therefore be only
-[=Partial Invalidation|Partially Invalidating=] (in that it will invalidate other [[#per-table]] patches but not
-[[#glyph-keyed]] patches. Additionally two sets of [[#per-table]] patches can be independent of each other if they do not
-modify any of the same tables.  For example, one could use [[#per-table]] patches for all
-content other than the glyph tables but then use another set of [[#per-table]] patches for those tables rather than
+[=Partial Invalidation|Partially Invalidating=] (in that it will invalidate other [[#table-keyed]] patches but not
+[[#glyph-keyed]] patches. Additionally two sets of [[#table-keyed]] patches can be independent of each other if they do not
+modify any of the same tables.  For example, one could use [[#table-keyed]] patches for all
+content other than the glyph tables but then use another set of [[#table-keyed]] patches for those tables rather than
 [[#glyph-keyed]] patches, and each of these could in theory be [=Partial Invalidation|Partially Invalidating=]—leaving them
 mutually dependent but independent of one another.
 
-An application of a [[#per-table]] patch will typically alter the IFT or IFTX table it was was listed in to add a new set
-of patches to further extend the font. This means that the total set of [[#per-table]] patches forms a graph,
+An application of a [[#table-keyed]] patch will typically alter the IFT or IFTX table it was was listed in to add a new set
+of patches to further extend the font. This means that the total set of [[#table-keyed]] patches forms a graph,
 in which each font subset in the segmentation is a node and each patch is an edge. This also means that patches of these types
 are typically downloaded and applied in series, which has implications for the performance of this patch type relative to latency.
 
@@ -2036,7 +2036,7 @@ which can significantly reduce the number of round trips needed relative to the 
 
 <b>Choosing patch formats for an encoding</b>
 
-All encodings must chose one or more patch types to use. [[#per-table]] patches allow
+All encodings must chose one or more patch types to use. [[#table-keyed]] patches allow
 all types of data in the font to be patched, but because this type is at least [=Partial Invalidation|Partially Invalidating=],
 the total number of patches needed increases exponentially with the number of segments rather than linearly. [[#glyph-keyed]] patches
 are limited to updating outline and variation delta data but the number needed scales linearly with number of segments.
@@ -2046,21 +2046,21 @@ get patches for typical content. For invalidating patch types it is necessary to
 content requires multiple segments then, multiple network round trips may be needed. Glyph keyed patches on the other hand are not
 invalidating and the patches can be fetched in parallel, needing only a single round trip.
 
-At the extremes of the two types of [[#per-table]] patches are most appropriate for fonts with sizable non-outline data that only require a
+At the extremes of the two types of [[#table-keyed]] patches are most appropriate for fonts with sizable non-outline data that only require a
 small number of patches. [[#glyph-keyed]] patches are most appropriate for fonts where the vast majority of data consists of glyph
 outlines, which is true of many existing CJK fonts.
 
 For fonts that are in-between, or in cases where fine-grained segmentation of glyph data is desired but segmentation of data
-in other tables is still needed, it can be desirable to mix the [[#per-table]] and [[#glyph-keyed]] patch types in this
+in other tables is still needed, it can be desirable to mix the [[#table-keyed]] and [[#glyph-keyed]] patch types in this
 way:
 
-1. Keep all per table patch entries in one mapping table and all glyph keyed entries in the other mapping table.
+1. Keep all table keyed patch entries in one mapping table and all glyph keyed entries in the other mapping table.
 
-2. Use per table patches to update all tables except for the tables touched by the glyph keyed patches (outline,
+2. Use table keyed patches to update all tables except for the tables touched by the glyph keyed patches (outline,
     variation deltas, and the glyph keyed patch mapping table). These patches should use a small number of large segments to keep
     the patch count reasonable.
 
-3. Because glyph keyed patches reference the specific glyph IDs that are updated, the per table patches must not change
+3. Because glyph keyed patches reference the specific glyph IDs that are updated, the table keyed patches must not change
     the glyph to glyph ID assignments used in the original font; otherwise, the glyph IDs listed in the glyph keyed patches may
     become incorrect. In font subsetters this is often available as an option called "retain glyph IDs".
 
@@ -2080,7 +2080,7 @@ patches needed.
 
 <b>Managing the number of patches</b>
 
-Using [[#per-table]] patches along side a large number of segments can result in a very large number of patches needed, which can have two
+Using [[#table-keyed]] patches along side a large number of segments can result in a very large number of patches needed, which can have two
 negative effects. First, the storage space needed for all of the pre-generated patches could be undesirably large. Second, more 
 patches will generally mean lower CDN cache performance, because a higher number of patches represents a higher number of paths
 from a given subset to a given subset, with different paths being taken by different users depending on the content they access.
@@ -2124,9 +2124,9 @@ As discussed in [[#encoding]] an encoder should preserve the functionality of th
 and often contain interactions between code points so maintaining functional equivalence with a partial copy of the font can be tricky.
 The next two subsections discuss maintaining functional equivalent using the different patch types.
 
-<b>Per table patches</b>
+<b>Table keyed patches</b>
 
-When preparing [[#per-table]] patches, one means of achieving functional equivalence is to leverage an
+When preparing [[#table-keyed]] patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.
 
@@ -2136,7 +2136,7 @@ beyond the scope of this document). It typically involves a reachability analysi
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
 Any reachable data is retained in the generated font subset, while any unreachable data may be removed.
 
-In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only per table patches:
+In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only table keyed patches:
 
 ```
 # Encode a font (full_font) into an incremental font that starts at base_subset_def
@@ -2164,7 +2164,7 @@ encode_node(full_font, base_font, cur_def, subset_definitions):
     next_fonts += (next_font, next_def, patch_url)
 
   for each (next_font, next_def, patch_url) in next_fonts:
-    patch = per_table_patch_diff(base_font, next_font)
+    patch = table_keyed_patch_diff(base_font, next_font)
     patches += (patch, patch_url)
   
   return base_font, patches
@@ -2243,7 +2243,7 @@ the file. Encoders should consider placing the mapping tables (IFT and IFTX) plu
 mapping tables (cmap) as early as possible in the file. This will allow optimized client implementations to access the 
 patch mapping prior to receiving all of the font data and potentially initiate requests for any required patches earlier.
 
-Likewise per table patches have a separate brotli stream for each patched table and the format allows these streams to be placed
+Likewise table keyed patches have a separate brotli stream for each patched table and the format allows these streams to be placed
 in any order in the patch file. So for the same reasons encoders should consider placing updates to the mapping tables plus any
 additional tables needed to decode the mapping tables as early as possible in the patch file.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -572,19 +572,18 @@ patch types. For example all patches of one type can be specified in the 'IFT ' 
 Incremental Font Transfer and WOFF2 {#ift-and-woff2}
 ----------------------------------------------------
 
+<!-- TODO note any type of compression format is fine to use (eg. WOFF1) as long as it preserves the exact table bytes of the uncompressed
+     font. -->
+
 [[WOFF2]] is a commonly used to encode fonts for transfer on the web. Incremental fonts can be encoded with WOFF2 as long as special care
 is taken. If an incremental font will be encoded by WOFF2 for transfer:
 
-1.  The incremental font should not make use of [[#brotli]] patches. The WOFF2 format does not guarantee the ordering of tables in
-     the decoded font. [[#brotli]] patches are relative to a specific fixed set of bytes and thus cannot be used if the decoded font
-     has unpredictable decoded bytes. [[#per-table-brotli]] patches do not depend on a specific table ordering and may be used.
-
-2.  If the WOFF2 encoding will include a transformed glyf and loca table ([[WOFF2#glyf_table_format]]) then, the incremental
+1.  If the WOFF2 encoding will include a transformed glyf and loca table ([[WOFF2#glyf_table_format]]) then, the incremental
      font should not contain [[#per-table-brotli]] patches which modify either the glyf or loca table. The WOFF2 format does not
-     guarantee the specific bytes that result from decoding a transformed glyf and loca table, so as with #1 brotli patches cannot
-     be used. [[#glyph-keyed]] patches may be used in conjunction with a transformed glyf and loca table.
+     guarantee the specific bytes that result from decoding a transformed glyf and loca table. [[#glyph-keyed]] patches may be used
+     in conjunction with a transformed glyf and loca table.
 
-3.  When utilizing a WOFF2 encoded IFT font, the client must first fully decode the WOFF2 font before [[#extending-font-subset]].
+2.  When utilizing a WOFF2 encoded IFT font, the client must first fully decode the WOFF2 font before [[#extending-font-subset]].
 
 The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in
 [[WOFF2#table_format]].
@@ -1609,7 +1608,7 @@ Font Patch Formats {#font-patch-formats}
 ========================================
 
 In incremental font transfer [=font subset|font subsets=] are extended by applying patches.
-This specification defines three patch formats, each appropriate to its own set of augmentation scenarios. A single
+This specification defines two patch formats, each appropriate to its own set of augmentation scenarios. A single
 encoding can make use of more than one patch format.
 
 
@@ -1618,114 +1617,38 @@ Formats Summary {#font-patch-formats-summary}
 
 The following patch formats are defined by this specification:
 
-<table>
-  <tr>
-    <th>Name</th>
-    <th>Format Number</th>
-    <th>Invalidation</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td>[[#brotli]]</td>
-    <td>1</td>
-    <td>[=Full Invalidation=]</td>
-    <td>A brotli encoded binary diff that uses the entire [=font subset=] as a base.</td>
-  </tr>
+* [[#per-table-brotli]]: a collection of brotli encoded binary diffs that use tables from a [=font subset=] as bases.
 
-  <tr>
-    <td>[[#per-table-brotli]]</td>
-    <td>2</td>
-    <td>[=Full Invalidation=]</td>
-    <td>A collection of brotli encoded binary diffs that use tables from the [=font subset=] as bases.</td>
-  </tr>
-  <tr>
-    <td>[[#per-table-brotli]]</td>
-    <td>3</td>
-    <td>[=Partial Invalidation=]</td>
-    <td>A collection of brotli encoded binary diffs that use tables from the [=font subset=] as bases.</td>
-  </tr>
-
-  <tr>
-    <td>[[#glyph-keyed]]</td>
-    <td>4</td>
-    <td>[=No Invalidation=]</td>
-    <td>Contains a collection of opaque binary blobs, each associated with a glyph id and table.</td>
-  </tr>
-</table>
+* [[#glyph-keyed]]: a collection of opaque binary blobs, each associated with a glyph id and table.
 
 More detailed descriptions of each algorithm can be found in the following sections.
 
-Brotli Patch {#brotli}
-------------------------------------
+The following format numbers are used to identify the patch format and invalidation mode in the [[#patch-map-table]]:
 
-In a brotli patch the target file is encoded with [[!RFC7932|brotli compression]] using the
-source file as a [[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. A brotli encoded patch consists
-of a short header followed by brotli encoded data.
-
-<dfn>Brotli patch</dfn> encoding:
 <table>
   <tr>
-    <th>Type</th><th>Name</th><th>Description</th>
+    <th>Format Number</th>
+    <th>Name</th>
+    <th>Invalidation</th>
+  </tr>
+
+  <tr>
+    <td>1</td>
+    <td>[[#per-table-brotli]]</td>
+    <td>[=Full Invalidation=]</td>
   </tr>
   <tr>
-    <td>Tag</td>
-    <td><dfn for="Brotli patch">format</dfn></td>
-    <td>Identifies the encoding as brotli, set to 'ifbr'</td>
+    <td>2</td>
+    <td>[[#per-table-brotli]]</td>
+    <td>[=Partial Invalidation=]</td>
   </tr>
+
   <tr>
-    <td>uint32</td>
-    <td>reserved</td>
-    <td>Reserved for future use, set to 0.</td>
-  </tr>
-  <tr>
-    <td>uint32</td>
-    <td><dfn for="Brotli patch">compatibilityId</dfn>[4]</td>
-    <td>The compatibility id of the [=font subset=] which this patch can be applied too. See [[#font-patch-invalidations]].</td>
-  </tr>
-  <tr>
-    <td>uint32</td>
-    <td>length</td>
-    <td>The uncompressed length of [=Brotli patch/brotliStream=].</td>
-  </tr>
-  <tr>
-    <td>uint8</td>
-    <td><dfn for="Brotli patch">brotliStream</dfn>[variable]</td>
-    <td>Brotli encoded byte stream.</td>
+    <td>3</td>
+    <td>[[#glyph-keyed]]</td>
+    <td>[=No Invalidation=]</td>
   </tr>
 </table>
-
-<h4 algorithm id="apply-brotli">Applying Brotli Patches</h4>
-
-This [=patch application algorithm=] is used to apply a brotli patch to extend a [=font subset=] to cover additional code points,
-features, and/or design-variation space.
-
-<dfn abstract-op>Apply brotli patch</dfn>
-
-The inputs to this algorithm are:
-
-* <var>base font subset</var>: a [=font subset=] which is to be extended.
-
-* <var>patch</var>: a [=brotli patch=] to be applied to <var>base font subset</var>.
-
-* <var>compatibility id</var>: The compatibility ID from the 'IFT ' or 'IFTX' table of <var>base font subset</var> which listed this patch.
-
-The algorithm outputs:
-
-* <var>extended font subset</var>: a [=font subset=] that has been extended by the <var>patch</var>.
-
-The algorithm:
-
-1. Check that the [=Brotli patch/format=] field in <var>patch</var> is equal to 'ifbr', if it is
-    not equal, then <var>patch</var> is not correctly formatted. Patch application has failed, return
-    an error.
-
-2. Check that the [=Brotli patch/compatibilityId=] field in <var>patch</var> is equal to  <var>compatibility id</var>.
-    If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
-    has failed, return an error.
-
-3. Decode the brotli encoded data in [=Brotli patch/brotliStream=] following [[RFC7932#section-10]] and
-    using the <var>base font subset</var> as a [[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. Return the decoded
-    result as the <var>extended font subset</var>
 
 Per Table Brotli {#per-table-brotli}
 --------------------------------------------------
@@ -2086,33 +2009,21 @@ is based on the experience of building an encoder implementation during developm
 understanding (at the time of writing) of how to generate a high performance encoding which meets requirements 1 through 4 of
 [[#encoding]] and thus preserves all functionality/behavior of the original font being encoded.
 
-<b>About [[#brotli]] and [[#per-table-brotli]] patches</b>
-
-A [[#brotli]] patch changes the content of an initial [=incremental font=] or subsequently updated font on a whole-file basis.
-This type of patch is therefore more or less incompatible with the [[#glyph-keyed]] patch type, although in theory a [[#brotli]]
-patch could add support for [[#glyph-keyed]] patches. [[#brotli]] patches also tend to mix poorly with [[#per-table-brotli]] patches.
-Therefore, a [[#brotli]] patch will typically mix only with other [[#brotli]] patches and will be [=Full Invalidation|Fully
-Invalidiating=], as the application of a [[#brotli]] patch only yields the right result relative to a specific file content.
+<b>About [[#per-table-brotli]] patches</b>
 
 A [[#per-table-brotli]] patch can change the contents of some font tables and not others. Each patched table typically needs to be
 relative to a specific table content, but other tables can have different contents. Therefore as long as a [[#per-table-brotli]]
 patch does not alter the tables containing glyph data it can be compatible with [[#glyph-keyed]] patches and therefore be only
 [=Partial Invalidation|Partially Invalidating=] (in that it will invalidate other [[#per-table-brotli]] patches but not
-[[#glyph-keyed]] patches.
-
-Generally speaking the advantage of a [[#brotli]] patch over a [[#per-table-brotli]] patch is that the content of the patch is
-compressed together, and can use the full content of the file it patches as a compression "dictionary". The typical advantage
-of a [[#per-table-brotli]] patch over a [[#brotli]] patch is that it can be compatible with [[#glyph-keyed]] patches. The patch
-types leave the possibility of less typical patterns open. For example, one could use [[#per-table-brotli]] patches for all
+[[#glyph-keyed]] patches. Additionally two sets of [[#per-table-brotli]] patches can be independent of each other if they do not
+modify any of the same tables.  For example, one could use [[#per-table-brotli]] patches for all
 content other than the glyph tables but then use another set of [[#per-table-brotli]] patches for those tables rather than
 [[#glyph-keyed]] patches, and each of these could in theory be [=Partial Invalidation|Partially Invalidating=]—leaving them
 mutually dependent but independent of one another.
 
-The two patch types are similar in that they are at least [=Partial Invalidation|Partially Invaliding=], so that the choice of
-one from a table (IFT or IFTX) means that all others in that table are invalidated.  Assuming the patched result does not
-represent the fully expanded font, that patch will typically alter the IFT or IFTX table it was was listed in to add a new set
-of patches to further extend the font. This means that the total set of [[#brotli]] or [[#per-table-brotli]] patches forms a graph,
-in which each font subset in the segmentation is a node and each patch is an edge.  This also means that patches of these types
+An application of a [[#per-table-brotli]] patch will typically alter the IFT or IFTX table it was was listed in to add a new set
+of patches to further extend the font. This means that the total set of [[#per-table-brotli]] patches forms a graph,
+in which each font subset in the segmentation is a node and each patch is an edge. This also means that patches of these types
 are typically downloaded and applied in series, which has implications for the performance of this patch type relative to latency.
 
 <b>About [[#glyph-keyed]] patches</b>
@@ -2125,8 +2036,8 @@ which can significantly reduce the number of round trips needed relative to the 
 
 <b>Choosing patch formats for an encoding</b>
 
-All encodings must chose one or more patch types to use. [[#brotli]] and [[#per-table-brotli]] patches allow
-all types of data in the font to be patched, but because these types are at least [=Partial Invalidation|Partially Invalidating=],
+All encodings must chose one or more patch types to use. [[#per-table-brotli]] patches allow
+all types of data in the font to be patched, but because this type is at least [=Partial Invalidation|Partially Invalidating=],
 the total number of patches needed increases exponentially with the number of segments rather than linearly. [[#glyph-keyed]] patches
 are limited to updating outline and variation delta data but the number needed scales linearly with number of segments.
 
@@ -2136,8 +2047,8 @@ content requires multiple segments then, multiple network round trips may be nee
 invalidating and the patches can be fetched in parallel, needing only a single round trip.
 
 At the extremes the two types of Brotli patches are most appropriate for fonts with sizable non-outline data that only require a
-small number of patches, with the [[#brotli]] type providing better compression. Glyph keyed patches are most appropriate for
-fonts where the vast majority of data consists of glyph outlines, which is true of many existing CJK fonts.
+small number of patches. Glyph keyed patches are most appropriate for fonts where the vast majority of data consists of glyph outlines,
+which is true of many existing CJK fonts.
 
 For fonts that are in-between, or in cases where fine-grained segmentation of glyph data is desired but segmentation of data
 in other tables is still needed, it can be desirable to mix the [[#per-table-brotli]] and [[#glyph-keyed]] patch types in this
@@ -2215,7 +2126,7 @@ The next two subsections discuss maintaining functional equivalent using the dif
 
 <b>Brotli patches</b>
 
-When preparing [[#brotli]] or [[#per-table-brotli]] patches, one means of achieving functional equivalence is to leverage an
+When preparing [[#per-table-brotli]] patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.
 

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="b0fe8556e0a5bbadabfa30a65c33328d03d9e1ce" name="revision">
+  <meta content="9a847d01678cd3d42cade08c8c9bb0b91e2591e0" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2324,7 +2324,7 @@ is based on the experience of building an encoder implementation during developm
 understanding (at the time of writing) of how to generate a high performance encoding which meets requirements 1 through 4 of <a href="#encoding">§ 7 Encoding</a> and thus preserves all functionality/behavior of the original font being encoded.</p>
    <p><b>About <a href="#table-keyed">§ 6.2 Table Keyed</a> patches</b></p>
    <p>A <a href="#table-keyed">§ 6.2 Table Keyed</a> patch can change the contents of some font tables and not others. Each patched table typically needs to be
-relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#table-keyed">§ 6.2 Table Keyed</a> patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches and therefore be only <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation④">Partially Invalidating</a> (in that it will invalidate other <a href="#table-keyed">§ 6.2 Table Keyed</a> patches but not <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches. Additionally two sets of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches can be independent of each other if they do not
+relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#table-keyed">§ 6.2 Table Keyed</a> patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches and therefore be only <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation④">Partially Invalidating</a> (in that it will invalidate other <a href="#table-keyed">§ 6.2 Table Keyed</a> patches but not <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches). Additionally two sets of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches can be independent of each other if they do not
 modify any of the same tables.  For example, one could use <a href="#table-keyed">§ 6.2 Table Keyed</a> patches for all
 content other than the glyph tables but then use another set of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches for those tables rather than <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches, and each of these could in theory be <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑤">Partially Invalidating</a>—leaving them
 mutually dependent but independent of one another.</p>
@@ -2347,8 +2347,8 @@ are limited to updating outline and variation delta data but the number needed s
 get patches for typical content. For invalidating patch types it is necessary to make patch requests in series. This means that if some
 content requires multiple segments then, multiple network round trips may be needed. Glyph keyed patches on the other hand are not
 invalidating and the patches can be fetched in parallel, needing only a single round trip.</p>
-   <p>At the extremes of the two types of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches are most appropriate for fonts with sizable non-outline data that only require a
-small number of patches. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches are most appropriate for fonts where the vast majority of data consists of glyph
+   <p>At the extremes of the two types, <a href="#table-keyed">§ 6.2 Table Keyed</a> patches, are most appropriate for fonts with sizable non-outline data that only require
+a small number of patches. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches are most appropriate for fonts where the vast majority of data consists of glyph
 outlines, which is true of many existing CJK fonts.</p>
    <p>For fonts that are in-between, or in cases where fine-grained segmentation of glyph data is desired but segmentation of data
 in other tables is still needed, it can be desirable to mix the <a href="#table-keyed">§ 6.2 Table Keyed</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patch types in this

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="14ee493423ba5ef97fa6ef88b6b07a400bcbf5d8" name="revision">
+  <meta content="b3754b901cdd23134c80a82208abea49a185748d" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -728,9 +728,9 @@ be loaded over multiple requests where each request incrementally adds additiona
      <ol class="toc">
       <li><a href="#font-patch-formats-summary"><span class="secno">6.1</span> <span class="content">Formats Summary</span></a>
       <li>
-       <a href="#per-table-brotli"><span class="secno">6.2</span> <span class="content">Per Table Brotli</span></a>
+       <a href="#per-table"><span class="secno">6.2</span> <span class="content">Per Table</span></a>
        <ol class="toc">
-        <li><a href="#apply-per-table-brotli"><span class="secno">6.2.1</span> <span class="content">Applying Per Table Brotli Patches</span></a>
+        <li><a href="#apply-per-table"><span class="secno">6.2.1</span> <span class="content">Applying Per Table Patches</span></a>
        </ol>
       <li>
        <a href="#glyph-keyed"><span class="secno">6.3</span> <span class="content">Glyph Keyed</span></a>
@@ -1162,7 +1162,7 @@ is taken. If an incremental font will be encoded by WOFF2 for transfer:</p>
    <ol>
     <li data-md>
      <p>If the WOFF2 encoding will include a transformed glyf and loca table (<a href="https://www.w3.org/TR/WOFF2/#glyf_table_format"><cite>WOFF 2.0</cite> § 5.1 Transformed glyf table format</a>) then, the incremental
- font should not contain <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches which modify either the glyf or loca table. The WOFF2 format does not
+ font should not contain <a href="#per-table">§ 6.2 Per Table</a> patches which modify either the glyf or loca table. The WOFF2 format does not
  guarantee the specific bytes that result from decoding a transformed glyf and loca table. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches may be used
  in conjunction with a transformed glyf and loca table.</p>
     <li data-md>
@@ -2003,7 +2003,7 @@ encoding can make use of more than one patch format.</p>
    <p>The following patch formats are defined by this specification:</p>
    <ul>
     <li data-md>
-     <p><a href="#per-table-brotli">§ 6.2 Per Table Brotli</a>: a collection of brotli encoded binary diffs that use tables from a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as bases.</p>
+     <p><a href="#per-table">§ 6.2 Per Table</a>: a collection of brotli encoded binary diffs that use tables from a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as bases.</p>
     <li data-md>
      <p><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a>: a collection of opaque binary blobs, each associated with a glyph id and table.</p>
    </ul>
@@ -2017,22 +2017,22 @@ encoding can make use of more than one patch format.</p>
       <th>Invalidation
      <tr>
       <td>1
-      <td><a href="#per-table-brotli">§ 6.2 Per Table Brotli</a>
+      <td><a href="#per-table">§ 6.2 Per Table</a>
       <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation③">Full Invalidation</a>
      <tr>
       <td>2
-      <td><a href="#per-table-brotli">§ 6.2 Per Table Brotli</a>
+      <td><a href="#per-table">§ 6.2 Per Table</a>
       <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation③">Partial Invalidation</a>
      <tr>
       <td>3
       <td><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a>
       <td><a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation①">No Invalidation</a>
    </table>
-   <h3 class="heading settled" data-level="6.2" id="per-table-brotli"><span class="secno">6.2. </span><span class="content">Per Table Brotli</span><a class="self-link" href="#per-table-brotli"></a></h3>
-   <p>A per table brotli patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A per table brotli encoded patch consists of a short header followed
+   <h3 class="heading settled" data-level="6.2" id="per-table"><span class="secno">6.2. </span><span class="content">Per Table</span><a class="self-link" href="#per-table"></a></h3>
+   <p>A per table patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A per table encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
 or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch">Per table brotli patch</dfn> encoding:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="per-table-patch">Per table patch</dfn> encoding:</p>
    <table>
     <tbody>
      <tr>
@@ -2041,15 +2041,15 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
       <th>Description
      <tr>
       <td>Tag
-      <td><dfn class="dfn-paneled" data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-format">format</dfn>
-      <td>Identifies the encoding as per table brotli, set to 'ifbt'
+      <td><dfn class="dfn-paneled" data-dfn-for="Per table patch" data-dfn-type="dfn" data-noexport id="per-table-patch-format">format</dfn>
+      <td>Identifies the encoding as per table, set to 'ifpt'
      <tr>
       <td>uint32
       <td>reserved
       <td>Reserved for future use, set to 0.
      <tr>
       <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-compatibilityid">compatibilityId</dfn>[4]
+      <td><dfn class="dfn-paneled" data-dfn-for="Per table patch" data-dfn-type="dfn" data-noexport id="per-table-patch-compatibilityid">compatibilityId</dfn>[4]
       <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint16
@@ -2057,10 +2057,10 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
       <td>The number of entries in the patches array.
      <tr>
       <td>Offset32
-      <td><dfn class="dfn-paneled" data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-patches">patches</dfn>[patchesCount+1]
+      <td><dfn class="dfn-paneled" data-dfn-for="Per table patch" data-dfn-type="dfn" data-noexport id="per-table-patch-patches">patches</dfn>[patchesCount+1]
       <td>Each entry is an offset from the start of this table to a <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch">TablePatch</a>. Offsets must be sorted in ascending order.
    </table>
-   <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches">patches</a> array gives the size
+   <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches">patches</a> array gives the size
 of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">TablePatch</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="tablepatch">TablePatch</dfn> encoding:</p>
    <table>
@@ -2086,16 +2086,16 @@ of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">Ta
       <td><dfn class="dfn-paneled" data-dfn-for="TablePatch" data-dfn-type="dfn" data-noexport id="tablepatch-brotlistream">brotliStream</dfn>[variable]
       <td>Brotli encoded byte stream.
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Brotli Patches" data-level="6.2.1" id="apply-per-table-brotli"><span class="secno">6.2.1. </span><span class="content">Applying Per Table Brotli Patches</span><a class="self-link" href="#apply-per-table-brotli"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a per table brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> to cover additional code points,
+   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Patches" data-level="6.2.1" id="apply-per-table"><span class="secno">6.2.1. </span><span class="content">Applying Per Table Patches</span><a class="self-link" href="#apply-per-table"></a></h4>
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a per table patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> to cover additional code points,
 features, and/or design-variation space.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</dfn></p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-per-table-patch">Apply per table patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
      <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> which is to be extended.</p>
     <li data-md>
-     <p><var>patch</var>: a <a data-link-type="dfn" href="#per-table-brotli-patch" id="ref-for-per-table-brotli-patch">per table brotli patch</a> to be applied to <var>base font subset</var>.</p>
+     <p><var>patch</var>: a <a data-link-type="dfn" href="#per-table-patch" id="ref-for-per-table-patch">per table patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
      <p><var>compatibility id</var>: The ID number from the 'IFT ' or 'IFTX' table of <var>base font subset</var> which listed this patch.</p>
    </ul>
@@ -2109,11 +2109,11 @@ features, and/or design-variation space.</p>
     <li data-md>
      <p>Initialize <var>extended font subset</var> to be an empty font with no tables.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#per-table-brotli-patch-format" id="ref-for-per-table-brotli-patch-format">format</a> field in <var>patch</var> is equal to 'ifbt', if it is
+     <p>Check that the <a data-link-type="dfn" href="#per-table-patch-format" id="ref-for-per-table-patch-format">format</a> field in <var>patch</var> is equal to 'ifpt', if it is
 not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
 an error.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#per-table-brotli-patch-compatibilityid" id="ref-for-per-table-brotli-patch-compatibilityid">compatibilityId</a> field in <var>patch</var> is equal to <var>compatibility id</var>.
+     <p>Check that the <a data-link-type="dfn" href="#per-table-patch-compatibilityid" id="ref-for-per-table-patch-compatibilityid">compatibilityId</a> field in <var>patch</var> is equal to <var>compatibility id</var>.
 If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
 has failed, return an error.</p>
     <li data-md>
@@ -2122,15 +2122,15 @@ inserting a new entry into the <a href="https://docs.microsoft.com/en-us/typogra
 type specification. That entry includes a checksum for the table data. When an existing table is copied unmodified, the client
 can re-use the checksum from the entry in the source font. Otherwise a new checksum will need to be computed.</p>
     <li data-md>
-     <p>For each entry in <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches①">patches</a>, with index <var>i</var>:</p>
+     <p>For each entry in <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches①">patches</a>, with index <var>i</var>:</p>
      <ul>
       <li data-md>
-       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch②">TablePatch</a> associated with index <var>i</var>. The object starts at the offset <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches②">patches[i]</a> (inclusive) and ends at the offset <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
+       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch②">TablePatch</a> associated with index <var>i</var>. The object starts at the offset <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches②">patches[i]</a> (inclusive) and ends at the offset <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
 the <var>patch</var>.</p>
       <li data-md>
-       <p>If an entry in <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches④">patches</a> was previously applied that has the same <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag">tag</a> as
+       <p>If an entry in <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches④">patches</a> was previously applied that has the same <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag">tag</a> as
 this entry, then ignore this entry and continue the iteration to the next one. Entries are processed in same order as they
-are listed in the <a data-link-type="dfn" href="#per-table-brotli-patch-patches" id="ref-for-per-table-brotli-patch-patches⑤">patches</a> array.</p>
+are listed in the <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches⑤">patches</a> array.</p>
       <li data-md>
        <p>If bit 0 (least significant bit) of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags">flags</a> is set, then decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream①">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a>. No shared dictionary is used. Add a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag①">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream②">brotliStream</a>.</p>
       <li data-md>
@@ -2322,14 +2322,14 @@ guidance that encoder implementations may want to consider, and that can be impo
 an existing font file when producing an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑤">incremental</a> version of that font. The guidance provided in this section
 is based on the experience of building an encoder implementation during development of this specification. It represents the  best
 understanding (at the time of writing) of how to generate a high performance encoding which meets requirements 1 through 4 of <a href="#encoding">§ 7 Encoding</a> and thus preserves all functionality/behavior of the original font being encoded.</p>
-   <p><b>About <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches</b></p>
-   <p>A <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patch can change the contents of some font tables and not others. Each patched table typically needs to be
-relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches and therefore be only <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation④">Partially Invalidating</a> (in that it will invalidate other <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches but not <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches. Additionally two sets of <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches can be independent of each other if they do not
-modify any of the same tables.  For example, one could use <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches for all
-content other than the glyph tables but then use another set of <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches for those tables rather than <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches, and each of these could in theory be <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑤">Partially Invalidating</a>—leaving them
+   <p><b>About <a href="#per-table">§ 6.2 Per Table</a> patches</b></p>
+   <p>A <a href="#per-table">§ 6.2 Per Table</a> patch can change the contents of some font tables and not others. Each patched table typically needs to be
+relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#per-table">§ 6.2 Per Table</a> patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches and therefore be only <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation④">Partially Invalidating</a> (in that it will invalidate other <a href="#per-table">§ 6.2 Per Table</a> patches but not <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches. Additionally two sets of <a href="#per-table">§ 6.2 Per Table</a> patches can be independent of each other if they do not
+modify any of the same tables.  For example, one could use <a href="#per-table">§ 6.2 Per Table</a> patches for all
+content other than the glyph tables but then use another set of <a href="#per-table">§ 6.2 Per Table</a> patches for those tables rather than <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches, and each of these could in theory be <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑤">Partially Invalidating</a>—leaving them
 mutually dependent but independent of one another.</p>
-   <p>An application of a <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patch will typically alter the IFT or IFTX table it was was listed in to add a new set
-of patches to further extend the font. This means that the total set of <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches forms a graph,
+   <p>An application of a <a href="#per-table">§ 6.2 Per Table</a> patch will typically alter the IFT or IFTX table it was was listed in to add a new set
+of patches to further extend the font. This means that the total set of <a href="#per-table">§ 6.2 Per Table</a> patches forms a graph,
 in which each font subset in the segmentation is a node and each patch is an edge. This also means that patches of these types
 are typically downloaded and applied in series, which has implications for the performance of this patch type relative to latency.</p>
    <p><b>About <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches</b></p>
@@ -2339,7 +2339,7 @@ other font table data in the initial font file. Second, <a href="#glyph-keyed">�
 and can therefore be downloaded and applied independently. This independence means multiple patches can be downloaded in parallel
 which can significantly reduce the number of round trips needed relative to the invalidating patch types.</p>
    <p><b>Choosing patch formats for an encoding</b></p>
-   <p>All encodings must chose one or more patch types to use. <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches allow
+   <p>All encodings must chose one or more patch types to use. <a href="#per-table">§ 6.2 Per Table</a> patches allow
 all types of data in the font to be patched, but because this type is at least <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑥">Partially Invalidating</a>,
 the total number of patches needed increases exponentially with the number of segments rather than linearly. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches
 are limited to updating outline and variation delta data but the number needed scales linearly with number of segments.</p>
@@ -2347,21 +2347,21 @@ are limited to updating outline and variation delta data but the number needed s
 get patches for typical content. For invalidating patch types it is necessary to make patch requests in series. This means that if some
 content requires multiple segments then, multiple network round trips may be needed. Glyph keyed patches on the other hand are not
 invalidating and the patches can be fetched in parallel, needing only a single round trip.</p>
-   <p>At the extremes the two types of Brotli patches are most appropriate for fonts with sizable non-outline data that only require a
-small number of patches. Glyph keyed patches are most appropriate for fonts where the vast majority of data consists of glyph outlines,
-which is true of many existing CJK fonts.</p>
+   <p>At the extremes of the two types of <a href="#per-table">§ 6.2 Per Table</a> patches are most appropriate for fonts with sizable non-outline data that only require a
+small number of patches. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches are most appropriate for fonts where the vast majority of data consists of glyph
+outlines, which is true of many existing CJK fonts.</p>
    <p>For fonts that are in-between, or in cases where fine-grained segmentation of glyph data is desired but segmentation of data
-in other tables is still needed, it can be desirable to mix the <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patch types in this
+in other tables is still needed, it can be desirable to mix the <a href="#per-table">§ 6.2 Per Table</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patch types in this
 way:</p>
    <ol>
     <li data-md>
-     <p>Keep all brotli patch entries in one mapping table and all glyph keyed entries in the other mapping table.</p>
+     <p>Keep all per table patch entries in one mapping table and all glyph keyed entries in the other mapping table.</p>
     <li data-md>
-     <p>Use per-table brotli patches to update all tables except for the tables touched by the glyph keyed patches (outline,
+     <p>Use per table patches to update all tables except for the tables touched by the glyph keyed patches (outline,
 variation deltas, and the glyph keyed patch mapping table). These patches should use a small number of large segments to keep
 the patch count reasonable.</p>
     <li data-md>
-     <p>Because glyph keyed patches reference the specific glyph IDs that are updated, the per-table brotli patches must not change
+     <p>Because glyph keyed patches reference the specific glyph IDs that are updated, the per table patches must not change
 the glyph to glyph ID assignments used in the original font; otherwise, the glyph IDs listed in the glyph keyed patches may
 become incorrect. In font subsetters this is often available as an option called "retain glyph IDs".</p>
     <li data-md>
@@ -2377,7 +2377,7 @@ A, B, C, and D. The patch table could list patches that add: A, B, C, D, A + B, 
 allow any two segments to be added in a single round trip. The downside to this approach is that it further increases the number of unique
 patches needed.</p>
    <p><b>Managing the number of patches</b></p>
-   <p>Using brotli patches along side a large number of segments can result in a very large number of patches needed, which can have two
+   <p>Using <a href="#per-table">§ 6.2 Per Table</a> patches along side a large number of segments can result in a very large number of patches needed, which can have two
 negative effects. First, the storage space needed for all of the pre-generated patches could be undesirably large. Second, more 
 patches will generally mean lower CDN cache performance, because a higher number of patches represents a higher number of paths
 from a given subset to a given subset, with different paths being taken by different users depending on the content they access.
@@ -2415,8 +2415,8 @@ optional in the encoding of a font.</p>
    <p>As discussed in <a href="#encoding">§ 7 Encoding</a> an encoder should preserve the functionality of the original font. Fonts are complex
 and often contain interactions between code points so maintaining functional equivalence with a partial copy of the font can be tricky.
 The next two subsections discuss maintaining functional equivalent using the different patch types.</p>
-   <p><b>Brotli patches</b></p>
-   <p>When preparing <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches, one means of achieving functional equivalence is to leverage an
+   <p><b>Per table patches</b></p>
+   <p>When preparing <a href="#per-table">§ 6.2 Per Table</a> patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.</p>
    <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a>. The practice of reliably
@@ -2424,7 +2424,7 @@ subsetting a font is well understood and has multiple open-source implementation
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
 Any reachable data is retained in the generated font subset, while any unreachable data may be removed.</p>
-   <p>In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only Brotli patches:</p>
+   <p>In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only per table patches:</p>
 <pre># Encode a font (full_font) into an incremental font that starts at base_subset_def
 # and can incrementally add any of subset_definitions. Returns the IFT encoded font
 # and set of associated patches.
@@ -2450,7 +2450,7 @@ encode_node(full_font, base_font, cur_def, subset_definitions):
     next_fonts += (next_font, next_def, patch_url)
 
   for each (next_font, next_def, patch_url) in next_fonts:
-    patch = brotli_patch_diff(base_font, next_font)
+    patch = per_table_patch_diff(base_font, next_font)
     patches += (patch, patch_url)
   
   return base_font, patches
@@ -2517,7 +2517,7 @@ same set.</p>
 the file. Encoders should consider placing the mapping tables (IFT and IFTX) plus any additional tables needed to decode the
 mapping tables (cmap) as early as possible in the file. This will allow optimized client implementations to access the 
 patch mapping prior to receiving all of the font data and potentially initiate requests for any required patches earlier.</p>
-   <p>Likewise per table brotli patches have a separate brotli stream for each patched table and the format allows these streams to be placed
+   <p>Likewise per table patches have a separate brotli stream for each patched table and the format allows these streams to be placed
 in any order in the patch file. So for the same reasons encoders should consider placing updates to the mapping tables plus any
 additional tables needed to decode the mapping tables as early as possible in the patch file.</p>
    <p><b>Choosing the input ID encoding</b></p>
@@ -2850,7 +2850,7 @@ to be used by default in most shaper implementations. This list was assembled fr
   <ul class="index">
    <li><a href="#format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a><span>, in § 5.2.1</span>
    <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 6.3.1</span>
-   <li><a href="#abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</a><span>, in § 6.2.1</span>
+   <li><a href="#abstract-opdef-apply-per-table-patch">Apply per table patch</a><span>, in § 6.2.1</span>
    <li><a href="#mapping-entry-bias">bias</a><span>, in § 5.2.2</span>
    <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 5.2.2.3</span>
    <li>
@@ -2867,7 +2867,7 @@ to be used by default in most shaper implementations. This list was assembled fr
      <li><a href="#format-1-patch-map-compatibilityid">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#format-2-patch-map-compatibilityid">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
      <li><a href="#glyph-keyed-patch-compatibilityid">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
-     <li><a href="#per-table-brotli-patch-compatibilityid">dfn for Per table brotli patch</a><span>, in § 6.2</span>
+     <li><a href="#per-table-patch-compatibilityid">dfn for Per table patch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#mapping-entry-copycount">copyCount</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 5.2.2</span>
@@ -2917,7 +2917,7 @@ to be used by default in most shaper implementations. This list was assembled fr
      <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
      <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
-     <li><a href="#per-table-brotli-patch-format">dfn for Per table brotli patch</a><span>, in § 6.2</span>
+     <li><a href="#per-table-patch-format">dfn for Per table patch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 5.2.1</span>
    <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 5.2.2</span>
@@ -2957,11 +2957,11 @@ to be used by default in most shaper implementations. This list was assembled fr
      <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 5.2.2</span>
     </ul>
-   <li><a href="#per-table-brotli-patch-patches">patches</a><span>, in § 6.2</span>
+   <li><a href="#per-table-patch-patches">patches</a><span>, in § 6.2</span>
    <li><a href="#patch-format">patch format</a><span>, in § 3.2</span>
    <li><a href="#patch-map">patch map</a><span>, in § 3.3</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
-   <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 6.2</span>
+   <li><a href="#per-table-patch">Per table patch</a><span>, in § 6.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.2.1.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 5.2.2.2</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.2.2.3</span>
@@ -3223,7 +3223,7 @@ function parseHTML(markup) {
 {
 let dfnPanelData = {
 "abstract-opdef-apply-glyph-keyed-patch": {"dfnID":"abstract-opdef-apply-glyph-keyed-patch","dfnText":"Apply glyph keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-glyph-keyed-patch"},
-"abstract-opdef-apply-per-table-brotli-patch": {"dfnID":"abstract-opdef-apply-per-table-brotli-patch","dfnText":"Apply per table brotli patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-per-table-brotli-patch"},
+"abstract-opdef-apply-per-table-patch": {"dfnID":"abstract-opdef-apply-per-table-patch","dfnText":"Apply per table patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-per-table-patch"},
 "abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.4. Fully Expanding a Font"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
 "abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
@@ -3251,7 +3251,7 @@ let dfnPanelData = {
 "featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"},{"id":"ref-for-featurerecord-featuretag\u2461"},{"id":"ref-for-featurerecord-featuretag\u2462"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
 "featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"},{"id":"ref-for-featurerecord-firstnewentryindex\u2460"},{"id":"ref-for-featurerecord-firstnewentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
-"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.2. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"}],"title":"6.2.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"},{"id":"ref-for-font-subset\u2461\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
+"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.2. Per Table"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"}],"title":"6.2.1. Applying Per Table Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"},{"id":"ref-for-font-subset\u2461\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
 "font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2463"},{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"},{"id":"ref-for-font-subset-definition\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u24ea"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"},{"id":"ref-for-font-subset-definition\u2460\u2462"},{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
@@ -3305,19 +3305,19 @@ let dfnPanelData = {
 "mapping-entry-patchencoding": {"dfnID":"mapping-entry-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchencoding"},{"id":"ref-for-mapping-entry-patchencoding\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchencoding"},
 "no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-no-invalidation\u2461"}],"title":"7.1. Encoding Considerations"}],"url":"#no-invalidation"},
 "partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"},{"id":"ref-for-partial-invalidation\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2463"},{"id":"ref-for-partial-invalidation\u2464"},{"id":"ref-for-partial-invalidation\u2465"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
-"patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
+"patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Per Table Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
 "patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2461"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map"},
 "patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2460"},{"id":"ref-for-patch-map-entries\u2461"},{"id":"ref-for-patch-map-entries\u2462"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"},{"id":"ref-for-patch-map-entries\u2467"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"},{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map-entries"},
-"per-table-brotli-patch": {"dfnID":"per-table-brotli-patch","dfnText":"Per table brotli patch","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch"},
-"per-table-brotli-patch-compatibilityid": {"dfnID":"per-table-brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-compatibilityid"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-compatibilityid"},
-"per-table-brotli-patch-format": {"dfnID":"per-table-brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-format"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-format"},
-"per-table-brotli-patch-patches": {"dfnID":"per-table-brotli-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-patches"}],"title":"6.2. Per Table Brotli"},{"refs":[{"id":"ref-for-per-table-brotli-patch-patches\u2460"},{"id":"ref-for-per-table-brotli-patch-patches\u2461"},{"id":"ref-for-per-table-brotli-patch-patches\u2462"},{"id":"ref-for-per-table-brotli-patch-patches\u2463"},{"id":"ref-for-per-table-brotli-patch-patches\u2464"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-patches"},
+"per-table-patch": {"dfnID":"per-table-patch","dfnText":"Per table patch","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-patch"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#per-table-patch"},
+"per-table-patch-compatibilityid": {"dfnID":"per-table-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-patch-compatibilityid"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#per-table-patch-compatibilityid"},
+"per-table-patch-format": {"dfnID":"per-table-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-patch-format"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#per-table-patch-format"},
+"per-table-patch-patches": {"dfnID":"per-table-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-patch-patches"}],"title":"6.2. Per Table"},{"refs":[{"id":"ref-for-per-table-patch-patches\u2460"},{"id":"ref-for-per-table-patch-patches\u2461"},{"id":"ref-for-per-table-patch-patches\u2462"},{"id":"ref-for-per-table-patch-patches\u2463"},{"id":"ref-for-per-table-patch-patches\u2464"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#per-table-patch-patches"},
 "sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
-"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.2. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch"},
-"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.2. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-brotlistream"},
-"tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-flags"},
-"tablepatch-tag": {"dfnID":"tablepatch-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-tag"},{"id":"ref-for-tablepatch-tag\u2460"},{"id":"ref-for-tablepatch-tag\u2461"},{"id":"ref-for-tablepatch-tag\u2462"},{"id":"ref-for-tablepatch-tag\u2463"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-tag"},
+"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.2. Per Table"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#tablepatch"},
+"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.2. Per Table"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#tablepatch-brotlistream"},
+"tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#tablepatch-flags"},
+"tablepatch-tag": {"dfnID":"tablepatch-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-tag"},{"id":"ref-for-tablepatch-tag\u2460"},{"id":"ref-for-tablepatch-tag\u2461"},{"id":"ref-for-tablepatch-tag\u2462"},{"id":"ref-for-tablepatch-tag\u2463"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#tablepatch-tag"},
 };
 
 document.addEventListener("DOMContentLoaded", ()=>{
@@ -3790,10 +3790,10 @@ let refsData = {
 "#patch-format": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch format","type":"dfn","url":"#patch-format"},
 "#patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map","type":"dfn","url":"#patch-map"},
 "#patch-map-entries": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map entries","type":"dfn","url":"#patch-map-entries"},
-"#per-table-brotli-patch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"per table brotli patch","type":"dfn","url":"#per-table-brotli-patch"},
-"#per-table-brotli-patch-compatibilityid": {"export":true,"for_":["Per table brotli patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#per-table-brotli-patch-compatibilityid"},
-"#per-table-brotli-patch-format": {"export":true,"for_":["Per table brotli patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#per-table-brotli-patch-format"},
-"#per-table-brotli-patch-patches": {"export":true,"for_":["Per table brotli patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patches","type":"dfn","url":"#per-table-brotli-patch-patches"},
+"#per-table-patch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"per table patch","type":"dfn","url":"#per-table-patch"},
+"#per-table-patch-compatibilityid": {"export":true,"for_":["Per table patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#per-table-patch-compatibilityid"},
+"#per-table-patch-format": {"export":true,"for_":["Per table patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#per-table-patch-format"},
+"#per-table-patch-patches": {"export":true,"for_":["Per table patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patches","type":"dfn","url":"#per-table-patch-patches"},
 "#sparse-bit-set": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"sparse bit set","type":"dfn","url":"#sparse-bit-set"},
 "#tablepatch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"tablepatch","type":"dfn","url":"#tablepatch"},
 "#tablepatch-brotlistream": {"export":true,"for_":["TablePatch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"brotlistream","type":"dfn","url":"#tablepatch-brotlistream"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,6 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
+  <meta content="14ee493423ba5ef97fa6ef88b6b07a400bcbf5d8" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -727,19 +728,14 @@ be loaded over multiple requests where each request incrementally adds additiona
      <ol class="toc">
       <li><a href="#font-patch-formats-summary"><span class="secno">6.1</span> <span class="content">Formats Summary</span></a>
       <li>
-       <a href="#brotli"><span class="secno">6.2</span> <span class="content">Brotli Patch</span></a>
+       <a href="#per-table-brotli"><span class="secno">6.2</span> <span class="content">Per Table Brotli</span></a>
        <ol class="toc">
-        <li><a href="#apply-brotli"><span class="secno">6.2.1</span> <span class="content">Applying Brotli Patches</span></a>
+        <li><a href="#apply-per-table-brotli"><span class="secno">6.2.1</span> <span class="content">Applying Per Table Brotli Patches</span></a>
        </ol>
       <li>
-       <a href="#per-table-brotli"><span class="secno">6.3</span> <span class="content">Per Table Brotli</span></a>
+       <a href="#glyph-keyed"><span class="secno">6.3</span> <span class="content">Glyph Keyed</span></a>
        <ol class="toc">
-        <li><a href="#apply-per-table-brotli"><span class="secno">6.3.1</span> <span class="content">Applying Per Table Brotli Patches</span></a>
-       </ol>
-      <li>
-       <a href="#glyph-keyed"><span class="secno">6.4</span> <span class="content">Glyph Keyed</span></a>
-       <ol class="toc">
-        <li><a href="#apply-glyph-keyed"><span class="secno">6.4.1</span> <span class="content">Applying Glyph Keyed Patches</span></a>
+        <li><a href="#apply-glyph-keyed"><span class="secno">6.3.1</span> <span class="content">Applying Glyph Keyed Patches</span></a>
        </ol>
      </ol>
     <li>
@@ -748,13 +744,13 @@ be loaded over multiple requests where each request incrementally adds additiona
       <li><a href="#encoding-considerations"><span class="secno">7.1</span> <span class="content">Encoding Considerations</span></a>
      </ol>
     <li>
-     <a href="#priv"><span class="secno"></span> <span class="content">Privacy Considerations</span></a>
+     <a href="#priv"><span class="secno">8</span> <span class="content">Privacy Considerations</span></a>
      <ol class="toc">
-      <li><a href="#content-inference-from-character-set"><span class="secno"></span> <span class="content">Content inference from character set</span></a>
-      <li><a href="#per-origin"><span class="secno"></span> <span class="content">Per-origin restriction avoids fingerprinting</span></a>
+      <li><a href="#content-inference-from-character-set"><span class="secno">8.1</span> <span class="content">Content inference from character set</span></a>
+      <li><a href="#per-origin"><span class="secno">8.2</span> <span class="content">Per-origin restriction avoids fingerprinting</span></a>
      </ol>
-    <li><a href="#sec"><span class="secno"></span> <span class="content">Security Considerations</span></a>
-    <li><a href="#changes"><span class="secno"></span> <span class="content">Changes</span></a>
+    <li><a href="#sec"><span class="secno">9</span> <span class="content">Security Considerations</span></a>
+    <li><a href="#changes"><span class="secno">10</span> <span class="content">Changes</span></a>
     <li><a href="#feature-tag-list"><span class="secno"></span> <span class="content"> Appendix A: Default Feature Tags</span></a>
     <li>
      <a href="#w3c-conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
@@ -1165,14 +1161,10 @@ patch types. For example all patches of one type can be specified in the 'IFT ' 
 is taken. If an incremental font will be encoded by WOFF2 for transfer:</p>
    <ol>
     <li data-md>
-     <p>The incremental font should not make use of <a href="#brotli">§ 6.2 Brotli Patch</a> patches. The WOFF2 format does not guarantee the ordering of tables in
- the decoded font. <a href="#brotli">§ 6.2 Brotli Patch</a> patches are relative to a specific fixed set of bytes and thus cannot be used if the decoded font
- has unpredictable decoded bytes. <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches do not depend on a specific table ordering and may be used.</p>
-    <li data-md>
      <p>If the WOFF2 encoding will include a transformed glyf and loca table (<a href="https://www.w3.org/TR/WOFF2/#glyf_table_format"><cite>WOFF 2.0</cite> § 5.1 Transformed glyf table format</a>) then, the incremental
- font should not contain <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches which modify either the glyf or loca table. The WOFF2 format does not
- guarantee the specific bytes that result from decoding a transformed glyf and loca table, so as with #1 brotli patches cannot
- be used. <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches may be used in conjunction with a transformed glyf and loca table.</p>
+ font should not contain <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches which modify either the glyf or loca table. The WOFF2 format does not
+ guarantee the specific bytes that result from decoding a transformed glyf and loca table. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches may be used
+ in conjunction with a transformed glyf and loca table.</p>
     <li data-md>
      <p>When utilizing a WOFF2 encoded IFT font, the client must first fully decode the WOFF2 font before <a href="#extending-font-subset">§ 4 Extending a Font Subset</a>.</p>
    </ol>
@@ -2005,108 +1997,41 @@ A string ID is a sequence of bytes. Several variables are defined which are used
    </div>
    <h2 class="heading settled" data-level="6" id="font-patch-formats"><span class="secno">6. </span><span class="content">Font Patch Formats</span><a class="self-link" href="#font-patch-formats"></a></h2>
    <p>In incremental font transfer <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subsets</a> are extended by applying patches.
-This specification defines three patch formats, each appropriate to its own set of augmentation scenarios. A single
+This specification defines two patch formats, each appropriate to its own set of augmentation scenarios. A single
 encoding can make use of more than one patch format.</p>
    <h3 class="heading settled" data-level="6.1" id="font-patch-formats-summary"><span class="secno">6.1. </span><span class="content">Formats Summary</span><a class="self-link" href="#font-patch-formats-summary"></a></h3>
    <p>The following patch formats are defined by this specification:</p>
-   <table>
-    <tbody>
-     <tr>
-      <th>Name
-      <th>Format Number
-      <th>Invalidation
-      <th>Description
-     <tr>
-      <td><a href="#brotli">§ 6.2 Brotli Patch</a>
-      <td>1
-      <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation③">Full Invalidation</a>
-      <td>A brotli encoded binary diff that uses the entire <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as a base.
-     <tr>
-      <td><a href="#per-table-brotli">§ 6.3 Per Table Brotli</a>
-      <td>2
-      <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation④">Full Invalidation</a>
-      <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> as bases.
-     <tr>
-      <td><a href="#per-table-brotli">§ 6.3 Per Table Brotli</a>
-      <td>3
-      <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation③">Partial Invalidation</a>
-      <td>A collection of brotli encoded binary diffs that use tables from the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> as bases.
-     <tr>
-      <td><a href="#glyph-keyed">§ 6.4 Glyph Keyed</a>
-      <td>4
-      <td><a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation①">No Invalidation</a>
-      <td>Contains a collection of opaque binary blobs, each associated with a glyph id and table.
-   </table>
+   <ul>
+    <li data-md>
+     <p><a href="#per-table-brotli">§ 6.2 Per Table Brotli</a>: a collection of brotli encoded binary diffs that use tables from a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as bases.</p>
+    <li data-md>
+     <p><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a>: a collection of opaque binary blobs, each associated with a glyph id and table.</p>
+   </ul>
    <p>More detailed descriptions of each algorithm can be found in the following sections.</p>
-   <h3 class="heading settled" data-level="6.2" id="brotli"><span class="secno">6.2. </span><span class="content">Brotli Patch</span><a class="self-link" href="#brotli"></a></h3>
-   <p>In a brotli patch the target file is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the
-source file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A brotli encoded patch consists
-of a short header followed by brotli encoded data.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="brotli-patch">Brotli patch</dfn> encoding:</p>
+   <p>The following format numbers are used to identify the patch format and invalidation mode in the <a href="#patch-map-table">§ 5.2 Patch Map Table</a>:</p>
    <table>
     <tbody>
      <tr>
-      <th>Type
+      <th>Format Number
       <th>Name
-      <th>Description
+      <th>Invalidation
      <tr>
-      <td>Tag
-      <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-format">format</dfn>
-      <td>Identifies the encoding as brotli, set to 'ifbr'
+      <td>1
+      <td><a href="#per-table-brotli">§ 6.2 Per Table Brotli</a>
+      <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation③">Full Invalidation</a>
      <tr>
-      <td>uint32
-      <td>reserved
-      <td>Reserved for future use, set to 0.
+      <td>2
+      <td><a href="#per-table-brotli">§ 6.2 Per Table Brotli</a>
+      <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation③">Partial Invalidation</a>
      <tr>
-      <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
-     <tr>
-      <td>uint32
-      <td>length
-      <td>The uncompressed length of <a data-link-type="dfn" href="#brotli-patch-brotlistream" id="ref-for-brotli-patch-brotlistream">brotliStream</a>.
-     <tr>
-      <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Brotli patch" data-dfn-type="dfn" data-noexport id="brotli-patch-brotlistream">brotliStream</dfn>[variable]
-      <td>Brotli encoded byte stream.
+      <td>3
+      <td><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a>
+      <td><a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation①">No Invalidation</a>
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Brotli Patches" data-level="6.2.1" id="apply-brotli"><span class="secno">6.2.1. </span><span class="content">Applying Brotli Patches</span><a class="self-link" href="#apply-brotli"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> to cover additional code points,
-features, and/or design-variation space.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-brotli-patch">Apply brotli patch</dfn></p>
-   <p>The inputs to this algorithm are:</p>
-   <ul>
-    <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> which is to be extended.</p>
-    <li data-md>
-     <p><var>patch</var>: a <a data-link-type="dfn" href="#brotli-patch" id="ref-for-brotli-patch">brotli patch</a> to be applied to <var>base font subset</var>.</p>
-    <li data-md>
-     <p><var>compatibility id</var>: The compatibility ID from the 'IFT ' or 'IFTX' table of <var>base font subset</var> which listed this patch.</p>
-   </ul>
-   <p>The algorithm outputs:</p>
-   <ul>
-    <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> that has been extended by the <var>patch</var>.</p>
-   </ul>
-   <p>The algorithm:</p>
-   <ol>
-    <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#brotli-patch-format" id="ref-for-brotli-patch-format">format</a> field in <var>patch</var> is equal to 'ifbr', if it is
-not equal, then <var>patch</var> is not correctly formatted. Patch application has failed, return
-an error.</p>
-    <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#brotli-patch-compatibilityid" id="ref-for-brotli-patch-compatibilityid">compatibilityId</a> field in <var>patch</var> is equal to <var>compatibility id</var>.
-If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
-has failed, return an error.</p>
-    <li data-md>
-     <p>Decode the brotli encoded data in <a data-link-type="dfn" href="#brotli-patch-brotlistream" id="ref-for-brotli-patch-brotlistream①">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a> and
-using the <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. Return the decoded
-result as the <var>extended font subset</var></p>
-   </ol>
-   <h3 class="heading settled" data-level="6.3" id="per-table-brotli"><span class="secno">6.3. </span><span class="content">Per Table Brotli</span><a class="self-link" href="#per-table-brotli"></a></h3>
+   <h3 class="heading settled" data-level="6.2" id="per-table-brotli"><span class="secno">6.2. </span><span class="content">Per Table Brotli</span><a class="self-link" href="#per-table-brotli"></a></h3>
    <p>A per table brotli patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A per table brotli encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
-or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a>.</p>
+or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch">Per table brotli patch</dfn> encoding:</p>
    <table>
     <tbody>
@@ -2125,7 +2050,7 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Per table brotli patch" data-dfn-type="dfn" data-noexport id="per-table-brotli-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
+      <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint16
       <td>patchesCount
@@ -2161,14 +2086,14 @@ of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">Ta
       <td><dfn class="dfn-paneled" data-dfn-for="TablePatch" data-dfn-type="dfn" data-noexport id="tablepatch-brotlistream">brotliStream</dfn>[variable]
       <td>Brotli encoded byte stream.
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Brotli Patches" data-level="6.3.1" id="apply-per-table-brotli"><span class="secno">6.3.1. </span><span class="content">Applying Per Table Brotli Patches</span><a class="self-link" href="#apply-per-table-brotli"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm①">patch application algorithm</a> is used to apply a per table brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> to cover additional code points,
+   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Brotli Patches" data-level="6.2.1" id="apply-per-table-brotli"><span class="secno">6.2.1. </span><span class="content">Applying Per Table Brotli Patches</span><a class="self-link" href="#apply-per-table-brotli"></a></h4>
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a per table brotli patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> to cover additional code points,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#per-table-brotli-patch" id="ref-for-per-table-brotli-patch">per table brotli patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -2177,7 +2102,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -2217,7 +2142,7 @@ are listed in the <a data-link-type="dfn" href="#per-table-brotli-patch-patches"
      <p>For each <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> in <var>base font subset</var> which has a tag that was not found in any of
 the entries processed in step 5, add a copy of that table to <var>extended font subset</var>.</p>
    </ol>
-   <h3 class="heading settled" data-level="6.4" id="glyph-keyed"><span class="secno">6.4. </span><span class="content">Glyph Keyed</span><a class="self-link" href="#glyph-keyed"></a></h3>
+   <h3 class="heading settled" data-level="6.3" id="glyph-keyed"><span class="secno">6.3. </span><span class="content">Glyph Keyed</span><a class="self-link" href="#glyph-keyed"></a></h3>
    <p>A glyph keyed patch contains a collection of data chunks that are each associated with a glyph index and a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font table</a>. The encoded data replaces any existing data for that glyph index in the referenced <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>. Glyph keyed patches can encode data for <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a>/<a href="https://docs.microsoft.com/en-us/typography/opentype/spec/loca#">loca</a>, <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/gvar#">gvar</a>, <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cff#">CFF</a>, and <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cff2#">CFF2</a> tables.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-keyed-patch">Glyph keyed patch</dfn> encoding:</p>
    <table>
@@ -2241,7 +2166,7 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Glyph keyed patch" data-dfn-type="dfn" data-noexport id="glyph-keyed-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑤">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
+      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint32
       <td>length
@@ -2286,14 +2211,14 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
    </table>
    <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets">glyphDataOffsets</a> array gives the size
 of that glyph data.</p>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Glyph Keyed Patches" data-level="6.4.1" id="apply-glyph-keyed"><span class="secno">6.4.1. </span><span class="content">Applying Glyph Keyed Patches</span><a class="self-link" href="#apply-glyph-keyed"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm②">patch application algorithm</a> is used to apply a glyph keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑥">font subset</a> to cover additional code points,
+   <h4 class="heading settled algorithm" data-algorithm="Applying Glyph Keyed Patches" data-level="6.3.1" id="apply-glyph-keyed"><span class="secno">6.3.1. </span><span class="content">Applying Glyph Keyed Patches</span><a class="self-link" href="#apply-glyph-keyed"></a></h4>
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm①">patch application algorithm</a> is used to apply a glyph keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> to cover additional code points,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑦">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#glyph-keyed-patch" id="ref-for-glyph-keyed-patch">glyph keyed patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -2304,7 +2229,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑧">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -2369,7 +2294,7 @@ of patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#ab
  expanded may not always be an exact binary match with the existing font.</p>
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font throughout the augmentation process, that is:
- given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⑨">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset④">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a> and the minimal subset definition covering that content should
+ given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset④">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
    </ol>
    <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①④">incremental font</a> and a client is implemented according to the
@@ -2397,45 +2322,36 @@ guidance that encoder implementations may want to consider, and that can be impo
 an existing font file when producing an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑤">incremental</a> version of that font. The guidance provided in this section
 is based on the experience of building an encoder implementation during development of this specification. It represents the  best
 understanding (at the time of writing) of how to generate a high performance encoding which meets requirements 1 through 4 of <a href="#encoding">§ 7 Encoding</a> and thus preserves all functionality/behavior of the original font being encoded.</p>
-   <p><b>About <a href="#brotli">§ 6.2 Brotli Patch</a> and <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches</b></p>
-   <p>A <a href="#brotli">§ 6.2 Brotli Patch</a> patch changes the content of an initial <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑥">incremental font</a> or subsequently updated font on a whole-file basis.
-This type of patch is therefore more or less incompatible with the <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patch type, although in theory a <a href="#brotli">§ 6.2 Brotli Patch</a> patch could add support for <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches. <a href="#brotli">§ 6.2 Brotli Patch</a> patches also tend to mix poorly with <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches.
-Therefore, a <a href="#brotli">§ 6.2 Brotli Patch</a> patch will typically mix only with other <a href="#brotli">§ 6.2 Brotli Patch</a> patches and will be <a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation⑤">Fully
-Invalidiating</a>, as the application of a <a href="#brotli">§ 6.2 Brotli Patch</a> patch only yields the right result relative to a specific file content.</p>
-   <p>A <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patch can change the contents of some font tables and not others. Each patched table typically needs to be
-relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches and therefore be only <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation④">Partially Invalidating</a> (in that it will invalidate other <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches but not <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches.</p>
-   <p>Generally speaking the advantage of a <a href="#brotli">§ 6.2 Brotli Patch</a> patch over a <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patch is that the content of the patch is
-compressed together, and can use the full content of the file it patches as a compression "dictionary". The typical advantage
-of a <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patch over a <a href="#brotli">§ 6.2 Brotli Patch</a> patch is that it can be compatible with <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches. The patch
-types leave the possibility of less typical patterns open. For example, one could use <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches for all
-content other than the glyph tables but then use another set of <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches for those tables rather than <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches, and each of these could in theory be <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑤">Partially Invalidating</a>—leaving them
+   <p><b>About <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches</b></p>
+   <p>A <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patch can change the contents of some font tables and not others. Each patched table typically needs to be
+relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches and therefore be only <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation④">Partially Invalidating</a> (in that it will invalidate other <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches but not <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches. Additionally two sets of <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches can be independent of each other if they do not
+modify any of the same tables.  For example, one could use <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches for all
+content other than the glyph tables but then use another set of <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches for those tables rather than <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches, and each of these could in theory be <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑤">Partially Invalidating</a>—leaving them
 mutually dependent but independent of one another.</p>
-   <p>The two patch types are similar in that they are at least <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑥">Partially Invaliding</a>, so that the choice of
-one from a table (IFT or IFTX) means that all others in that table are invalidated.  Assuming the patched result does not
-represent the fully expanded font, that patch will typically alter the IFT or IFTX table it was was listed in to add a new set
-of patches to further extend the font. This means that the total set of <a href="#brotli">§ 6.2 Brotli Patch</a> or <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches forms a graph,
-in which each font subset in the segmentation is a node and each patch is an edge.  This also means that patches of these types
+   <p>An application of a <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patch will typically alter the IFT or IFTX table it was was listed in to add a new set
+of patches to further extend the font. This means that the total set of <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches forms a graph,
+in which each font subset in the segmentation is a node and each patch is an edge. This also means that patches of these types
 are typically downloaded and applied in series, which has implications for the performance of this patch type relative to latency.</p>
-   <p><b>About <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches</b></p>
-   <p><a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches are quite distinct from the other patch types. First, <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches can only modify
-tables containing glyph outline data, and therefore an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑦">incremental font</a> that only uses <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> must include all
-other font table data in the initial font file. Second, <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches are <a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation②">not Invalidating</a>,
+   <p><b>About <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches</b></p>
+   <p><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches are quite distinct from the other patch types. First, <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches can only modify
+tables containing glyph outline data, and therefore an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑥">incremental font</a> that only uses <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> must include all
+other font table data in the initial font file. Second, <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches are <a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation②">not Invalidating</a>,
 and can therefore be downloaded and applied independently. This independence means multiple patches can be downloaded in parallel
 which can significantly reduce the number of round trips needed relative to the invalidating patch types.</p>
    <p><b>Choosing patch formats for an encoding</b></p>
-   <p>All encodings must chose one or more patch types to use. <a href="#brotli">§ 6.2 Brotli Patch</a> and <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches allow
-all types of data in the font to be patched, but because these types are at least <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑦">Partially Invalidating</a>,
-the total number of patches needed increases exponentially with the number of segments rather than linearly. <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches
+   <p>All encodings must chose one or more patch types to use. <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches allow
+all types of data in the font to be patched, but because this type is at least <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑥">Partially Invalidating</a>,
+the total number of patches needed increases exponentially with the number of segments rather than linearly. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches
 are limited to updating outline and variation delta data but the number needed scales linearly with number of segments.</p>
    <p>In addition to the number of patches, the encoder should also consider the number of network round trips that will be needed to
 get patches for typical content. For invalidating patch types it is necessary to make patch requests in series. This means that if some
 content requires multiple segments then, multiple network round trips may be needed. Glyph keyed patches on the other hand are not
 invalidating and the patches can be fetched in parallel, needing only a single round trip.</p>
    <p>At the extremes the two types of Brotli patches are most appropriate for fonts with sizable non-outline data that only require a
-small number of patches, with the <a href="#brotli">§ 6.2 Brotli Patch</a> type providing better compression. Glyph keyed patches are most appropriate for
-fonts where the vast majority of data consists of glyph outlines, which is true of many existing CJK fonts.</p>
+small number of patches. Glyph keyed patches are most appropriate for fonts where the vast majority of data consists of glyph outlines,
+which is true of many existing CJK fonts.</p>
    <p>For fonts that are in-between, or in cases where fine-grained segmentation of glyph data is desired but segmentation of data
-in other tables is still needed, it can be desirable to mix the <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> and <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patch types in this
+in other tables is still needed, it can be desirable to mix the <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patch types in this
 way:</p>
    <ol>
     <li data-md>
@@ -2477,7 +2393,7 @@ level.</p>
    </ol>
    <p><b>Choosing segmentations</b></p>
    <p>One of the most important and complex decisions an encoder needs to make is how to segment the data in the encoded font. The discussion
-above focused on the number of segments, but the performance of an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑧">incremental font</a> depends much more on the grouping of data
+above focused on the number of segments, but the performance of an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑦">incremental font</a> depends much more on the grouping of data
 within segments. To maximize efficiency an encoder needs to group data (eg. code points) that are commonly used together into the same
 segments. This will reduce the amount of unneeded data load by clients when extending the font. The encoder must also decide the size
 of segments. Smaller segments will produce more patches, and thus incur more overhead by requiring more network requests, but will
@@ -2500,10 +2416,10 @@ optional in the encoding of a font.</p>
 and often contain interactions between code points so maintaining functional equivalence with a partial copy of the font can be tricky.
 The next two subsections discuss maintaining functional equivalent using the different patch types.</p>
    <p><b>Brotli patches</b></p>
-   <p>When preparing <a href="#brotli">§ 6.2 Brotli Patch</a> or <a href="#per-table-brotli">§ 6.3 Per Table Brotli</a> patches, one means of achieving functional equivalence is to leverage an
+   <p>When preparing <a href="#per-table-brotli">§ 6.2 Per Table Brotli</a> patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.</p>
-   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③⓪">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a>. The practice of reliably
+   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a>. The practice of reliably
 subsetting a font is well understood and has multiple open-source implementations (a full formal description is
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
@@ -2545,13 +2461,13 @@ requirements in <a href="#encoding">§ 7 Encoding</a> to be a neutral encoding
 to be representative of all possible encoder implementations. Notably it does not make use of nor demonstrate utilizing glyph keyed
 patches. Most encoders will likely be more complex and need to consider additional factors some of which are discussed in the remaining
 sections.</p>
-   <p><b><a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches</b></p>
-   <p>Specifically because they are parameterized by code points and feature tags but can be applied independently of one another, <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches have additional requirements and cannot be directly derived by using a subsetter implementation.  However,
+   <p><b><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches</b></p>
+   <p>Specifically because they are parameterized by code points and feature tags but can be applied independently of one another, <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches have additional requirements and cannot be directly derived by using a subsetter implementation.  However,
 such an implementation can help clarify what an encoder needs to do to maintain functional equivalence when producing this type
 of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①②">font subset definition</a>. We can define
 the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> as the full set of glyphs included in the subset, which the
 subsetter has determined is needed to render any combination of the described code points and layout features.</p>
-   <p>Using that definition, the <b>glyph closure requirement</b> on the full set <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches is:</p>
+   <p>Using that definition, the <b>glyph closure requirement</b> on the full set <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches is:</p>
    <ul>
     <li data-md>
      <p>The set of glyphs contained in the patches loaded for a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①④">font subset definition</a> through the patch map tables must be a superset
@@ -2559,9 +2475,9 @@ of those in the <a data-link-type="dfn" href="#glyph-closure" id="ref-for-glyph-
    </ul>
    <p>Assuming the subsetter does its job accurately, the glyph closure requirement is a consequence of the requirement for equivalent
 behavior: Suppose there is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a> such that the subsetter includes glyph *i* in its subset, but an encoder that
-produces <a href="#glyph-keyed">§ 6.4 Glyph Keyed</a> patches omits glyph *i* from the set of patches that correspond to that definition. If the subsetter is
+produces <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches omits glyph *i* from the set of patches that correspond to that definition. If the subsetter is
 right, that glyph must be present to retain equivalent behavior when rendering some combination of the code points and features in 
-the definition, which means that the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑨">incremental font</a> will not behave equivalently when rendering that combination.</p>
+the definition, which means that the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑧">incremental font</a> will not behave equivalently when rendering that combination.</p>
    <p>Therefore, when generating an encoding utilizing glyph-keyed patches the encoder must determine how to distribute glyphs between all
 of the patches in a way that meets the glyph closure requirement. This is primarily a matter of looking at the code points assigned
 to a segment and determining what other glyphs must be included in the patch that corresponds to it, as when a glyph variant can
@@ -2585,7 +2501,7 @@ when loading the patches for two or more segments.  There are three main strateg
    <p>In some cases it might be desirable to avoid the overhead of applying patches to an initial file. For example, it could
 be desirable that the font loaded on a company home page already be able to render the content on that page. The main benefit
 of such a file is reduced rendering latency: the content can be rendered after a single round-trip.</p>
-   <p>There are two approaches to including data in the downloaded font file. One is to simply encode the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②⓪">incremental font</a> as a whole so that the data is in the initial file. Any such data will always be available in any patched version of the font.
+   <p>There are two approaches to including data in the downloaded font file. One is to simply encode the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑨">incremental font</a> as a whole so that the data is in the initial file. Any such data will always be available in any patched version of the font.
 This can be helpful in cases when the same data would otherwise be needed in many different segments.</p>
    <p>The other approach is to download an already-patched font. That is, one can encode a font with little or no data in the "base"
 file but then apply patches to that file on the server side, so that the file downloaded already includes the data contained
@@ -2618,8 +2534,8 @@ subdirectory according to the trailing letters of the id encoding. These will te
 when using integer ids, but may be unevenly distributed or even constant for string ids. Encoders that wish to use string ids with
 d1 through d4 should take care to make the ends of the id strings vary.  It is valid to mix d1 through d4 with a base64url-encoded
 id.</p>
-   <h2 class="no-num heading settled" id="priv"><span class="content">Privacy Considerations</span><a class="self-link" href="#priv"></a></h2>
-   <h3 class="heading settled" id="content-inference-from-character-set"><span class="content">Content inference from character set</span><a class="self-link" href="#content-inference-from-character-set"></a></h3>
+   <h2 class="heading settled" data-level="8" id="priv"><span class="secno">8. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#priv"></a></h2>
+   <h3 class="heading settled" data-level="8.1" id="content-inference-from-character-set"><span class="secno">8.1. </span><span class="content">Content inference from character set</span><a class="self-link" href="#content-inference-from-character-set"></a></h3>
    <p>IFT exposes, to the server hosting a Web font, information on the set of characters that the browser wants to render with the font (for
 details, see <a href="#extending-font-subset">§ 4 Extending a Font Subset</a>).</p>
    <p>For some languages, which use a very large character set (Chinese and Japanese are examples) the vast reduction in total
@@ -2640,7 +2556,7 @@ that are not required by the current content to provide obfuscation of what patc
     <li data-md>
      <p><a href="https://www.w3.org/TR/css-fonts-4/#sp208"><cite>CSS Fonts 4</cite> § 15.8 What data does this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts.</a></p>
    </ul>
-   <h3 class="heading settled" id="per-origin"><span class="content">Per-origin restriction avoids fingerprinting</span><a class="self-link" href="#per-origin"></a></h3>
+   <h3 class="heading settled" data-level="8.2" id="per-origin"><span class="secno">8.2. </span><span class="content">Per-origin restriction avoids fingerprinting</span><a class="self-link" href="#per-origin"></a></h3>
    <p>As required by <a data-link-type="biblio" href="#biblio-css-fonts-4" title="CSS Fonts Module Level 4">[css-fonts-4]</a>:</p>
    <p>"A Web Font must not be accessible in any other Document from the one which either is associated with
   the @font-face rule or owns the FontFaceSet. Other applications on the device must not be able to access
@@ -2651,7 +2567,7 @@ that are not required by the current content to provide obfuscation of what patc
    <p>"An author-defined font color palette must only be available to the documents that reference it. Using an author-defined color palette
   outside of the documents that reference it would constitute a security leak since the contents of one page would be able to
   affect other pages, something an attacker could use as an attack vector." - <a href="https://www.w3.org/TR/css-fonts-4/#font-palette-values"><cite>CSS Fonts 4</cite> § 9.2 User-defined font color palettes: The @font-palette-values rule</a></p>
-   <h2 class="no-num heading settled" id="sec"><span class="content">Security Considerations</span><a class="self-link" href="#sec"></a></h2>
+   <h2 class="heading settled" data-level="9" id="sec"><span class="secno">9. </span><span class="content">Security Considerations</span><a class="self-link" href="#sec"></a></h2>
    <p>One security concern is that IFT fonts could potentially generate a large number of network requests for patches. This could cause
 problems on the client or the service hosting the patches. The IFT specification contains a couple of mitigations to limit excessive
 number of requests:</p>
@@ -2664,7 +2580,7 @@ number of requests:</p>
  font load. As a result cross-origin requests for patch files are disallowed unless the hosting service opts in via the appropriate
  access control headers.</p>
    </ol>
-   <h2 class="no-num heading settled" id="changes"><span class="content">Changes</span><a class="self-link" href="#changes"></a></h2>
+   <h2 class="heading settled" data-level="10" id="changes"><span class="secno">10. </span><span class="content">Changes</span><a class="self-link" href="#changes"></a></h2>
    <p>Since the <a href="https://www.w3.org/TR/2023/WD-IFT-20230530/">Working
   Draft of 30 May 2023</a> (see <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
    <ul>
@@ -2933,29 +2849,25 @@ to be used by default in most shaper implementations. This list was assembled fr
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a><span>, in § 5.2.1</span>
-   <li><a href="#abstract-opdef-apply-brotli-patch">Apply brotli patch</a><span>, in § 6.2.1</span>
-   <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 6.4.1</span>
-   <li><a href="#abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</a><span>, in § 6.3.1</span>
+   <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 6.3.1</span>
+   <li><a href="#abstract-opdef-apply-per-table-brotli-patch">Apply per table brotli patch</a><span>, in § 6.2.1</span>
    <li><a href="#mapping-entry-bias">bias</a><span>, in § 5.2.2</span>
    <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 5.2.2.3</span>
-   <li><a href="#brotli-patch">Brotli patch</a><span>, in § 6.2</span>
    <li>
     brotliStream
     <ul>
-     <li><a href="#brotli-patch-brotlistream">dfn for Brotli patch</a><span>, in § 6.2</span>
-     <li><a href="#glyph-keyed-patch-brotlistream">dfn for Glyph keyed patch</a><span>, in § 6.4</span>
-     <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 6.3</span>
+     <li><a href="#glyph-keyed-patch-brotlistream">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
+     <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 4.3</span>
    <li><a href="#mapping-entry-codepoints">codePoints</a><span>, in § 5.2.2</span>
    <li>
     compatibilityId
     <ul>
-     <li><a href="#brotli-patch-compatibilityid">dfn for Brotli patch</a><span>, in § 6.2</span>
      <li><a href="#format-1-patch-map-compatibilityid">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#format-2-patch-map-compatibilityid">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
-     <li><a href="#glyph-keyed-patch-compatibilityid">dfn for Glyph keyed patch</a><span>, in § 6.4</span>
-     <li><a href="#per-table-brotli-patch-compatibilityid">dfn for Per table brotli patch</a><span>, in § 6.3</span>
+     <li><a href="#glyph-keyed-patch-compatibilityid">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
+     <li><a href="#per-table-brotli-patch-compatibilityid">dfn for Per table brotli patch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#mapping-entry-copycount">copyCount</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 5.2.2</span>
@@ -2993,8 +2905,8 @@ to be used by default in most shaper implementations. This list was assembled fr
    <li>
     flags
     <ul>
-     <li><a href="#glyph-keyed-patch-flags">dfn for Glyph keyed patch</a><span>, in § 6.4</span>
-     <li><a href="#tablepatch-flags">dfn for TablePatch</a><span>, in § 6.3</span>
+     <li><a href="#glyph-keyed-patch-flags">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
+     <li><a href="#tablepatch-flags">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#font-patch">font patch</a><span>, in § 3.2</span>
    <li><a href="#font-subset">font subset</a><span>, in § 3.1</span>
@@ -3002,11 +2914,10 @@ to be used by default in most shaper implementations. This list was assembled fr
    <li>
     format
     <ul>
-     <li><a href="#brotli-patch-format">dfn for Brotli patch</a><span>, in § 6.2</span>
      <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
-     <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 6.4</span>
-     <li><a href="#per-table-brotli-patch-format">dfn for Per table brotli patch</a><span>, in § 6.3</span>
+     <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
+     <li><a href="#per-table-brotli-patch-format">dfn for Per table brotli patch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 5.2.1</span>
    <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 5.2.2</span>
@@ -3018,14 +2929,14 @@ to be used by default in most shaper implementations. This list was assembled fr
     glyphCount
     <ul>
      <li><a href="#format-1-patch-map-glyphcount">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
-     <li><a href="#glyphpatches-glyphcount">dfn for GlyphPatches</a><span>, in § 6.4</span>
+     <li><a href="#glyphpatches-glyphcount">dfn for GlyphPatches</a><span>, in § 6.3</span>
     </ul>
-   <li><a href="#glyphpatches-glyphdata">glyphData</a><span>, in § 6.4</span>
-   <li><a href="#glyphpatches-glyphdataoffsets">glyphDataOffsets</a><span>, in § 6.4</span>
-   <li><a href="#glyphpatches-glyphids">glyphIds</a><span>, in § 6.4</span>
-   <li><a href="#glyph-keyed-patch">Glyph keyed patch</a><span>, in § 6.4</span>
+   <li><a href="#glyphpatches-glyphdata">glyphData</a><span>, in § 6.3</span>
+   <li><a href="#glyphpatches-glyphdataoffsets">glyphDataOffsets</a><span>, in § 6.3</span>
+   <li><a href="#glyphpatches-glyphids">glyphIds</a><span>, in § 6.3</span>
+   <li><a href="#glyph-keyed-patch">Glyph keyed patch</a><span>, in § 6.3</span>
    <li><a href="#glyph-map">Glyph Map</a><span>, in § 5.2.1</span>
-   <li><a href="#glyphpatches">GlyphPatches</a><span>, in § 6.4</span>
+   <li><a href="#glyphpatches">GlyphPatches</a><span>, in § 6.3</span>
    <li><a href="#abstract-opdef-handle-errors">Handle errors</a><span>, in § 4.3</span>
    <li><a href="#incremental-font">incremental font</a><span>, in § 1.2</span>
    <li><a href="#abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a><span>, in § 5.2.1.1</span>
@@ -3046,22 +2957,22 @@ to be used by default in most shaper implementations. This list was assembled fr
      <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 5.2.2</span>
     </ul>
-   <li><a href="#per-table-brotli-patch-patches">patches</a><span>, in § 6.3</span>
+   <li><a href="#per-table-brotli-patch-patches">patches</a><span>, in § 6.2</span>
    <li><a href="#patch-format">patch format</a><span>, in § 3.2</span>
    <li><a href="#patch-map">patch map</a><span>, in § 3.3</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
-   <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 6.3</span>
+   <li><a href="#per-table-brotli-patch">Per table brotli patch</a><span>, in § 6.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.2.1.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 5.2.2.2</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.2.2.3</span>
    <li><a href="#design-space-segment-start">start</a><span>, in § 5.2.2</span>
-   <li><a href="#tablepatch">TablePatch</a><span>, in § 6.3</span>
-   <li><a href="#glyphpatches-tables">tables</a><span>, in § 6.4</span>
+   <li><a href="#tablepatch">TablePatch</a><span>, in § 6.2</span>
+   <li><a href="#glyphpatches-tables">tables</a><span>, in § 6.3</span>
    <li>
     tag
     <ul>
      <li><a href="#design-space-segment-tag">dfn for Design Space Segment</a><span>, in § 5.2.2</span>
-     <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 6.3</span>
+     <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
    <li>
     uriTemplate
@@ -3311,7 +3222,6 @@ function parseHTML(markup) {
 "use strict";
 {
 let dfnPanelData = {
-"abstract-opdef-apply-brotli-patch": {"dfnID":"abstract-opdef-apply-brotli-patch","dfnText":"Apply brotli patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-brotli-patch"},
 "abstract-opdef-apply-glyph-keyed-patch": {"dfnID":"abstract-opdef-apply-glyph-keyed-patch","dfnText":"Apply glyph keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-glyph-keyed-patch"},
 "abstract-opdef-apply-per-table-brotli-patch": {"dfnID":"abstract-opdef-apply-per-table-brotli-patch","dfnText":"Apply per table brotli patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-per-table-brotli-patch"},
 "abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.4. Fully Expanding a Font"}],"url":"#abstract-opdef-check-entry-intersection"},
@@ -3322,14 +3232,10 @@ let dfnPanelData = {
 "abstract-opdef-interpret-format-1-patch-map": {"dfnID":"abstract-opdef-interpret-format-1-patch-map","dfnText":"Interpret Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-1-patch-map"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-interpret-format-1-patch-map"},
 "abstract-opdef-interpret-format-2-patch-map": {"dfnID":"abstract-opdef-interpret-format-2-patch-map","dfnText":"Interpret Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2460"},{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2461"},{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2462"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#abstract-opdef-interpret-format-2-patch-map"},
 "abstract-opdef-interpret-format-2-patch-map-entry": {"dfnID":"abstract-opdef-interpret-format-2-patch-map-entry","dfnText":"Interpret Format 2 Patch Map Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2461"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#abstract-opdef-interpret-format-2-patch-map-entry"},
-"abstract-opdef-load-patch-file": {"dfnID":"abstract-opdef-load-patch-file","dfnText":"Load patch file","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file"},{"id":"ref-for-abstract-opdef-load-patch-file\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file\u2461"}],"title":"Security Considerations"}],"url":"#abstract-opdef-load-patch-file"},
-"abstract-opdef-remove-entries-from-format-1-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-1-patch-map","dfnText":"Remove Entries from Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-1-patch-map"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-1-patch-map"},
-"abstract-opdef-remove-entries-from-format-2-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-2-patch-map","dfnText":"Remove Entries from Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-2-patch-map"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-2-patch-map"},
+"abstract-opdef-load-patch-file": {"dfnID":"abstract-opdef-load-patch-file","dfnText":"Load patch file","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file"},{"id":"ref-for-abstract-opdef-load-patch-file\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file\u2461"}],"title":"9. Security Considerations"}],"url":"#abstract-opdef-load-patch-file"},
+"abstract-opdef-remove-entries-from-format-1-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-1-patch-map","dfnText":"Remove Entries from Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-1-patch-map"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-1-patch-map"},
+"abstract-opdef-remove-entries-from-format-2-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-2-patch-map","dfnText":"Remove Entries from Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-2-patch-map"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-2-patch-map"},
 "branch-factor-encoding": {"dfnID":"branch-factor-encoding","dfnText":"Branch Factor Encoding","external":false,"refSections":[{"refs":[{"id":"ref-for-branch-factor-encoding"},{"id":"ref-for-branch-factor-encoding\u2460"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#branch-factor-encoding"},
-"brotli-patch": {"dfnID":"brotli-patch","dfnText":"Brotli patch","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch"},
-"brotli-patch-brotlistream": {"dfnID":"brotli-patch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-brotlistream"}],"title":"6.2. Brotli Patch"},{"refs":[{"id":"ref-for-brotli-patch-brotlistream\u2460"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch-brotlistream"},
-"brotli-patch-compatibilityid": {"dfnID":"brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-compatibilityid"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch-compatibilityid"},
-"brotli-patch-format": {"dfnID":"brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-brotli-patch-format"}],"title":"6.2.1. Applying Brotli Patches"}],"url":"#brotli-patch-format"},
 "design-space-segment": {"dfnID":"design-space-segment","dfnText":"Design Space Segment","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#design-space-segment"},
 "design-space-segment-end": {"dfnID":"design-space-segment-end","dfnText":"end","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-end"},{"id":"ref-for-design-space-segment-end\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-end"},
 "design-space-segment-start": {"dfnID":"design-space-segment-start","dfnText":"start","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-start"},{"id":"ref-for-design-space-segment-start\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#design-space-segment-start"},
@@ -3345,7 +3251,7 @@ let dfnPanelData = {
 "featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"},{"id":"ref-for-featurerecord-featuretag\u2461"},{"id":"ref-for-featurerecord-featuretag\u2462"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
 "featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"},{"id":"ref-for-featurerecord-firstnewentryindex\u2460"},{"id":"ref-for-featurerecord-firstnewentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
-"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"}],"title":"6.2. Brotli Patch"},{"refs":[{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"},{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2461\u2461"},{"id":"ref-for-font-subset\u2461\u2462"},{"id":"ref-for-font-subset\u2461\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2464"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u2465"},{"id":"ref-for-font-subset\u2461\u2466"},{"id":"ref-for-font-subset\u2461\u2467"}],"title":"6.4.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2468"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2462\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
+"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.2. Per Table Brotli"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"}],"title":"6.2.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"},{"id":"ref-for-font-subset\u2461\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
 "font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2463"},{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"},{"id":"ref-for-font-subset-definition\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u24ea"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"},{"id":"ref-for-font-subset-definition\u2460\u2462"},{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
@@ -3365,23 +3271,23 @@ let dfnPanelData = {
 "format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
 "format-2-patch-map-format": {"dfnID":"format-2-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-format"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-format"},
 "format-2-patch-map-uritemplate": {"dfnID":"format-2-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-uritemplate"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-uritemplate"},
-"full-invalidation": {"dfnID":"full-invalidation","dfnText":"Full Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-full-invalidation"},{"id":"ref-for-full-invalidation\u2460"},{"id":"ref-for-full-invalidation\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-full-invalidation\u2462"},{"id":"ref-for-full-invalidation\u2463"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-full-invalidation\u2464"}],"title":"7.1. Encoding Considerations"}],"url":"#full-invalidation"},
+"full-invalidation": {"dfnID":"full-invalidation","dfnText":"Full Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-full-invalidation"},{"id":"ref-for-full-invalidation\u2460"},{"id":"ref-for-full-invalidation\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-full-invalidation\u2462"}],"title":"6.1. Formats Summary"}],"url":"#full-invalidation"},
 "glyph-closure": {"dfnID":"glyph-closure","dfnText":"glyph closure","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-closure"}],"title":"7.1. Encoding Considerations"}],"url":"#glyph-closure"},
-"glyph-keyed-patch": {"dfnID":"glyph-keyed-patch","dfnText":"Glyph keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch"},
-"glyph-keyed-patch-brotlistream": {"dfnID":"glyph-keyed-patch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-brotlistream"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyph-keyed-patch-brotlistream\u2460"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-brotlistream"},
-"glyph-keyed-patch-compatibilityid": {"dfnID":"glyph-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-compatibilityid"},{"id":"ref-for-glyph-keyed-patch-compatibilityid\u2460"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-compatibilityid"},
-"glyph-keyed-patch-flags": {"dfnID":"glyph-keyed-patch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-flags"}],"title":"6.4. Glyph Keyed"}],"url":"#glyph-keyed-patch-flags"},
-"glyph-keyed-patch-format": {"dfnID":"glyph-keyed-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-format"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-format"},
+"glyph-keyed-patch": {"dfnID":"glyph-keyed-patch","dfnText":"Glyph keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch"},
+"glyph-keyed-patch-brotlistream": {"dfnID":"glyph-keyed-patch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-brotlistream"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-glyph-keyed-patch-brotlistream\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-brotlistream"},
+"glyph-keyed-patch-compatibilityid": {"dfnID":"glyph-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-compatibilityid"},{"id":"ref-for-glyph-keyed-patch-compatibilityid\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-compatibilityid"},
+"glyph-keyed-patch-flags": {"dfnID":"glyph-keyed-patch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-flags"}],"title":"6.3. Glyph Keyed"}],"url":"#glyph-keyed-patch-flags"},
+"glyph-keyed-patch-format": {"dfnID":"glyph-keyed-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-format"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-format"},
 "glyph-map": {"dfnID":"glyph-map","dfnText":"Glyph Map","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map"},{"id":"ref-for-glyph-map\u2460"},{"id":"ref-for-glyph-map\u2461"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map"},
 "glyph-map-entryindex": {"dfnID":"glyph-map-entryindex","dfnText":"entryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-entryindex"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-glyph-map-entryindex\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#glyph-map-entryindex"},
 "glyph-map-firstmappedglyph": {"dfnID":"glyph-map-firstmappedglyph","dfnText":"firstMappedGlyph","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-firstmappedglyph"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#glyph-map-firstmappedglyph"},
-"glyphpatches": {"dfnID":"glyphpatches","dfnText":"GlyphPatches","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches"},{"id":"ref-for-glyphpatches\u2460"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches"},
-"glyphpatches-glyphcount": {"dfnID":"glyphpatches-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphcount"},{"id":"ref-for-glyphpatches-glyphcount\u2460"}],"title":"6.4. Glyph Keyed"}],"url":"#glyphpatches-glyphcount"},
-"glyphpatches-glyphdata": {"dfnID":"glyphpatches-glyphdata","dfnText":"glyphData","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphdata"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphdata"},
-"glyphpatches-glyphdataoffsets": {"dfnID":"glyphpatches-glyphdataoffsets","dfnText":"glyphDataOffsets","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphdataoffsets"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-glyphdataoffsets\u2460"},{"id":"ref-for-glyphpatches-glyphdataoffsets\u2461"},{"id":"ref-for-glyphpatches-glyphdataoffsets\u2462"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphdataoffsets"},
-"glyphpatches-glyphids": {"dfnID":"glyphpatches-glyphids","dfnText":"glyphIds","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphids"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-glyphids\u2460"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphids"},
-"glyphpatches-tables": {"dfnID":"glyphpatches-tables","dfnText":"tables","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-tables"},{"id":"ref-for-glyphpatches-tables\u2460"}],"title":"6.4. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-tables\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-tables"},
-"incremental-font": {"dfnID":"incremental-font","dfnText":"incremental font","external":false,"refSections":[{"refs":[{"id":"ref-for-incremental-font"}],"title":"1.2. Overview"},{"refs":[{"id":"ref-for-incremental-font\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-incremental-font\u2461"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-incremental-font\u2462"},{"id":"ref-for-incremental-font\u2463"},{"id":"ref-for-incremental-font\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-incremental-font\u2465"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-incremental-font\u2466"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-incremental-font\u2467"},{"id":"ref-for-incremental-font\u2468"},{"id":"ref-for-incremental-font\u2460\u24ea"},{"id":"ref-for-incremental-font\u2460\u2460"},{"id":"ref-for-incremental-font\u2460\u2461"},{"id":"ref-for-incremental-font\u2460\u2462"},{"id":"ref-for-incremental-font\u2460\u2463"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-incremental-font\u2460\u2464"},{"id":"ref-for-incremental-font\u2460\u2465"},{"id":"ref-for-incremental-font\u2460\u2466"},{"id":"ref-for-incremental-font\u2460\u2467"},{"id":"ref-for-incremental-font\u2460\u2468"},{"id":"ref-for-incremental-font\u2461\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#incremental-font"},
+"glyphpatches": {"dfnID":"glyphpatches","dfnText":"GlyphPatches","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches"},{"id":"ref-for-glyphpatches\u2460"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches"},
+"glyphpatches-glyphcount": {"dfnID":"glyphpatches-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphcount"},{"id":"ref-for-glyphpatches-glyphcount\u2460"}],"title":"6.3. Glyph Keyed"}],"url":"#glyphpatches-glyphcount"},
+"glyphpatches-glyphdata": {"dfnID":"glyphpatches-glyphdata","dfnText":"glyphData","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphdata"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphdata"},
+"glyphpatches-glyphdataoffsets": {"dfnID":"glyphpatches-glyphdataoffsets","dfnText":"glyphDataOffsets","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphdataoffsets"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-glyphdataoffsets\u2460"},{"id":"ref-for-glyphpatches-glyphdataoffsets\u2461"},{"id":"ref-for-glyphpatches-glyphdataoffsets\u2462"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphdataoffsets"},
+"glyphpatches-glyphids": {"dfnID":"glyphpatches-glyphids","dfnText":"glyphIds","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphids"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-glyphids\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphids"},
+"glyphpatches-tables": {"dfnID":"glyphpatches-tables","dfnText":"tables","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-tables"},{"id":"ref-for-glyphpatches-tables\u2460"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-tables\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-tables"},
+"incremental-font": {"dfnID":"incremental-font","dfnText":"incremental font","external":false,"refSections":[{"refs":[{"id":"ref-for-incremental-font"}],"title":"1.2. Overview"},{"refs":[{"id":"ref-for-incremental-font\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-incremental-font\u2461"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-incremental-font\u2462"},{"id":"ref-for-incremental-font\u2463"},{"id":"ref-for-incremental-font\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-incremental-font\u2465"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-incremental-font\u2466"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-incremental-font\u2467"},{"id":"ref-for-incremental-font\u2468"},{"id":"ref-for-incremental-font\u2460\u24ea"},{"id":"ref-for-incremental-font\u2460\u2460"},{"id":"ref-for-incremental-font\u2460\u2461"},{"id":"ref-for-incremental-font\u2460\u2462"},{"id":"ref-for-incremental-font\u2460\u2463"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-incremental-font\u2460\u2464"},{"id":"ref-for-incremental-font\u2460\u2465"},{"id":"ref-for-incremental-font\u2460\u2466"},{"id":"ref-for-incremental-font\u2460\u2467"},{"id":"ref-for-incremental-font\u2460\u2468"}],"title":"7.1. Encoding Considerations"}],"url":"#incremental-font"},
 "mapping-entries": {"dfnID":"mapping-entries","dfnText":"Mapping Entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#mapping-entries"},
 "mapping-entries-entries": {"dfnID":"mapping-entries-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries-entries"},{"id":"ref-for-mapping-entries-entries\u2460"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2461"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entries-entries"},
 "mapping-entry": {"dfnID":"mapping-entry","dfnText":"Mapping Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry"},{"id":"ref-for-mapping-entry\u2460"},{"id":"ref-for-mapping-entry\u2461"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry\u2462"},{"id":"ref-for-mapping-entry\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry"},
@@ -3398,20 +3304,20 @@ let dfnPanelData = {
 "mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#mapping-entry-formatflags"},
 "mapping-entry-patchencoding": {"dfnID":"mapping-entry-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchencoding"},{"id":"ref-for-mapping-entry-patchencoding\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchencoding"},
 "no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-no-invalidation\u2461"}],"title":"7.1. Encoding Considerations"}],"url":"#no-invalidation"},
-"partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"},{"id":"ref-for-partial-invalidation\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2463"},{"id":"ref-for-partial-invalidation\u2464"},{"id":"ref-for-partial-invalidation\u2465"},{"id":"ref-for-partial-invalidation\u2466"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
-"patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2461"}],"title":"6.4.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
+"partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"},{"id":"ref-for-partial-invalidation\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2463"},{"id":"ref-for-partial-invalidation\u2464"},{"id":"ref-for-partial-invalidation\u2465"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
+"patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Per Table Brotli Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
 "patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2461"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map"},
 "patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2460"},{"id":"ref-for-patch-map-entries\u2461"},{"id":"ref-for-patch-map-entries\u2462"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"},{"id":"ref-for-patch-map-entries\u2467"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"},{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map-entries"},
-"per-table-brotli-patch": {"dfnID":"per-table-brotli-patch","dfnText":"Per table brotli patch","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch"},
-"per-table-brotli-patch-compatibilityid": {"dfnID":"per-table-brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-compatibilityid"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-compatibilityid"},
-"per-table-brotli-patch-format": {"dfnID":"per-table-brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-format"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-format"},
-"per-table-brotli-patch-patches": {"dfnID":"per-table-brotli-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-patches"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-per-table-brotli-patch-patches\u2460"},{"id":"ref-for-per-table-brotli-patch-patches\u2461"},{"id":"ref-for-per-table-brotli-patch-patches\u2462"},{"id":"ref-for-per-table-brotli-patch-patches\u2463"},{"id":"ref-for-per-table-brotli-patch-patches\u2464"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-patches"},
+"per-table-brotli-patch": {"dfnID":"per-table-brotli-patch","dfnText":"Per table brotli patch","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch"},
+"per-table-brotli-patch-compatibilityid": {"dfnID":"per-table-brotli-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-compatibilityid"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-compatibilityid"},
+"per-table-brotli-patch-format": {"dfnID":"per-table-brotli-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-format"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-format"},
+"per-table-brotli-patch-patches": {"dfnID":"per-table-brotli-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-brotli-patch-patches"}],"title":"6.2. Per Table Brotli"},{"refs":[{"id":"ref-for-per-table-brotli-patch-patches\u2460"},{"id":"ref-for-per-table-brotli-patch-patches\u2461"},{"id":"ref-for-per-table-brotli-patch-patches\u2462"},{"id":"ref-for-per-table-brotli-patch-patches\u2463"},{"id":"ref-for-per-table-brotli-patch-patches\u2464"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#per-table-brotli-patch-patches"},
 "sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
-"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch"},
-"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.3. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-brotlistream"},
-"tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-flags"},
-"tablepatch-tag": {"dfnID":"tablepatch-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-tag"},{"id":"ref-for-tablepatch-tag\u2460"},{"id":"ref-for-tablepatch-tag\u2461"},{"id":"ref-for-tablepatch-tag\u2462"},{"id":"ref-for-tablepatch-tag\u2463"}],"title":"6.3.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-tag"},
+"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.2. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch"},
+"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.2. Per Table Brotli"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-brotlistream"},
+"tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-flags"},
+"tablepatch-tag": {"dfnID":"tablepatch-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-tag"},{"id":"ref-for-tablepatch-tag\u2460"},{"id":"ref-for-tablepatch-tag\u2461"},{"id":"ref-for-tablepatch-tag\u2462"},{"id":"ref-for-tablepatch-tag\u2463"}],"title":"6.2.1. Applying Per Table Brotli Patches"}],"url":"#tablepatch-tag"},
 };
 
 document.addEventListener("DOMContentLoaded", ()=>{
@@ -3811,10 +3717,6 @@ let refsData = {
 "#abstract-opdef-remove-entries-from-format-1-patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Remove Entries from Format 1 Patch Map","type":"abstract-op","url":"#abstract-opdef-remove-entries-from-format-1-patch-map"},
 "#abstract-opdef-remove-entries-from-format-2-patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Remove Entries from Format 2 Patch Map","type":"abstract-op","url":"#abstract-opdef-remove-entries-from-format-2-patch-map"},
 "#branch-factor-encoding": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"branch factor encoding","type":"dfn","url":"#branch-factor-encoding"},
-"#brotli-patch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"brotli patch","type":"dfn","url":"#brotli-patch"},
-"#brotli-patch-brotlistream": {"export":true,"for_":["Brotli patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"brotlistream","type":"dfn","url":"#brotli-patch-brotlistream"},
-"#brotli-patch-compatibilityid": {"export":true,"for_":["Brotli patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#brotli-patch-compatibilityid"},
-"#brotli-patch-format": {"export":true,"for_":["Brotli patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#brotli-patch-format"},
 "#design-space-segment": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"design space segment","type":"dfn","url":"#design-space-segment"},
 "#design-space-segment-end": {"export":true,"for_":["Design Space Segment"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"end","type":"dfn","url":"#design-space-segment-end"},
 "#design-space-segment-start": {"export":true,"for_":["Design Space Segment"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"start","type":"dfn","url":"#design-space-segment-start"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="b3754b901cdd23134c80a82208abea49a185748d" name="revision">
+  <meta content="b0fe8556e0a5bbadabfa30a65c33328d03d9e1ce" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -728,9 +728,9 @@ be loaded over multiple requests where each request incrementally adds additiona
      <ol class="toc">
       <li><a href="#font-patch-formats-summary"><span class="secno">6.1</span> <span class="content">Formats Summary</span></a>
       <li>
-       <a href="#per-table"><span class="secno">6.2</span> <span class="content">Per Table</span></a>
+       <a href="#table-keyed"><span class="secno">6.2</span> <span class="content">Table Keyed</span></a>
        <ol class="toc">
-        <li><a href="#apply-per-table"><span class="secno">6.2.1</span> <span class="content">Applying Per Table Patches</span></a>
+        <li><a href="#apply-table-keyed"><span class="secno">6.2.1</span> <span class="content">Applying Table Keyed Patches</span></a>
        </ol>
       <li>
        <a href="#glyph-keyed"><span class="secno">6.3</span> <span class="content">Glyph Keyed</span></a>
@@ -1162,7 +1162,7 @@ is taken. If an incremental font will be encoded by WOFF2 for transfer:</p>
    <ol>
     <li data-md>
      <p>If the WOFF2 encoding will include a transformed glyf and loca table (<a href="https://www.w3.org/TR/WOFF2/#glyf_table_format"><cite>WOFF 2.0</cite> § 5.1 Transformed glyf table format</a>) then, the incremental
- font should not contain <a href="#per-table">§ 6.2 Per Table</a> patches which modify either the glyf or loca table. The WOFF2 format does not
+ font should not contain <a href="#table-keyed">§ 6.2 Table Keyed</a> patches which modify either the glyf or loca table. The WOFF2 format does not
  guarantee the specific bytes that result from decoding a transformed glyf and loca table. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches may be used
  in conjunction with a transformed glyf and loca table.</p>
     <li data-md>
@@ -2003,7 +2003,7 @@ encoding can make use of more than one patch format.</p>
    <p>The following patch formats are defined by this specification:</p>
    <ul>
     <li data-md>
-     <p><a href="#per-table">§ 6.2 Per Table</a>: a collection of brotli encoded binary diffs that use tables from a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as bases.</p>
+     <p><a href="#table-keyed">§ 6.2 Table Keyed</a>: a collection of brotli encoded binary diffs that use tables from a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> as bases.</p>
     <li data-md>
      <p><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a>: a collection of opaque binary blobs, each associated with a glyph id and table.</p>
    </ul>
@@ -2017,22 +2017,22 @@ encoding can make use of more than one patch format.</p>
       <th>Invalidation
      <tr>
       <td>1
-      <td><a href="#per-table">§ 6.2 Per Table</a>
+      <td><a href="#table-keyed">§ 6.2 Table Keyed</a>
       <td><a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation③">Full Invalidation</a>
      <tr>
       <td>2
-      <td><a href="#per-table">§ 6.2 Per Table</a>
+      <td><a href="#table-keyed">§ 6.2 Table Keyed</a>
       <td><a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation③">Partial Invalidation</a>
      <tr>
       <td>3
       <td><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a>
       <td><a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation①">No Invalidation</a>
    </table>
-   <h3 class="heading settled" data-level="6.2" id="per-table"><span class="secno">6.2. </span><span class="content">Per Table</span><a class="self-link" href="#per-table"></a></h3>
-   <p>A per table patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A per table encoded patch consists of a short header followed
+   <h3 class="heading settled" data-level="6.2" id="table-keyed"><span class="secno">6.2. </span><span class="content">Table Keyed</span><a class="self-link" href="#table-keyed"></a></h3>
+   <p>A table keyed patch contains a collection of patches which are applied to the individual <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A table keyed encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
 or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a>.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="per-table-patch">Per table patch</dfn> encoding:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="table-keyed-patch">Table keyed patch</dfn> encoding:</p>
    <table>
     <tbody>
      <tr>
@@ -2041,15 +2041,15 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
       <th>Description
      <tr>
       <td>Tag
-      <td><dfn class="dfn-paneled" data-dfn-for="Per table patch" data-dfn-type="dfn" data-noexport id="per-table-patch-format">format</dfn>
-      <td>Identifies the encoding as per table, set to 'ifpt'
+      <td><dfn class="dfn-paneled" data-dfn-for="Table keyed patch" data-dfn-type="dfn" data-noexport id="table-keyed-patch-format">format</dfn>
+      <td>Identifies the encoding as table keyed, set to 'iftk'
      <tr>
       <td>uint32
       <td>reserved
       <td>Reserved for future use, set to 0.
      <tr>
       <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Per table patch" data-dfn-type="dfn" data-noexport id="per-table-patch-compatibilityid">compatibilityId</dfn>[4]
+      <td><dfn class="dfn-paneled" data-dfn-for="Table keyed patch" data-dfn-type="dfn" data-noexport id="table-keyed-patch-compatibilityid">compatibilityId</dfn>[4]
       <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint16
@@ -2057,10 +2057,10 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
       <td>The number of entries in the patches array.
      <tr>
       <td>Offset32
-      <td><dfn class="dfn-paneled" data-dfn-for="Per table patch" data-dfn-type="dfn" data-noexport id="per-table-patch-patches">patches</dfn>[patchesCount+1]
+      <td><dfn class="dfn-paneled" data-dfn-for="Table keyed patch" data-dfn-type="dfn" data-noexport id="table-keyed-patch-patches">patches</dfn>[patchesCount+1]
       <td>Each entry is an offset from the start of this table to a <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch">TablePatch</a>. Offsets must be sorted in ascending order.
    </table>
-   <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches">patches</a> array gives the size
+   <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches">patches</a> array gives the size
 of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">TablePatch</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="tablepatch">TablePatch</dfn> encoding:</p>
    <table>
@@ -2086,16 +2086,16 @@ of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">Ta
       <td><dfn class="dfn-paneled" data-dfn-for="TablePatch" data-dfn-type="dfn" data-noexport id="tablepatch-brotlistream">brotliStream</dfn>[variable]
       <td>Brotli encoded byte stream.
    </table>
-   <h4 class="heading settled algorithm" data-algorithm="Applying Per Table Patches" data-level="6.2.1" id="apply-per-table"><span class="secno">6.2.1. </span><span class="content">Applying Per Table Patches</span><a class="self-link" href="#apply-per-table"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a per table patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> to cover additional code points,
+   <h4 class="heading settled algorithm" data-algorithm="Applying Table Keyed Patches" data-level="6.2.1" id="apply-table-keyed"><span class="secno">6.2.1. </span><span class="content">Applying Table Keyed Patches</span><a class="self-link" href="#apply-table-keyed"></a></h4>
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a table keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> to cover additional code points,
 features, and/or design-variation space.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-per-table-patch">Apply per table patch</dfn></p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-table-keyed-patch">Apply table keyed patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
      <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> which is to be extended.</p>
     <li data-md>
-     <p><var>patch</var>: a <a data-link-type="dfn" href="#per-table-patch" id="ref-for-per-table-patch">per table patch</a> to be applied to <var>base font subset</var>.</p>
+     <p><var>patch</var>: a <a data-link-type="dfn" href="#table-keyed-patch" id="ref-for-table-keyed-patch">table keyed patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
      <p><var>compatibility id</var>: The ID number from the 'IFT ' or 'IFTX' table of <var>base font subset</var> which listed this patch.</p>
    </ul>
@@ -2109,11 +2109,11 @@ features, and/or design-variation space.</p>
     <li data-md>
      <p>Initialize <var>extended font subset</var> to be an empty font with no tables.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#per-table-patch-format" id="ref-for-per-table-patch-format">format</a> field in <var>patch</var> is equal to 'ifpt', if it is
+     <p>Check that the <a data-link-type="dfn" href="#table-keyed-patch-format" id="ref-for-table-keyed-patch-format">format</a> field in <var>patch</var> is equal to 'iftk', if it is
 not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
 an error.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#per-table-patch-compatibilityid" id="ref-for-per-table-patch-compatibilityid">compatibilityId</a> field in <var>patch</var> is equal to <var>compatibility id</var>.
+     <p>Check that the <a data-link-type="dfn" href="#table-keyed-patch-compatibilityid" id="ref-for-table-keyed-patch-compatibilityid">compatibilityId</a> field in <var>patch</var> is equal to <var>compatibility id</var>.
 If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
 has failed, return an error.</p>
     <li data-md>
@@ -2122,15 +2122,15 @@ inserting a new entry into the <a href="https://docs.microsoft.com/en-us/typogra
 type specification. That entry includes a checksum for the table data. When an existing table is copied unmodified, the client
 can re-use the checksum from the entry in the source font. Otherwise a new checksum will need to be computed.</p>
     <li data-md>
-     <p>For each entry in <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches①">patches</a>, with index <var>i</var>:</p>
+     <p>For each entry in <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches①">patches</a>, with index <var>i</var>:</p>
      <ul>
       <li data-md>
-       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch②">TablePatch</a> associated with index <var>i</var>. The object starts at the offset <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches②">patches[i]</a> (inclusive) and ends at the offset <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
+       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch②">TablePatch</a> associated with index <var>i</var>. The object starts at the offset <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches②">patches[i]</a> (inclusive) and ends at the offset <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
 the <var>patch</var>.</p>
       <li data-md>
-       <p>If an entry in <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches④">patches</a> was previously applied that has the same <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag">tag</a> as
+       <p>If an entry in <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches④">patches</a> was previously applied that has the same <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag">tag</a> as
 this entry, then ignore this entry and continue the iteration to the next one. Entries are processed in same order as they
-are listed in the <a data-link-type="dfn" href="#per-table-patch-patches" id="ref-for-per-table-patch-patches⑤">patches</a> array.</p>
+are listed in the <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches⑤">patches</a> array.</p>
       <li data-md>
        <p>If bit 0 (least significant bit) of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags">flags</a> is set, then decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream①">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a>. No shared dictionary is used. Add a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag①">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream②">brotliStream</a>.</p>
       <li data-md>
@@ -2322,14 +2322,14 @@ guidance that encoder implementations may want to consider, and that can be impo
 an existing font file when producing an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑤">incremental</a> version of that font. The guidance provided in this section
 is based on the experience of building an encoder implementation during development of this specification. It represents the  best
 understanding (at the time of writing) of how to generate a high performance encoding which meets requirements 1 through 4 of <a href="#encoding">§ 7 Encoding</a> and thus preserves all functionality/behavior of the original font being encoded.</p>
-   <p><b>About <a href="#per-table">§ 6.2 Per Table</a> patches</b></p>
-   <p>A <a href="#per-table">§ 6.2 Per Table</a> patch can change the contents of some font tables and not others. Each patched table typically needs to be
-relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#per-table">§ 6.2 Per Table</a> patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches and therefore be only <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation④">Partially Invalidating</a> (in that it will invalidate other <a href="#per-table">§ 6.2 Per Table</a> patches but not <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches. Additionally two sets of <a href="#per-table">§ 6.2 Per Table</a> patches can be independent of each other if they do not
-modify any of the same tables.  For example, one could use <a href="#per-table">§ 6.2 Per Table</a> patches for all
-content other than the glyph tables but then use another set of <a href="#per-table">§ 6.2 Per Table</a> patches for those tables rather than <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches, and each of these could in theory be <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑤">Partially Invalidating</a>—leaving them
+   <p><b>About <a href="#table-keyed">§ 6.2 Table Keyed</a> patches</b></p>
+   <p>A <a href="#table-keyed">§ 6.2 Table Keyed</a> patch can change the contents of some font tables and not others. Each patched table typically needs to be
+relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#table-keyed">§ 6.2 Table Keyed</a> patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches and therefore be only <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation④">Partially Invalidating</a> (in that it will invalidate other <a href="#table-keyed">§ 6.2 Table Keyed</a> patches but not <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches. Additionally two sets of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches can be independent of each other if they do not
+modify any of the same tables.  For example, one could use <a href="#table-keyed">§ 6.2 Table Keyed</a> patches for all
+content other than the glyph tables but then use another set of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches for those tables rather than <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches, and each of these could in theory be <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑤">Partially Invalidating</a>—leaving them
 mutually dependent but independent of one another.</p>
-   <p>An application of a <a href="#per-table">§ 6.2 Per Table</a> patch will typically alter the IFT or IFTX table it was was listed in to add a new set
-of patches to further extend the font. This means that the total set of <a href="#per-table">§ 6.2 Per Table</a> patches forms a graph,
+   <p>An application of a <a href="#table-keyed">§ 6.2 Table Keyed</a> patch will typically alter the IFT or IFTX table it was was listed in to add a new set
+of patches to further extend the font. This means that the total set of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches forms a graph,
 in which each font subset in the segmentation is a node and each patch is an edge. This also means that patches of these types
 are typically downloaded and applied in series, which has implications for the performance of this patch type relative to latency.</p>
    <p><b>About <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches</b></p>
@@ -2339,7 +2339,7 @@ other font table data in the initial font file. Second, <a href="#glyph-keyed">�
 and can therefore be downloaded and applied independently. This independence means multiple patches can be downloaded in parallel
 which can significantly reduce the number of round trips needed relative to the invalidating patch types.</p>
    <p><b>Choosing patch formats for an encoding</b></p>
-   <p>All encodings must chose one or more patch types to use. <a href="#per-table">§ 6.2 Per Table</a> patches allow
+   <p>All encodings must chose one or more patch types to use. <a href="#table-keyed">§ 6.2 Table Keyed</a> patches allow
 all types of data in the font to be patched, but because this type is at least <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation⑥">Partially Invalidating</a>,
 the total number of patches needed increases exponentially with the number of segments rather than linearly. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches
 are limited to updating outline and variation delta data but the number needed scales linearly with number of segments.</p>
@@ -2347,21 +2347,21 @@ are limited to updating outline and variation delta data but the number needed s
 get patches for typical content. For invalidating patch types it is necessary to make patch requests in series. This means that if some
 content requires multiple segments then, multiple network round trips may be needed. Glyph keyed patches on the other hand are not
 invalidating and the patches can be fetched in parallel, needing only a single round trip.</p>
-   <p>At the extremes of the two types of <a href="#per-table">§ 6.2 Per Table</a> patches are most appropriate for fonts with sizable non-outline data that only require a
+   <p>At the extremes of the two types of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches are most appropriate for fonts with sizable non-outline data that only require a
 small number of patches. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches are most appropriate for fonts where the vast majority of data consists of glyph
 outlines, which is true of many existing CJK fonts.</p>
    <p>For fonts that are in-between, or in cases where fine-grained segmentation of glyph data is desired but segmentation of data
-in other tables is still needed, it can be desirable to mix the <a href="#per-table">§ 6.2 Per Table</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patch types in this
+in other tables is still needed, it can be desirable to mix the <a href="#table-keyed">§ 6.2 Table Keyed</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patch types in this
 way:</p>
    <ol>
     <li data-md>
-     <p>Keep all per table patch entries in one mapping table and all glyph keyed entries in the other mapping table.</p>
+     <p>Keep all table keyed patch entries in one mapping table and all glyph keyed entries in the other mapping table.</p>
     <li data-md>
-     <p>Use per table patches to update all tables except for the tables touched by the glyph keyed patches (outline,
+     <p>Use table keyed patches to update all tables except for the tables touched by the glyph keyed patches (outline,
 variation deltas, and the glyph keyed patch mapping table). These patches should use a small number of large segments to keep
 the patch count reasonable.</p>
     <li data-md>
-     <p>Because glyph keyed patches reference the specific glyph IDs that are updated, the per table patches must not change
+     <p>Because glyph keyed patches reference the specific glyph IDs that are updated, the table keyed patches must not change
 the glyph to glyph ID assignments used in the original font; otherwise, the glyph IDs listed in the glyph keyed patches may
 become incorrect. In font subsetters this is often available as an option called "retain glyph IDs".</p>
     <li data-md>
@@ -2377,7 +2377,7 @@ A, B, C, and D. The patch table could list patches that add: A, B, C, D, A + B, 
 allow any two segments to be added in a single round trip. The downside to this approach is that it further increases the number of unique
 patches needed.</p>
    <p><b>Managing the number of patches</b></p>
-   <p>Using <a href="#per-table">§ 6.2 Per Table</a> patches along side a large number of segments can result in a very large number of patches needed, which can have two
+   <p>Using <a href="#table-keyed">§ 6.2 Table Keyed</a> patches along side a large number of segments can result in a very large number of patches needed, which can have two
 negative effects. First, the storage space needed for all of the pre-generated patches could be undesirably large. Second, more 
 patches will generally mean lower CDN cache performance, because a higher number of patches represents a higher number of paths
 from a given subset to a given subset, with different paths being taken by different users depending on the content they access.
@@ -2415,8 +2415,8 @@ optional in the encoding of a font.</p>
    <p>As discussed in <a href="#encoding">§ 7 Encoding</a> an encoder should preserve the functionality of the original font. Fonts are complex
 and often contain interactions between code points so maintaining functional equivalence with a partial copy of the font can be tricky.
 The next two subsections discuss maintaining functional equivalent using the different patch types.</p>
-   <p><b>Per table patches</b></p>
-   <p>When preparing <a href="#per-table">§ 6.2 Per Table</a> patches, one means of achieving functional equivalence is to leverage an
+   <p><b>Table keyed patches</b></p>
+   <p>When preparing <a href="#table-keyed">§ 6.2 Table Keyed</a> patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.</p>
    <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a>. The practice of reliably
@@ -2424,7 +2424,7 @@ subsetting a font is well understood and has multiple open-source implementation
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
 Any reachable data is retained in the generated font subset, while any unreachable data may be removed.</p>
-   <p>In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only per table patches:</p>
+   <p>In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only table keyed patches:</p>
 <pre># Encode a font (full_font) into an incremental font that starts at base_subset_def
 # and can incrementally add any of subset_definitions. Returns the IFT encoded font
 # and set of associated patches.
@@ -2450,7 +2450,7 @@ encode_node(full_font, base_font, cur_def, subset_definitions):
     next_fonts += (next_font, next_def, patch_url)
 
   for each (next_font, next_def, patch_url) in next_fonts:
-    patch = per_table_patch_diff(base_font, next_font)
+    patch = table_keyed_patch_diff(base_font, next_font)
     patches += (patch, patch_url)
   
   return base_font, patches
@@ -2517,7 +2517,7 @@ same set.</p>
 the file. Encoders should consider placing the mapping tables (IFT and IFTX) plus any additional tables needed to decode the
 mapping tables (cmap) as early as possible in the file. This will allow optimized client implementations to access the 
 patch mapping prior to receiving all of the font data and potentially initiate requests for any required patches earlier.</p>
-   <p>Likewise per table patches have a separate brotli stream for each patched table and the format allows these streams to be placed
+   <p>Likewise table keyed patches have a separate brotli stream for each patched table and the format allows these streams to be placed
 in any order in the patch file. So for the same reasons encoders should consider placing updates to the mapping tables plus any
 additional tables needed to decode the mapping tables as early as possible in the patch file.</p>
    <p><b>Choosing the input ID encoding</b></p>
@@ -2850,7 +2850,7 @@ to be used by default in most shaper implementations. This list was assembled fr
   <ul class="index">
    <li><a href="#format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a><span>, in § 5.2.1</span>
    <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 6.3.1</span>
-   <li><a href="#abstract-opdef-apply-per-table-patch">Apply per table patch</a><span>, in § 6.2.1</span>
+   <li><a href="#abstract-opdef-apply-table-keyed-patch">Apply table keyed patch</a><span>, in § 6.2.1</span>
    <li><a href="#mapping-entry-bias">bias</a><span>, in § 5.2.2</span>
    <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 5.2.2.3</span>
    <li>
@@ -2867,7 +2867,7 @@ to be used by default in most shaper implementations. This list was assembled fr
      <li><a href="#format-1-patch-map-compatibilityid">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#format-2-patch-map-compatibilityid">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
      <li><a href="#glyph-keyed-patch-compatibilityid">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
-     <li><a href="#per-table-patch-compatibilityid">dfn for Per table patch</a><span>, in § 6.2</span>
+     <li><a href="#table-keyed-patch-compatibilityid">dfn for Table keyed patch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#mapping-entry-copycount">copyCount</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 5.2.2</span>
@@ -2917,7 +2917,7 @@ to be used by default in most shaper implementations. This list was assembled fr
      <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
      <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
-     <li><a href="#per-table-patch-format">dfn for Per table patch</a><span>, in § 6.2</span>
+     <li><a href="#table-keyed-patch-format">dfn for Table keyed patch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 5.2.1</span>
    <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 5.2.2</span>
@@ -2957,15 +2957,15 @@ to be used by default in most shaper implementations. This list was assembled fr
      <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 5.2.2</span>
     </ul>
-   <li><a href="#per-table-patch-patches">patches</a><span>, in § 6.2</span>
+   <li><a href="#table-keyed-patch-patches">patches</a><span>, in § 6.2</span>
    <li><a href="#patch-format">patch format</a><span>, in § 3.2</span>
    <li><a href="#patch-map">patch map</a><span>, in § 3.3</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
-   <li><a href="#per-table-patch">Per table patch</a><span>, in § 6.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.2.1.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 5.2.2.2</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.2.2.3</span>
    <li><a href="#design-space-segment-start">start</a><span>, in § 5.2.2</span>
+   <li><a href="#table-keyed-patch">Table keyed patch</a><span>, in § 6.2</span>
    <li><a href="#tablepatch">TablePatch</a><span>, in § 6.2</span>
    <li><a href="#glyphpatches-tables">tables</a><span>, in § 6.3</span>
    <li>
@@ -3223,7 +3223,7 @@ function parseHTML(markup) {
 {
 let dfnPanelData = {
 "abstract-opdef-apply-glyph-keyed-patch": {"dfnID":"abstract-opdef-apply-glyph-keyed-patch","dfnText":"Apply glyph keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-glyph-keyed-patch"},
-"abstract-opdef-apply-per-table-patch": {"dfnID":"abstract-opdef-apply-per-table-patch","dfnText":"Apply per table patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-per-table-patch"},
+"abstract-opdef-apply-table-keyed-patch": {"dfnID":"abstract-opdef-apply-table-keyed-patch","dfnText":"Apply table keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-table-keyed-patch"},
 "abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.4. Fully Expanding a Font"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
 "abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
@@ -3251,7 +3251,7 @@ let dfnPanelData = {
 "featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"},{"id":"ref-for-featurerecord-featuretag\u2461"},{"id":"ref-for-featurerecord-featuretag\u2462"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
 "featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"},{"id":"ref-for-featurerecord-firstnewentryindex\u2460"},{"id":"ref-for-featurerecord-firstnewentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
-"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.2. Per Table"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"}],"title":"6.2.1. Applying Per Table Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"},{"id":"ref-for-font-subset\u2461\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
+"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"},{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"4.4. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"},{"id":"ref-for-font-subset\u2460\u2467"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2468"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"},{"id":"ref-for-font-subset\u2461\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
 "font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2463"},{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"},{"id":"ref-for-font-subset-definition\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u24ea"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"},{"id":"ref-for-font-subset-definition\u2460\u2462"},{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
@@ -3305,19 +3305,19 @@ let dfnPanelData = {
 "mapping-entry-patchencoding": {"dfnID":"mapping-entry-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchencoding"},{"id":"ref-for-mapping-entry-patchencoding\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchencoding"},
 "no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-no-invalidation\u2461"}],"title":"7.1. Encoding Considerations"}],"url":"#no-invalidation"},
 "partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"},{"id":"ref-for-partial-invalidation\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2463"},{"id":"ref-for-partial-invalidation\u2464"},{"id":"ref-for-partial-invalidation\u2465"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
-"patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Per Table Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
+"patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
 "patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2461"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map"},
 "patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2460"},{"id":"ref-for-patch-map-entries\u2461"},{"id":"ref-for-patch-map-entries\u2462"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"},{"id":"ref-for-patch-map-entries\u2467"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"},{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#patch-map-entries"},
-"per-table-patch": {"dfnID":"per-table-patch","dfnText":"Per table patch","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-patch"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#per-table-patch"},
-"per-table-patch-compatibilityid": {"dfnID":"per-table-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-patch-compatibilityid"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#per-table-patch-compatibilityid"},
-"per-table-patch-format": {"dfnID":"per-table-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-patch-format"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#per-table-patch-format"},
-"per-table-patch-patches": {"dfnID":"per-table-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-per-table-patch-patches"}],"title":"6.2. Per Table"},{"refs":[{"id":"ref-for-per-table-patch-patches\u2460"},{"id":"ref-for-per-table-patch-patches\u2461"},{"id":"ref-for-per-table-patch-patches\u2462"},{"id":"ref-for-per-table-patch-patches\u2463"},{"id":"ref-for-per-table-patch-patches\u2464"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#per-table-patch-patches"},
 "sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
-"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.2. Per Table"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#tablepatch"},
-"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.2. Per Table"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#tablepatch-brotlistream"},
-"tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#tablepatch-flags"},
-"tablepatch-tag": {"dfnID":"tablepatch-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-tag"},{"id":"ref-for-tablepatch-tag\u2460"},{"id":"ref-for-tablepatch-tag\u2461"},{"id":"ref-for-tablepatch-tag\u2462"},{"id":"ref-for-tablepatch-tag\u2463"}],"title":"6.2.1. Applying Per Table Patches"}],"url":"#tablepatch-tag"},
+"table-keyed-patch": {"dfnID":"table-keyed-patch","dfnText":"Table keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch"},
+"table-keyed-patch-compatibilityid": {"dfnID":"table-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-compatibilityid"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-compatibilityid"},
+"table-keyed-patch-format": {"dfnID":"table-keyed-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-format"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-format"},
+"table-keyed-patch-patches": {"dfnID":"table-keyed-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-patches"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-table-keyed-patch-patches\u2460"},{"id":"ref-for-table-keyed-patch-patches\u2461"},{"id":"ref-for-table-keyed-patch-patches\u2462"},{"id":"ref-for-table-keyed-patch-patches\u2463"},{"id":"ref-for-table-keyed-patch-patches\u2464"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-patches"},
+"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch"},
+"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch-brotlistream"},
+"tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch-flags"},
+"tablepatch-tag": {"dfnID":"tablepatch-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-tag"},{"id":"ref-for-tablepatch-tag\u2460"},{"id":"ref-for-tablepatch-tag\u2461"},{"id":"ref-for-tablepatch-tag\u2462"},{"id":"ref-for-tablepatch-tag\u2463"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch-tag"},
 };
 
 document.addEventListener("DOMContentLoaded", ()=>{
@@ -3790,11 +3790,11 @@ let refsData = {
 "#patch-format": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch format","type":"dfn","url":"#patch-format"},
 "#patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map","type":"dfn","url":"#patch-map"},
 "#patch-map-entries": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map entries","type":"dfn","url":"#patch-map-entries"},
-"#per-table-patch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"per table patch","type":"dfn","url":"#per-table-patch"},
-"#per-table-patch-compatibilityid": {"export":true,"for_":["Per table patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#per-table-patch-compatibilityid"},
-"#per-table-patch-format": {"export":true,"for_":["Per table patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#per-table-patch-format"},
-"#per-table-patch-patches": {"export":true,"for_":["Per table patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patches","type":"dfn","url":"#per-table-patch-patches"},
 "#sparse-bit-set": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"sparse bit set","type":"dfn","url":"#sparse-bit-set"},
+"#table-keyed-patch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"table keyed patch","type":"dfn","url":"#table-keyed-patch"},
+"#table-keyed-patch-compatibilityid": {"export":true,"for_":["Table keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#table-keyed-patch-compatibilityid"},
+"#table-keyed-patch-format": {"export":true,"for_":["Table keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#table-keyed-patch-format"},
+"#table-keyed-patch-patches": {"export":true,"for_":["Table keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patches","type":"dfn","url":"#table-keyed-patch-patches"},
 "#tablepatch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"tablepatch","type":"dfn","url":"#tablepatch"},
 "#tablepatch-brotlistream": {"export":true,"for_":["TablePatch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"brotlistream","type":"dfn","url":"#tablepatch-brotlistream"},
 "#tablepatch-flags": {"export":true,"for_":["TablePatch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"flags","type":"dfn","url":"#tablepatch-flags"},


### PR DESCRIPTION
As discussed at the TPAC working group meeting this drops the "brotli" patch type because it is not expected to see wide use due to incompatibility with WOFF2 and mixed patch type encodings.

This leaves two remaining patch types:
- Table Keyed (renamed from the previous "per table brotli"): operates at the table level.
- Glyph Keyed: operates at the glyph level.

"Per table brotli" was renamed to "Table Keyed" to keep the naming of the patch formats consistent. The mention of brotli was dropped from the name since both glyph keyed and table keyed patches use brotli internally.

Fixes: #214


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/217.html" title="Last updated on Sep 30, 2024, 10:10 PM UTC (0eab2f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/217/14ee493...0eab2f7.html" title="Last updated on Sep 30, 2024, 10:10 PM UTC (0eab2f7)">Diff</a>