### PR TITLE
Tweaks to table keyed patches based on experience implementing it.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1766,7 +1766,7 @@ The algorithm:
 1. Initialize <var>extended font subset</var> to be an empty font with no tables.
 
 2. Check that the <var>patch</var> is valid according to the requirements in [[#table-keyed]] (requirements are marked with a
-    "must") and all [=TablePatch=]'s are contained within <var>patch</var>. If it is not return an error.
+    "must") and all [=TablePatch=]'s are contained within <var>patch</var>. Otherwise, return an error
 
 3. Check that the [=Table keyed patch/compatibilityId=] field in <var>patch</var> is equal to <var>compatibility id</var>.
     If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application

--- a/Overview.bs
+++ b/Overview.bs
@@ -1687,8 +1687,8 @@ or remove tables in a [=font subset=].
   </tr>
   <tr>
     <td>Tag</td>
-    <td><dfn for="Table keyed patch">format</dfn></td>
-    <td>Identifies the encoding as table keyed, set to 'iftk'</td>
+    <td>format</td>
+    <td>Identifies the encoding as table keyed, must be set to 'iftk'</td>
   </tr>
   <tr>
     <td>uint32</td>
@@ -1732,8 +1732,8 @@ of that [=TablePatch=].
   </tr>
   <tr>
     <td>uint32</td>
-    <td>length</td>
-    <td>The uncompressed length of [=TablePatch/brotliStream=].</td>
+    <td><dfn for="TablePatch">maxUncompressedLength</dfn></td>
+    <td>The maximum uncompressed length of [=TablePatch/brotliStream=].</td>
   </tr>
   <tr>
     <td>uint8</td>
@@ -1765,9 +1765,8 @@ The algorithm:
 
 1. Initialize <var>extended font subset</var> to be an empty font with no tables.
 
-2. Check that the [=Table keyed patch/format=] field in <var>patch</var> is equal to 'iftk', if it is
-    not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
-    an error.
+2. Check that the <var>patch</var> is valid according to the requirements in [[#table-keyed]] (requirements are marked with a
+    "must") and all [=TablePatch=]'s are contained within <var>patch</var>. If it is not return an error.
 
 3. Check that the [=Table keyed patch/compatibilityId=] field in <var>patch</var> is equal to <var>compatibility id</var>.
     If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
@@ -1790,22 +1789,25 @@ The algorithm:
         are listed in the [=Table keyed patch/patches=] array.
 
 
-    *  If bit 0 (least significant bit) of [=TablePatch/flags=] is set, then decode [=TablePatch/brotliStream=] following
-        [[RFC7932#section-10]]. No shared dictionary is used. Add a [[open-type/otff#table-directory|table]] to
-        <var>extended font subset</var> identified by [=TablePatch/tag=] with it's contents set to the decoded [=TablePatch/brotliStream=].
-
     *  If bit 1 of [=TablePatch/flags=] is set, then do not copy or add a [[open-type/otff#table-directory|table]] to
-        <var>extended font subset</var> identified by [=TablePatch/tag=].
+        <var>extended font subset</var> identified by [=TablePatch/tag=]. Continue to the next entry.
+
+    *  If bit 0 (least significant bit) of [=TablePatch/flags=] is set, then decode [=TablePatch/brotliStream=] following
+        [[RFC7932#section-10]]. No shared dictionary is used. If the decoded data is larger than [=TablePatch/maxUncompressedLength=]
+        return an error. If there is any data in [=TablePatch/brotliStream=] which was not used by the decoding process return an error.
+        Add a [[open-type/otff#table-directory|table]] to <var>extended font subset</var> identified by
+        [=TablePatch/tag=] with it's contents set to the decoded [=TablePatch/brotliStream=]. Continue to the next entry.
 
     *  Otherwise, decode [=TablePatch/brotliStream=] following [[RFC7932#section-10]] and using the
         [[open-type/otff#table-directory|table]] identified by [=TablePatch/tag=] in <var>base font subset</var>
-        as a [[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. Add a [[open-type/otff#table-directory|table]] to
-        <var>extended font subset</var> identified by [=TablePatch/tag=] with it's contents set to the decoded [=TablePatch/brotliStream=].
+        as a [[Shared-Brotli#section-3.2|shared LZ77 dictionary]]. If no such table exists return an error. If the decoded data is
+        larger than [=TablePatch/maxUncompressedLength=] return an error. If there is any data in [=TablePatch/brotliStream=] which was
+        not used by the decoding process return an error. Add a [[open-type/otff#table-directory|table]] to
+        <var>extended font subset</var> identified by [=TablePatch/tag=] with it's contents set to the decoded
+        [=TablePatch/brotliStream=].
 
 6. For each [[open-type/otff#table-directory|table]] in <var>base font subset</var> which has a tag that was not found in any of
     the entries processed in step 5, add a copy of that table to <var>extended font subset</var>.
-
-
 
 Glyph Keyed {#glyph-keyed}
 --------------------------

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="dae2dc1472f2280bfb926fefc6cd933eaa04f2bc" name="revision">
+  <meta content="f088d8aa65f12d652e10de3f12037454f3953d74" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2065,8 +2065,8 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
       <th>Description
      <tr>
       <td>Tag
-      <td><dfn class="dfn-paneled" data-dfn-for="Table keyed patch" data-dfn-type="dfn" data-noexport id="table-keyed-patch-format">format</dfn>
-      <td>Identifies the encoding as table keyed, set to 'iftk'
+      <td>format
+      <td>Identifies the encoding as table keyed, must be set to 'iftk'
      <tr>
       <td>uint32
       <td>reserved
@@ -2103,8 +2103,8 @@ of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">Ta
       <td>Bit-field. If bit 0 (least significant bit) is set this patch replaces the existing table. If bit 1 is set this table is removed.
      <tr>
       <td>uint32
-      <td>length
-      <td>The uncompressed length of <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream">brotliStream</a>.
+      <td><dfn class="dfn-paneled" data-dfn-for="TablePatch" data-dfn-type="dfn" data-noexport id="tablepatch-maxuncompressedlength">maxUncompressedLength</dfn>
+      <td>The maximum uncompressed length of <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream">brotliStream</a>.
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="TablePatch" data-dfn-type="dfn" data-noexport id="tablepatch-brotlistream">brotliStream</dfn>[variable]
@@ -2133,9 +2133,8 @@ features, and/or design-variation space.</p>
     <li data-md>
      <p>Initialize <var>extended font subset</var> to be an empty font with no tables.</p>
     <li data-md>
-     <p>Check that the <a data-link-type="dfn" href="#table-keyed-patch-format" id="ref-for-table-keyed-patch-format">format</a> field in <var>patch</var> is equal to 'iftk', if it is
-not equal then <var>patch</var> is not correctly formatted. Patch application has failed, return
-an error.</p>
+     <p>Check that the <var>patch</var> is valid according to the requirements in <a href="#table-keyed">§ 6.2 Table Keyed</a> (requirements are marked with a
+"must") and all <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch②">TablePatch</a>'s are contained within <var>patch</var>. If it is not return an error.</p>
     <li data-md>
      <p>Check that the <a data-link-type="dfn" href="#table-keyed-patch-compatibilityid" id="ref-for-table-keyed-patch-compatibilityid">compatibilityId</a> field in <var>patch</var> is equal to <var>compatibility id</var>.
 If there is no match, or <var>base font subset</var> does not have either an 'IFT ' or 'IFTX' table, then patch application
@@ -2149,18 +2148,21 @@ can re-use the checksum from the entry in the source font. Otherwise a new check
      <p>For each entry in <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches①">patches</a>, with index <var>i</var>:</p>
      <ul>
       <li data-md>
-       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch②">TablePatch</a> associated with index <var>i</var>. The object starts at the offset <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches②">patches[i]</a> (inclusive) and ends at the offset <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
+       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch③">TablePatch</a> associated with index <var>i</var>. The object starts at the offset <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches②">patches[i]</a> (inclusive) and ends at the offset <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
 the <var>patch</var>.</p>
       <li data-md>
        <p>If an entry in <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches④">patches</a> was previously applied that has the same <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag">tag</a> as
 this entry, then ignore this entry and continue the iteration to the next one. Entries are processed in same order as they
 are listed in the <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches⑤">patches</a> array.</p>
       <li data-md>
-       <p>If bit 0 (least significant bit) of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags">flags</a> is set, then decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream①">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a>. No shared dictionary is used. Add a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag①">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream②">brotliStream</a>.</p>
+       <p>If bit 1 of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags">flags</a> is set, then do not copy or add a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag①">tag</a>. Continue to the next entry.</p>
       <li data-md>
-       <p>If bit 1 of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags①">flags</a> is set, then do not copy or add a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag②">tag</a>.</p>
+       <p>If bit 0 (least significant bit) of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags①">flags</a> is set, then decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream①">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a>. No shared dictionary is used. If the decoded data is larger than <a data-link-type="dfn" href="#tablepatch-maxuncompressedlength" id="ref-for-tablepatch-maxuncompressedlength">maxUncompressedLength</a> return an error. If there is any data in <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream②">brotliStream</a> which was not used by the decoding process return an error.
+Add a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag②">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream③">brotliStream</a>. Continue to the next entry.</p>
       <li data-md>
-       <p>Otherwise, decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream③">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a> and using the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag③">tag</a> in <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. Add a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag④">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream④">brotliStream</a>.</p>
+       <p>Otherwise, decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream④">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a> and using the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag③">tag</a> in <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. If no such table exists return an error. If the decoded data is
+larger than <a data-link-type="dfn" href="#tablepatch-maxuncompressedlength" id="ref-for-tablepatch-maxuncompressedlength①">maxUncompressedLength</a> return an error. If there is any data in <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream⑤">brotliStream</a> which was
+not used by the decoding process return an error. Add a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag④">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream⑥">brotliStream</a>.</p>
      </ul>
     <li data-md>
      <p>For each <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> in <var>base font subset</var> which has a tag that was not found in any of
@@ -2953,7 +2955,6 @@ to be used by default in most shaper implementations. This list was assembled fr
      <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
      <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 5.2.2</span>
      <li><a href="#glyph-keyed-patch-format">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
-     <li><a href="#table-keyed-patch-format">dfn for Table keyed patch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 5.2.1</span>
    <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 5.2.2</span>
@@ -2984,6 +2985,7 @@ to be used by default in most shaper implementations. This list was assembled fr
    <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 5.2.2</span>
    <li><a href="#format-1-patch-map-maxentryindex">maxEntryIndex</a><span>, in § 5.2.1</span>
    <li><a href="#format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</a><span>, in § 5.2.1</span>
+   <li><a href="#tablepatch-maxuncompressedlength">maxUncompressedLength</a><span>, in § 6.2</span>
    <li><a href="#no-invalidation">No Invalidation</a><span>, in § 4.1</span>
    <li><a href="#partial-invalidation">Partial Invalidation</a><span>, in § 4.1</span>
    <li><a href="#patch-application-algorithm">patch application algorithm</a><span>, in § 3.2</span>
@@ -3350,11 +3352,11 @@ let dfnPanelData = {
 "sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
 "table-keyed-patch": {"dfnID":"table-keyed-patch","dfnText":"Table keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch"},
 "table-keyed-patch-compatibilityid": {"dfnID":"table-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-compatibilityid"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-compatibilityid"},
-"table-keyed-patch-format": {"dfnID":"table-keyed-patch-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-format"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-format"},
 "table-keyed-patch-patches": {"dfnID":"table-keyed-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-patches"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-table-keyed-patch-patches\u2460"},{"id":"ref-for-table-keyed-patch-patches\u2461"},{"id":"ref-for-table-keyed-patch-patches\u2462"},{"id":"ref-for-table-keyed-patch-patches\u2463"},{"id":"ref-for-table-keyed-patch-patches\u2464"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-patches"},
-"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-tablepatch\u2461"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch"},
-"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch-brotlistream"},
+"tablepatch": {"dfnID":"tablepatch","dfnText":"TablePatch","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch"},{"id":"ref-for-tablepatch\u2460"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-tablepatch\u2461"},{"id":"ref-for-tablepatch\u2462"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch"},
+"tablepatch-brotlistream": {"dfnID":"tablepatch-brotlistream","dfnText":"brotliStream","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-brotlistream"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-tablepatch-brotlistream\u2460"},{"id":"ref-for-tablepatch-brotlistream\u2461"},{"id":"ref-for-tablepatch-brotlistream\u2462"},{"id":"ref-for-tablepatch-brotlistream\u2463"},{"id":"ref-for-tablepatch-brotlistream\u2464"},{"id":"ref-for-tablepatch-brotlistream\u2465"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch-brotlistream"},
 "tablepatch-flags": {"dfnID":"tablepatch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-flags"},{"id":"ref-for-tablepatch-flags\u2460"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch-flags"},
+"tablepatch-maxuncompressedlength": {"dfnID":"tablepatch-maxuncompressedlength","dfnText":"maxUncompressedLength","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-maxuncompressedlength"},{"id":"ref-for-tablepatch-maxuncompressedlength\u2460"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch-maxuncompressedlength"},
 "tablepatch-tag": {"dfnID":"tablepatch-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-tablepatch-tag"},{"id":"ref-for-tablepatch-tag\u2460"},{"id":"ref-for-tablepatch-tag\u2461"},{"id":"ref-for-tablepatch-tag\u2462"},{"id":"ref-for-tablepatch-tag\u2463"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#tablepatch-tag"},
 };
 
@@ -3831,11 +3833,11 @@ let refsData = {
 "#sparse-bit-set": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"sparse bit set","type":"dfn","url":"#sparse-bit-set"},
 "#table-keyed-patch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"table keyed patch","type":"dfn","url":"#table-keyed-patch"},
 "#table-keyed-patch-compatibilityid": {"export":true,"for_":["Table keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#table-keyed-patch-compatibilityid"},
-"#table-keyed-patch-format": {"export":true,"for_":["Table keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#table-keyed-patch-format"},
 "#table-keyed-patch-patches": {"export":true,"for_":["Table keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patches","type":"dfn","url":"#table-keyed-patch-patches"},
 "#tablepatch": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"tablepatch","type":"dfn","url":"#tablepatch"},
 "#tablepatch-brotlistream": {"export":true,"for_":["TablePatch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"brotlistream","type":"dfn","url":"#tablepatch-brotlistream"},
 "#tablepatch-flags": {"export":true,"for_":["TablePatch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"flags","type":"dfn","url":"#tablepatch-flags"},
+"#tablepatch-maxuncompressedlength": {"export":true,"for_":["TablePatch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxuncompressedlength","type":"dfn","url":"#tablepatch-maxuncompressedlength"},
 "#tablepatch-tag": {"export":true,"for_":["TablePatch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"tag","type":"dfn","url":"#tablepatch-tag"},
 };
 


### PR DESCRIPTION
- Make TablePatch/length into TablePatch/maxUncompressedLength and actually enforce it in the application algorithm.
- Clarify what happens when both bit 1 and 0 of flags are set, table removal takes priority.
- Make it an error for a non-replacement patch to be missing the base table in the source font.
- Make it an error to have leftover unused data in the brotliStream.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/220.html" title="Last updated on Oct 7, 2024, 2:51 AM UTC (ac7d201)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/220/f088d8a...ac7d201.html" title="Last updated on Oct 7, 2024, 2:51 AM UTC (ac7d201)">Diff</a>