### PR TITLE
Add a more general readiness check for finding which parts within a shaping unit are supported.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -584,23 +584,21 @@ incremental font:
 # supported by and can be safely rendered with ift_font.
 #
 # shaping_unit is an array where each item has a code point, associated list of
-# features, and the design space point that code point is being rendered with.
+# layout features, and the design space point that code point is being rendered with.
 def supported_spans(shaping_unit, ift_font):
-  current_start = None
-  current_end = None
-  current_subset_def = None
-
+  current_start, current_end, current_subset_def = None
   supported_spans = []
 
-  while i < len(shaping_unit):
+  i = 0
+  while i < shaping_unit.length():
     if current_subset_def is None:
       current_subset_def = SubsetDefinition()
       current_start = i
 
     current_end = i
-    current_subset_def.add(shapping_unit_text[i].codepoint,
-                           shapping_unit_text[i].features,
-                           shapping_unit_text[i].design_space_point)
+    current_subset_def.add(shaping_unit.codepoint_at(i),
+                           shaping_unit.features_at(i),
+                           shaping_unit.design_space_point_at(i))
 
     if not has_unapplied_patches(ift_font, current_subset_def):
       i += 1
@@ -613,9 +611,7 @@ def supported_spans(shaping_unit, ift_font):
     else:
       i += 1
 
-    current_subset_def = None
-    current_start = None
-    current_end = None
+    current_start, current_end, current_subset_def = None
 
   return supported_spans
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -575,29 +575,69 @@ parts of some content an incremental font can render:
 
 * Any shaping units that passed both checks can be rendered in their entirety with the font.
 
-The client may also wish to know what the font can render at a more granular level than a shaping unit. The following
-procedure can produce an approximate check at the Unicode code point level for any shaping units which failed the previous check:
+The client may also wish to know what the font can render at a more granular level than a shaping unit. The following pseudo code
+demonstrates a possible method for splitting a shaping unit which failed the above check up into spans which can be rendered using the
+incremental font:
 
-* For each code point within a shaping unit:
+<pre highlight="python">
+# Returns a list of spans, [start, end] inclusive, within shaping_unit that are
+# supported by and can be safely rendered with ift_font.
+#
+# shaping_unit is an array where each item has a code point, associated list of
+# features, and the design space point that code point is being rendered with.
+def supported_spans(shaping_unit, ift_font):
+  current_start = None
+  current_end = None
+  current_subset_def = None
 
-    *  If there is not a [[open-type/cmap|cmap]] entry for the code point, or the entry maps to glyph 0 then the incremental font does not
-         support rendering that code point.
+  supported_spans = []
 
-    *  Compute the point in design space and set of layout features which will apply to that
-         code point. Form a [=font subset definition=] which contains the code point, computed design space point, and layout features.
-         Execute the [$Extend an Incremental Font Subset$] algorithm, stopping at step 6. If the entry list is not empty then the
-         incremental font does not fully support rendering this specific code point at this position in the text.
+  while i < len(shaping_unit):
+    if current_subset_def is None:
+      current_subset_def = SubsetDefinition()
+      current_start = i
 
-In some cases the per code point procedure may report a code point as supported when there is an optional layout feature and multi
-character substitution lookup which has not been added to the font yet. The check will confirm that the font has enough support to render
-the code point in isolation. If the client is correctly following the [$Extend an Incremental Font Subset$] algorithm with
-a subset definition formed according to [[#target-subset-definitions]] then the missing data will be loaded and this case will only
-occur temporarily while the relevant patch is loading. Once the missing patch arrives and has been applied the rendering of the affected
+    current_end = i
+    current_subset_def.add(shapping_unit_text[i].codepoint,
+                           shapping_unit_text[i].features,
+                           shapping_unit_text[i].design_space_point)
+
+    if not has_unapplied_patches(ift_font, current_subset_def):
+      i += 1
+      continue
+
+    if current_end > current_start:
+      supported_spans.append(Span(current_start, current_end - 1))
+      # i isn't incremented so the current code point can be checked on it's own
+      # in the next iteration.
+    else:
+      i += 1
+
+    current_subset_def = None
+    current_start = None
+    current_end = None
+
+  return supported_spans
+
+
+# Returns true if ift_font has at least one unapplied patch which matches
+# subset_def.
+def has_unapplied_patches(ift_font, subset_def):
+  # Implementation: execute the "Extend an Incremental Font Subset" algorithm
+  # stopping at step 6. If the entry list is not empty then return true.
+  # Otherwise returns false.
+</pre>
+
+Any text from the shaping unit which is not covered by one of the returned spans is not supported by the incremental font and should
+be rendered with a fallback font. Each span should be shaped in isolation (ie. each span becomes a new shaping unit).
+Because this method splits a shaping unit up, not all features of the original font, such as multi code point substitutions, may be
+present. If the client is correctly following the [$Extend an Incremental Font Subset$] algorithm with a subset definition formed
+according to [[#target-subset-definitions]] then the missing data will be loaded and this case will only occur temporarily while the
+relevant patch is loading. Once the missing patch arrives and has been applied the rendering of the affected
 code points may change as a result of the substitution.
 
-Note: The per code point check above should not be used to drive incremental font extension. Target subset definitions for full executions
-of [$Extend an Incremental Font Subset$] should follow the guidelines in [[#target-subset-definitions]]. Similarly, rendering should be
-done using shaping units and not at a code point by code point level.
+Note: The "supported_spans(...)" check above should not be used to drive incremental font extension. Target subset definitions for full
+executions of [$Extend an Incremental Font Subset$] should follow the guidelines in [[#target-subset-definitions]].
 
 <h3 algorithm id="fully-expanding-a-font">Fully Expanding a Font</h3>
 
@@ -2231,9 +2271,9 @@ beyond the scope of this document). It typically involves a reachability analysi
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
 Any reachable data is retained in the generated font subset, while any unreachable data may be removed.
 
-In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only table keyed patches:
+In the following example pseudo code a font subsetter is used to generate an IFT encoded font that utilizes only table keyed patches:
 
-```
+<pre highlight="python">
 # Encode a font (full_font) into an incremental font that starts at base_subset_def
 # and can incrementally add any of subset_definitions. Returns the IFT encoded font
 # and set of associated patches.
@@ -2263,7 +2303,7 @@ encode_node(full_font, base_font, cur_def, subset_definitions):
     patches += (patch, patch_url)
   
   return base_font, patches
-```
+</pre>
 
 In this example implementation, if the union of the input base subset definition and the list of subset definitions fully covers the input
 full font, and the subsetter implementation used correctly retains all functionality then, the above implementation should meet the

--- a/Overview.bs
+++ b/Overview.bs
@@ -586,7 +586,7 @@ incremental font:
 # shaping_unit is an array where each item has a code point, associated list of
 # layout features, and the design space point that code point is being rendered with.
 def supported_spans(shaping_unit, ift_font):
-  current_start, current_end, current_subset_def = None
+  current_start = current_end = current_subset_def = None
   supported_spans = []
 
   i = 0
@@ -611,7 +611,7 @@ def supported_spans(shaping_unit, ift_font):
     else:
       i += 1
 
-    current_start, current_end, current_subset_def = None
+    current_start = current_end = current_subset_def = None
 
   return supported_spans
 

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="7a93ad95e4bc9884148c933c3ce952aa21c15345" name="revision">
+  <meta content="2ad687eabd88994fbd88c72f04cbedfc2eeacadd" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -579,6 +579,127 @@ dfn > a.self-link:hover {
 a.self-link::before            { content: "¶"; }
 .heading > a.self-link::before { content: "§"; }
 dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* Boilerplate: style-syntax-highlighting */
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+
+@media (prefers-color-scheme: dark) {
+    .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
+
+    c-[a] { color: #d33682 } /* Keyword.Declaration */
+    c-[b] { color: #d33682 } /* Keyword.Type */
+    c-[c] { color: #2aa198 } /* Comment */
+    c-[d] { color: #2aa198 } /* Comment.Multiline */
+    c-[e] { color: #268bd2 } /* Name.Attribute */
+    c-[f] { color: #b58900 } /* Name.Tag */
+    c-[g] { color: #cb4b16 } /* Name.Variable */
+    c-[k] { color: #d33682 } /* Keyword */
+    c-[l] { color: #657b83 } /* Literal */
+    c-[m] { color: #657b83 } /* Literal.Number */
+    c-[n] { color: #268bd2 } /* Name */
+    c-[o] { color: #657b83 } /* Operator */
+    c-[p] { color: #657b83 } /* Punctuation */
+    c-[s] { color: #6c71c4 } /* Literal.String */
+    c-[t] { color: #6c71c4 } /* Literal.String.Single */
+    c-[u] { color: #6c71c4 } /* Literal.String.Double */
+    c-[ch] { color: #2aa198 } /* Comment.Hashbang */
+    c-[cp] { color: #2aa198 } /* Comment.Preproc */
+    c-[cpf] { color: #2aa198 } /* Comment.PreprocFile */
+    c-[c1] { color: #2aa198 } /* Comment.Single */
+    c-[cs] { color: #2aa198 } /* Comment.Special */
+    c-[kc] { color: #d33682 } /* Keyword.Constant */
+    c-[kn] { color: #d33682 } /* Keyword.Namespace */
+    c-[kp] { color: #d33682 } /* Keyword.Pseudo */
+    c-[kr] { color: #d33682 } /* Keyword.Reserved */
+    c-[ld] { color: #657b83 } /* Literal.Date */
+    c-[nc] { color: #268bd2 } /* Name.Class */
+    c-[no] { color: #268bd2 } /* Name.Constant */
+    c-[nd] { color: #268bd2 } /* Name.Decorator */
+    c-[ni] { color: #268bd2 } /* Name.Entity */
+    c-[ne] { color: #268bd2 } /* Name.Exception */
+    c-[nf] { color: #268bd2 } /* Name.Function */
+    c-[nl] { color: #268bd2 } /* Name.Label */
+    c-[nn] { color: #268bd2 } /* Name.Namespace */
+    c-[py] { color: #268bd2 } /* Name.Property */
+    c-[ow] { color: #657b83 } /* Operator.Word */
+    c-[mb] { color: #657b83 } /* Literal.Number.Bin */
+    c-[mf] { color: #657b83 } /* Literal.Number.Float */
+    c-[mh] { color: #657b83 } /* Literal.Number.Hex */
+    c-[mi] { color: #657b83 } /* Literal.Number.Integer */
+    c-[mo] { color: #657b83 } /* Literal.Number.Oct */
+    c-[sa] { color: #6c71c4 } /* Literal.String.Affix */
+    c-[sb] { color: #6c71c4 } /* Literal.String.Backtick */
+    c-[sc] { color: #6c71c4 } /* Literal.String.Char */
+    c-[dl] { color: #6c71c4 } /* Literal.String.Delimiter */
+    c-[sd] { color: #6c71c4 } /* Literal.String.Doc */
+    c-[se] { color: #6c71c4 } /* Literal.String.Escape */
+    c-[sh] { color: #6c71c4 } /* Literal.String.Heredoc */
+    c-[si] { color: #6c71c4 } /* Literal.String.Interpol */
+    c-[sx] { color: #6c71c4 } /* Literal.String.Other */
+    c-[sr] { color: #6c71c4 } /* Literal.String.Regex */
+    c-[ss] { color: #6c71c4 } /* Literal.String.Symbol */
+    c-[fm] { color: #268bd2 } /* Name.Function.Magic */
+    c-[vc] { color: #cb4b16 } /* Name.Variable.Class */
+    c-[vg] { color: #cb4b16 } /* Name.Variable.Global */
+    c-[vi] { color: #cb4b16 } /* Name.Variable.Instance */
+    c-[vm] { color: #cb4b16 } /* Name.Variable.Magic */
+    c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
+}
 </style>
 <style>/* Boilerplate: style-var-click-highlighting */
 /*
@@ -1174,31 +1295,65 @@ stopping at step 6. If the entry list is not empty then the incremental font doe
     <li data-md>
      <p>Any shaping units that passed both checks can be rendered in their entirety with the font.</p>
    </ul>
-   <p>The client may also wish to know what the font can render at a more granular level than a shaping unit. The following
-procedure can produce an approximate check at the Unicode code point level for any shaping units which failed the previous check:</p>
-   <ul>
-    <li data-md>
-     <p>For each code point within a shaping unit:</p>
-     <ul>
-      <li data-md>
-       <p>If there is not a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> entry for the code point, or the entry maps to glyph 0 then the incremental font does not
- support rendering that code point.</p>
-      <li data-md>
-       <p>Compute the point in design space and set of layout features which will apply to that
- code point. Form a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definition</a> which contains the code point, computed design space point, and layout features.
- Execute the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset②">Extend an Incremental Font Subset</a> algorithm, stopping at step 6. If the entry list is not empty then the
- incremental font does not fully support rendering this specific code point at this position in the text.</p>
-     </ul>
-   </ul>
-   <p>In some cases the per code point procedure may report a code point as supported when there is an optional layout feature and multi
-character substitution lookup which has not been added to the font yet. The check will confirm that the font has enough support to render
-the code point in isolation. If the client is correctly following the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset③">Extend an Incremental Font Subset</a> algorithm with
-a subset definition formed according to <a href="#target-subset-definitions">§ 4.4 Target Subset Definition</a> then the missing data will be loaded and this case will only
-occur temporarily while the relevant patch is loading. Once the missing patch arrives and has been applied the rendering of the affected
+   <p>The client may also wish to know what the font can render at a more granular level than a shaping unit. The following pseudo code
+demonstrates a possible method for splitting a shaping unit which failed the above check up into spans which can be rendered using the
+incremental font:</p>
+<pre class="highlight"><c- c1># Returns a list of spans, [start, end] inclusive, within shaping_unit that are</c->
+<c- c1># supported by and can be safely rendered with ift_font.</c->
+<c- c1>#</c->
+<c- c1># shaping_unit is an array where each item has a code point, associated list of</c->
+<c- c1># features, and the design space point that code point is being rendered with.</c->
+<c- k>def</c-> <c- nf>supported_spans</c-><c- p>(</c-><c- n>shaping_unit</c-><c- p>,</c-> <c- n>ift_font</c-><c- p>):</c->
+  <c- n>current_start</c-> <c- o>=</c-> <c- kc>None</c->
+  <c- n>current_end</c-> <c- o>=</c-> <c- kc>None</c->
+  <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
+
+  <c- n>supported_spans</c-> <c- o>=</c-> <c- p>[]</c->
+
+  <c- k>while</c-> <c- n>i</c-> <c- o>&lt;</c-> len<c- p>(</c-><c- n>shaping_unit</c-><c- p>):</c->
+    <c- k>if</c-> <c- n>current_subset_def</c-> <c- ow>is</c-> <c- kc>None</c-><c- p>:</c->
+      <c- n>current_subset_def</c-> <c- o>=</c-> <c- n>SubsetDefinition</c-><c- p>()</c->
+      <c- n>current_start</c-> <c- o>=</c-> <c- n>i</c->
+
+    <c- n>current_end</c-> <c- o>=</c-> <c- n>i</c->
+    <c- n>current_subset_def</c-><c- o>.</c-><c- n>add</c-><c- p>(</c-><c- n>shapping_unit_text</c-><c- p>[</c-><c- n>i</c-><c- p>]</c-><c- o>.</c-><c- n>codepoint</c-><c- p>,</c->
+                           <c- n>shapping_unit_text</c-><c- p>[</c-><c- n>i</c-><c- p>]</c-><c- o>.</c-><c- n>features</c-><c- p>,</c->
+                           <c- n>shapping_unit_text</c-><c- p>[</c-><c- n>i</c-><c- p>]</c-><c- o>.</c-><c- n>design_space_point</c-><c- p>)</c->
+
+    <c- k>if</c-> <c- ow>not</c-> <c- n>has_unapplied_patches</c-><c- p>(</c-><c- n>ift_font</c-><c- p>,</c-> <c- n>current_subset_def</c-><c- p>):</c->
+      <c- n>i</c-> <c- o>+=</c-> <c- mi>1</c->
+      <c- k>continue</c->
+
+    <c- k>if</c-> <c- n>current_end</c-> <c- o>></c-> <c- n>current_start</c-><c- p>:</c->
+      <c- n>supported_spans</c-><c- o>.</c-><c- n>append</c-><c- p>(</c-><c- n>Span</c-><c- p>(</c-><c- n>current_start</c-><c- p>,</c-> <c- n>current_end</c-> <c- o>-</c-> <c- mi>1</c-><c- p>))</c->
+      <c- c1># i isn’t incremented so the current code point can be checked on it’s own</c->
+      <c- c1># in the next iteration.</c->
+    <c- k>else</c-><c- p>:</c->
+      <c- n>i</c-> <c- o>+=</c-> <c- mi>1</c->
+
+    <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
+    <c- n>current_start</c-> <c- o>=</c-> <c- kc>None</c->
+    <c- n>current_end</c-> <c- o>=</c-> <c- kc>None</c->
+
+  <c- k>return</c-> <c- n>supported_spans</c->
+
+
+<c- c1># Returns true if ift_font has at least one unapplied patch which matches</c->
+<c- c1># subset_def.</c->
+<c- k>def</c-> <c- nf>has_unapplied_patches</c-><c- p>(</c-><c- n>ift_font</c-><c- p>,</c-> <c- n>subset_def</c-><c- p>):</c->
+  <c- c1># Implementation: execute the "Extend an Incremental Font Subset" algorithm</c->
+  <c- c1># stopping at step 6. If the entry list is not empty then return true.</c->
+  <c- c1># Otherwise returns false.</c->
+</pre>
+   <p>Any text from the shaping unit which is not covered by one of the returned spans is not supported by the incremental font and should
+be rendered with a fallback font. Each span should be shaped in isolation (ie. each span becomes a new shaping unit).
+Because this method splits a shaping unit up, not all features of the original font, such as multi code point substitutions, may be
+present. If the client is correctly following the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset②">Extend an Incremental Font Subset</a> algorithm with a subset definition formed
+according to <a href="#target-subset-definitions">§ 4.4 Target Subset Definition</a> then the missing data will be loaded and this case will only occur temporarily while the
+relevant patch is loading. Once the missing patch arrives and has been applied the rendering of the affected
 code points may change as a result of the substitution.</p>
-   <p class="note" role="note"><span class="marker">Note:</span> The per code point check above should not be used to drive incremental font extension. Target subset definitions for full executions
-of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset④">Extend an Incremental Font Subset</a> should follow the guidelines in <a href="#target-subset-definitions">§ 4.4 Target Subset Definition</a>. Similarly, rendering should be
-done using shaping units and not at a code point by code point level.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> The "supported_spans(...)" check above should not be used to drive incremental font extension. Target subset definitions for full
+executions of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset③">Extend an Incremental Font Subset</a> should follow the guidelines in <a href="#target-subset-definitions">§ 4.4 Target Subset Definition</a>.</p>
    <h3 class="heading settled algorithm" data-algorithm="Fully Expanding a Font" data-level="4.6" id="fully-expanding-a-font"><span class="secno">4.6. </span><span class="content">Fully Expanding a Font</span><a class="self-link" href="#fully-expanding-a-font"></a></h3>
    <p>This sections defines an algorithm that can be used to transform an incremental font into a fully expanded non-incremental font. This
 process loads all available data provided by the incremental font and produces a single static font file that contains no further
@@ -1217,7 +1372,7 @@ patches to be applied.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑤">Extend an Incremental Font Subset</a> with <var>font subset</var>. The input target subset definition is a special one which
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset④">Extend an Incremental Font Subset</a> with <var>font subset</var>. The input target subset definition is a special one which
 is considered to intersect all entries in the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> step. Return the resulting font subset as
 the <var>expanded font</var>.</p>
    </ol>
@@ -1259,12 +1414,12 @@ file, the compressed font needs to be decoded before attempting to extend it.</p
    <ul>
     <li data-md>
      <p>Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URIs. It does
-not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
+not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
     <li data-md>
      <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
 is typically less compact than format 1.</p>
    </ul>
-   <p>Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑥">Extend an Incremental Font Subset</a> algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
+   <p>Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑤">Extend an Incremental Font Subset</a> algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
 encoded bytes are the source of truth at all times for the patch map. Patch application during subset extension will alter the encoded
 bytes of the patch map and as a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets
 the encoded bytes at the start of every iteration to pick up any changes made in the previous iteration.</p>
@@ -1609,7 +1764,7 @@ change the number of bytes.</p>
      <tr>
       <td>Tag
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags</dfn>[featureCount]
-      <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set. 
+      <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set. 
      <tr>
       <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount</dfn>
@@ -1617,7 +1772,7 @@ change the number of bytes.</p>
      <tr>
       <td><a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment">Design Space Segment</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments</dfn>[designSpaceCount]
-      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set. 
+      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copycount">copyCount</dfn>
@@ -1625,7 +1780,7 @@ change the number of bytes.</p>
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices</dfn>[copyCount]
-      <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> should be copied into this entry. May
+      <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a> should be copied into this entry. May
       only reference entries that occurred prior to this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
      <tr>
       <td>int24
@@ -2377,8 +2532,8 @@ The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-fon
     <li data-md>
      <p>Must meet all of the requirements in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 6 Font Patch Formats</a>.</p>
     <li data-md>
-     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①②">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑦">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
-of patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑧">Extend an Incremental Font Subset</a>.</p>
+     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑥">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
+of patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑦">Extend an Incremental Font Subset</a>.</p>
     <li data-md>
      <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
  should have all of the same <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> as the existing font (excluding the incremental IFT/IFTX
@@ -2386,7 +2541,7 @@ of patch selection chosen in step 6 of <a data-link-type="abstract-op" href="#ab
  expanded may not always be an exact binary match with the existing font.</p>
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font throughout the augmentation process, that is:
- given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①④">incremental font</a> and the minimal subset definition covering that content should
+ given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑧">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①④">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
    </ol>
    <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑤">incremental font</a> and a client is implemented according to the
@@ -2511,41 +2666,41 @@ The next two subsections discuss maintaining functional equivalent using the dif
    <p>When preparing <a href="#table-keyed">§ 6.2 Table Keyed</a> patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.</p>
-   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a>. The practice of reliably
+   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①②">font subset definition</a>. The practice of reliably
 subsetting a font is well understood and has multiple open-source implementations (a full formal description is
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
 Any reachable data is retained in the generated font subset, while any unreachable data may be removed.</p>
-   <p>In the following example psuedo code a font subsetter is used to generate an IFT encoded font that utilizes only table keyed patches:</p>
-<pre># Encode a font (full_font) into an incremental font that starts at base_subset_def
-# and can incrementally add any of subset_definitions. Returns the IFT encoded font
-# and set of associated patches.
-encode_as_ift(full_font, base_subset_def, subset_definitions):
-  base_font = subset(full_font, base_subset_def)
-  base_font, patches  = encode_node(full_font, base_font, base_subset_def, subset_definitions)
-  return base_font, patches
+   <p>In the following example pseudo code a font subsetter is used to generate an IFT encoded font that utilizes only table keyed patches:</p>
+<pre class="highlight"><c- c1># Encode a font (full_font) into an incremental font that starts at base_subset_def</c->
+<c- c1># and can incrementally add any of subset_definitions. Returns the IFT encoded font</c->
+<c- c1># and set of associated patches.</c->
+<c- n>encode_as_ift</c-><c- p>(</c-><c- n>full_font</c-><c- p>,</c-> <c- n>base_subset_def</c-><c- p>,</c-> <c- n>subset_definitions</c-><c- p>):</c->
+  <c- n>base_font</c-> <c- o>=</c-> <c- n>subset</c-><c- p>(</c-><c- n>full_font</c-><c- p>,</c-> <c- n>base_subset_def</c-><c- p>)</c->
+  <c- n>base_font</c-><c- p>,</c-> <c- n>patches</c->  <c- o>=</c-> <c- n>encode_node</c-><c- p>(</c-><c- n>full_font</c-><c- p>,</c-> <c- n>base_font</c-><c- p>,</c-> <c- n>base_subset_def</c-><c- p>,</c-> <c- n>subset_definitions</c-><c- p>)</c->
+  <c- k>return</c-> <c- n>base_font</c-><c- p>,</c-> <c- n>patches</c->
 
-# Update base_font to add all of the ift patch mappings to reach any of
-# subset_definitions and produces the associated patches.
-encode_node(full_font, base_font, cur_def, subset_definitions):
-  patches = []
-  next_fonts = []
+<c- c1># Update base_font to add all of the ift patch mappings to reach any of</c->
+<c- c1># subset_definitions and produces the associated patches.</c->
+<c- n>encode_node</c-><c- p>(</c-><c- n>full_font</c-><c- p>,</c-> <c- n>base_font</c-><c- p>,</c-> <c- n>cur_def</c-><c- p>,</c-> <c- n>subset_definitions</c-><c- p>):</c->
+  <c- n>patches</c-> <c- o>=</c-> <c- p>[]</c->
+  <c- n>next_fonts</c-> <c- o>=</c-> <c- p>[]</c->
   
-  for each subset_def in subset_definitions not fully covered by cur_def:
-    next_def = subset_def union cur_def
-    next_font = subset(full_font, next_def)
-    let patch_url be a new unique url
+  <c- k>for</c-> <c- n>each</c-> <c- n>subset_def</c-> <c- ow>in</c-> <c- n>subset_definitions</c-> <c- ow>not</c-> <c- n>fully</c-> <c- n>covered</c-> <c- n>by</c-> <c- n>cur_def</c-><c- p>:</c->
+    <c- n>next_def</c-> <c- o>=</c-> <c- n>subset_def</c-> <c- n>union</c-> <c- n>cur_def</c->
+    <c- n>next_font</c-> <c- o>=</c-> <c- n>subset</c-><c- p>(</c-><c- n>full_font</c-><c- p>,</c-> <c- n>next_def</c-><c- p>)</c->
+    <c- n>let</c-> <c- n>patch_url</c-> <c- n>be</c-> <c- n>a</c-> <c- n>new</c-> <c- n>unique</c-> <c- n>url</c->
 
-    add a mapping from, (subset_def - cur_def) to patch_url, into base_font
-    next_font, patches += encode_node(full_font, next_font, next_def, subset_definitions)
+    <c- n>add</c-> <c- n>a</c-> <c- n>mapping</c-> <c- n>from</c-><c- p>,</c-> <c- p>(</c-><c- n>subset_def</c-> <c- o>-</c-> <c- n>cur_def</c-><c- p>)</c-> <c- n>to</c-> <c- n>patch_url</c-><c- p>,</c-> <c- n>into</c-> <c- n>base_font</c->
+    <c- n>next_font</c-><c- p>,</c-> <c- n>patches</c-> <c- o>+=</c-> <c- n>encode_node</c-><c- p>(</c-><c- n>full_font</c-><c- p>,</c-> <c- n>next_font</c-><c- p>,</c-> <c- n>next_def</c-><c- p>,</c-> <c- n>subset_definitions</c-><c- p>)</c->
 
-    next_fonts += (next_font, next_def, patch_url)
+    <c- n>next_fonts</c-> <c- o>+=</c-> <c- p>(</c-><c- n>next_font</c-><c- p>,</c-> <c- n>next_def</c-><c- p>,</c-> <c- n>patch_url</c-><c- p>)</c->
 
-  for each (next_font, next_def, patch_url) in next_fonts:
-    patch = table_keyed_patch_diff(base_font, next_font)
-    patches += (patch, patch_url)
+  <c- k>for</c-> <c- n>each</c-> <c- p>(</c-><c- n>next_font</c-><c- p>,</c-> <c- n>next_def</c-><c- p>,</c-> <c- n>patch_url</c-><c- p>)</c-> <c- ow>in</c-> <c- n>next_fonts</c-><c- p>:</c->
+    <c- n>patch</c-> <c- o>=</c-> <c- n>table_keyed_patch_diff</c-><c- p>(</c-><c- n>base_font</c-><c- p>,</c-> <c- n>next_font</c-><c- p>)</c->
+    <c- n>patches</c-> <c- o>+=</c-> <c- p>(</c-><c- n>patch</c-><c- p>,</c-> <c- n>patch_url</c-><c- p>)</c->
   
-  return base_font, patches
+  <c- k>return</c-> <c- n>base_font</c-><c- p>,</c-> <c- n>patches</c->
 </pre>
    <p>In this example implementation, if the union of the input base subset definition and the list of subset definitions fully covers the input
 full font, and the subsetter implementation used correctly retains all functionality then, the above implementation should meet the
@@ -2556,17 +2711,17 @@ sections.</p>
    <p><b><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches</b></p>
    <p>Specifically because they are parameterized by code points and feature tags but can be applied independently of one another, <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches have additional requirements and cannot be directly derived by using a subsetter implementation.  However,
 such an implementation can help clarify what an encoder needs to do to maintain functional equivalence when producing this type
-of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①④">font subset definition</a>. We can define
-the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑤">font subset definition</a> as the full set of glyphs included in the subset, which the
+of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a>. We can define
+the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①④">font subset definition</a> as the full set of glyphs included in the subset, which the
 subsetter has determined is needed to render any combination of the described code points and layout features.</p>
    <p>Using that definition, the <b>glyph closure requirement</b> on the full set <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches is:</p>
    <ul>
     <li data-md>
-     <p>The set of glyphs contained in the patches loaded for a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a> through the patch map tables must be a superset
-of those in the <a data-link-type="dfn" href="#glyph-closure" id="ref-for-glyph-closure">glyph closure</a> of the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑦">font subset definition</a>.</p>
+     <p>The set of glyphs contained in the patches loaded for a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑤">font subset definition</a> through the patch map tables must be a superset
+of those in the <a data-link-type="dfn" href="#glyph-closure" id="ref-for-glyph-closure">glyph closure</a> of the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a>.</p>
    </ul>
    <p>Assuming the subsetter does its job accurately, the glyph closure requirement is a consequence of the requirement for equivalent
-behavior: Suppose there is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑧">font subset definition</a> such that the subsetter includes glyph *i* in its subset, but an encoder that
+behavior: Suppose there is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑦">font subset definition</a> such that the subsetter includes glyph *i* in its subset, but an encoder that
 produces <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches omits glyph *i* from the set of patches that correspond to that definition. If the subsetter is
 right, that glyph must be present to retain equivalent behavior when rendering some combination of the code points and features in 
 the definition, which means that the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑨">incremental font</a> will not behave equivalently when rendering that combination.</p>
@@ -3336,7 +3491,7 @@ let dfnPanelData = {
 "abstract-opdef-apply-table-keyed-patch": {"dfnID":"abstract-opdef-apply-table-keyed-patch","dfnText":"Apply table keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-table-keyed-patch"},
 "abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.6. Fully Expanding a Font"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
-"abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"}],"title":"4.4. Target Subset Definition"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"}],"title":"4.5. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2464"}],"title":"4.6. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2465"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2466"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2467"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2468"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
+"abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"}],"title":"4.4. Target Subset Definition"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"}],"title":"4.5. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"}],"title":"4.6. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2464"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2465"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2466"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2467"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "abstract-opdef-fully-expand-a-font-subset": {"dfnID":"abstract-opdef-fully-expand-a-font-subset","dfnText":"Fully Expand a Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset"}],"title":"2.1. Offline Usage"},{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2460"},{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2461"}],"title":"7. Encoding"}],"url":"#abstract-opdef-fully-expand-a-font-subset"},
 "abstract-opdef-handle-errors": {"dfnID":"abstract-opdef-handle-errors","dfnText":"Handle errors","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-handle-errors"},{"id":"ref-for-abstract-opdef-handle-errors\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-handle-errors"},
 "abstract-opdef-interpret-format-1-patch-map": {"dfnID":"abstract-opdef-interpret-format-1-patch-map","dfnText":"Interpret Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-1-patch-map"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-interpret-format-1-patch-map"},
@@ -3362,7 +3517,7 @@ let dfnPanelData = {
 "featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"},{"id":"ref-for-featurerecord-firstnewentryindex\u2460"},{"id":"ref-for-featurerecord-firstnewentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
 "font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.6. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2464"},{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2467"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2468"},{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2461"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
-"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2463"},{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"},{"id":"ref-for-font-subset-definition\u2466"}],"title":"4.5. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-font-subset-definition\u2467"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2468"},{"id":"ref-for-font-subset-definition\u2460\u24ea"},{"id":"ref-for-font-subset-definition\u2460\u2460"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2461"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2462"},{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"},{"id":"ref-for-font-subset-definition\u2460\u2466"},{"id":"ref-for-font-subset-definition\u2460\u2467"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
+"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2463"},{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"4.5. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2467"},{"id":"ref-for-font-subset-definition\u2468"},{"id":"ref-for-font-subset-definition\u2460\u24ea"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2460"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2461"},{"id":"ref-for-font-subset-definition\u2460\u2462"},{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"},{"id":"ref-for-font-subset-definition\u2460\u2466"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
 "format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="2ad687eabd88994fbd88c72f04cbedfc2eeacadd" name="revision">
+  <meta content="75d55d4f35818826858aa7bd5f693ec5785e04a1" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1302,23 +1302,21 @@ incremental font:</p>
 <c- c1># supported by and can be safely rendered with ift_font.</c->
 <c- c1>#</c->
 <c- c1># shaping_unit is an array where each item has a code point, associated list of</c->
-<c- c1># features, and the design space point that code point is being rendered with.</c->
+<c- c1># layout features, and the design space point that code point is being rendered with.</c->
 <c- k>def</c-> <c- nf>supported_spans</c-><c- p>(</c-><c- n>shaping_unit</c-><c- p>,</c-> <c- n>ift_font</c-><c- p>):</c->
-  <c- n>current_start</c-> <c- o>=</c-> <c- kc>None</c->
-  <c- n>current_end</c-> <c- o>=</c-> <c- kc>None</c->
-  <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
-
+  <c- n>current_start</c-><c- p>,</c-> <c- n>current_end</c-><c- p>,</c-> <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
   <c- n>supported_spans</c-> <c- o>=</c-> <c- p>[]</c->
 
-  <c- k>while</c-> <c- n>i</c-> <c- o>&lt;</c-> len<c- p>(</c-><c- n>shaping_unit</c-><c- p>):</c->
+  <c- n>i</c-> <c- o>=</c-> <c- mi>0</c->
+  <c- k>while</c-> <c- n>i</c-> <c- o>&lt;</c-> <c- n>shaping_unit</c-><c- o>.</c-><c- n>length</c-><c- p>():</c->
     <c- k>if</c-> <c- n>current_subset_def</c-> <c- ow>is</c-> <c- kc>None</c-><c- p>:</c->
       <c- n>current_subset_def</c-> <c- o>=</c-> <c- n>SubsetDefinition</c-><c- p>()</c->
       <c- n>current_start</c-> <c- o>=</c-> <c- n>i</c->
 
     <c- n>current_end</c-> <c- o>=</c-> <c- n>i</c->
-    <c- n>current_subset_def</c-><c- o>.</c-><c- n>add</c-><c- p>(</c-><c- n>shapping_unit_text</c-><c- p>[</c-><c- n>i</c-><c- p>]</c-><c- o>.</c-><c- n>codepoint</c-><c- p>,</c->
-                           <c- n>shapping_unit_text</c-><c- p>[</c-><c- n>i</c-><c- p>]</c-><c- o>.</c-><c- n>features</c-><c- p>,</c->
-                           <c- n>shapping_unit_text</c-><c- p>[</c-><c- n>i</c-><c- p>]</c-><c- o>.</c-><c- n>design_space_point</c-><c- p>)</c->
+    <c- n>current_subset_def</c-><c- o>.</c-><c- n>add</c-><c- p>(</c-><c- n>shaping_unit</c-><c- o>.</c-><c- n>codepoint_at</c-><c- p>(</c-><c- n>i</c-><c- p>),</c->
+                           <c- n>shaping_unit</c-><c- o>.</c-><c- n>features_at</c-><c- p>(</c-><c- n>i</c-><c- p>),</c->
+                           <c- n>shaping_unit</c-><c- o>.</c-><c- n>design_space_point_at</c-><c- p>(</c-><c- n>i</c-><c- p>))</c->
 
     <c- k>if</c-> <c- ow>not</c-> <c- n>has_unapplied_patches</c-><c- p>(</c-><c- n>ift_font</c-><c- p>,</c-> <c- n>current_subset_def</c-><c- p>):</c->
       <c- n>i</c-> <c- o>+=</c-> <c- mi>1</c->
@@ -1331,9 +1329,7 @@ incremental font:</p>
     <c- k>else</c-><c- p>:</c->
       <c- n>i</c-> <c- o>+=</c-> <c- mi>1</c->
 
-    <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
-    <c- n>current_start</c-> <c- o>=</c-> <c- kc>None</c->
-    <c- n>current_end</c-> <c- o>=</c-> <c- kc>None</c->
+    <c- n>current_start</c-><c- p>,</c-> <c- n>current_end</c-><c- p>,</c-> <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
 
   <c- k>return</c-> <c- n>supported_spans</c->
 


### PR DESCRIPTION
Insted of checking code point by code point, greedily accumulate spans of text which do not have any matching unnapplied patches. Each span can be safely rendered in isolation, however substitution rules between spans will not work until font extension is complete for the shaping unit.

This works on the following assumptions:
- By encoder requirements, if we have a span of text with an associated subset definition and there are no unapplied patches matching that definition then that span of text can be rendered correctly in isolation.
- Then while a shaping unit as a whole is not ready we can still find spans within that unit which are ready.

Given that, we can then use a straightforward greedy approach where we incrementally increase a span until it fails the intersection check. This then repeats to form as many spans as possible within the shaping unit. Code points which are not currently supported at all will not be included in any of the returned spans, and those should be rendered with a fallback.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/227.html" title="Last updated on Oct 30, 2024, 11:04 PM UTC (8cb7b66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/227/2ad687e...8cb7b66.html" title="Last updated on Oct 30, 2024, 11:04 PM UTC (8cb7b66)">Diff</a>