### PR TITLE
In the readiness check also check that cmap supports each codepoint.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -600,7 +600,7 @@ def supported_spans(shaping_unit, ift_font):
                            shaping_unit.features_at(i),
                            shaping_unit.design_space_point_at(i))
 
-    if not has_unapplied_patches(ift_font, current_subset_def):
+    if supports_subset_def(ift_font, current_subset_def):
       i += 1
       continue
 
@@ -616,12 +616,12 @@ def supported_spans(shaping_unit, ift_font):
   return supported_spans
 
 
-# Returns true if ift_font has at least one unapplied patch which matches
-# subset_def.
-def has_unapplied_patches(ift_font, subset_def):
-  # Implementation: execute the "Extend an Incremental Font Subset" algorithm
-  # stopping at step 6. If the entry list is not empty then return true.
-  # Otherwise returns false.
+# Returns true if ift_font has support for rendering content covered by subset_def.
+def supports_subset_def(ift_font, subset_def):
+  # Return true only if both of the following two checks are true:
+  # - Each code point in subset_def is mapped to a glyph id other than '0' by ift_font's cmap table.
+  # - After executing the "Extend an Incremental Font Subset" algorithm on ift_font with subset_def and stopping at step 6 the
+  #   entry list is empty.
 </pre>
 
 Any text from the shaping unit which is not covered by one of the returned spans is not supported by the incremental font and should

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="75d55d4f35818826858aa7bd5f693ec5785e04a1" name="revision">
+  <meta content="0d75a6c2ab28a5270ebf37ea59f9960ede1371e6" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1304,7 +1304,7 @@ incremental font:</p>
 <c- c1># shaping_unit is an array where each item has a code point, associated list of</c->
 <c- c1># layout features, and the design space point that code point is being rendered with.</c->
 <c- k>def</c-> <c- nf>supported_spans</c-><c- p>(</c-><c- n>shaping_unit</c-><c- p>,</c-> <c- n>ift_font</c-><c- p>):</c->
-  <c- n>current_start</c-><c- p>,</c-> <c- n>current_end</c-><c- p>,</c-> <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
+  <c- n>current_start</c-> <c- o>=</c-> <c- n>current_end</c-> <c- o>=</c-> <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
   <c- n>supported_spans</c-> <c- o>=</c-> <c- p>[]</c->
 
   <c- n>i</c-> <c- o>=</c-> <c- mi>0</c->
@@ -1318,7 +1318,7 @@ incremental font:</p>
                            <c- n>shaping_unit</c-><c- o>.</c-><c- n>features_at</c-><c- p>(</c-><c- n>i</c-><c- p>),</c->
                            <c- n>shaping_unit</c-><c- o>.</c-><c- n>design_space_point_at</c-><c- p>(</c-><c- n>i</c-><c- p>))</c->
 
-    <c- k>if</c-> <c- ow>not</c-> <c- n>has_unapplied_patches</c-><c- p>(</c-><c- n>ift_font</c-><c- p>,</c-> <c- n>current_subset_def</c-><c- p>):</c->
+    <c- k>if</c-> <c- n>supports_subset_def</c-><c- p>(</c-><c- n>ift_font</c-><c- p>,</c-> <c- n>current_subset_def</c-><c- p>):</c->
       <c- n>i</c-> <c- o>+=</c-> <c- mi>1</c->
       <c- k>continue</c->
 
@@ -1329,17 +1329,17 @@ incremental font:</p>
     <c- k>else</c-><c- p>:</c->
       <c- n>i</c-> <c- o>+=</c-> <c- mi>1</c->
 
-    <c- n>current_start</c-><c- p>,</c-> <c- n>current_end</c-><c- p>,</c-> <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
+    <c- n>current_start</c-> <c- o>=</c-> <c- n>current_end</c-> <c- o>=</c-> <c- n>current_subset_def</c-> <c- o>=</c-> <c- kc>None</c->
 
   <c- k>return</c-> <c- n>supported_spans</c->
 
 
-<c- c1># Returns true if ift_font has at least one unapplied patch which matches</c->
-<c- c1># subset_def.</c->
-<c- k>def</c-> <c- nf>has_unapplied_patches</c-><c- p>(</c-><c- n>ift_font</c-><c- p>,</c-> <c- n>subset_def</c-><c- p>):</c->
-  <c- c1># Implementation: execute the "Extend an Incremental Font Subset" algorithm</c->
-  <c- c1># stopping at step 6. If the entry list is not empty then return true.</c->
-  <c- c1># Otherwise returns false.</c->
+<c- c1># Returns true if ift_font has support for rendering content covered by subset_def.</c->
+<c- k>def</c-> <c- nf>supports_subset_def</c-><c- p>(</c-><c- n>ift_font</c-><c- p>,</c-> <c- n>subset_def</c-><c- p>):</c->
+  <c- c1># Return true only if both of the following two checks are true:</c->
+  <c- c1># - Each code point in subset_def is mapped to a glyph id other than '0' by ift_font’s cmap table.</c->
+  <c- c1># - After executing the "Extend an Incremental Font Subset" algorithm on ift_font with subset_def and stopping at step 6 the</c->
+  <c- c1>#   entry list is empty.</c->
 </pre>
    <p>Any text from the shaping unit which is not covered by one of the returned spans is not supported by the incremental font and should
 be rendered with a fallback font. Each span should be shaped in isolation (ie. each span becomes a new shaping unit).


### PR DESCRIPTION
Missed in the previous PR, we also need to check that the font normally supports the code point by checking it is present in the cmap table.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/229.html" title="Last updated on Oct 31, 2024, 12:02 AM UTC (44c2d97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/229/0d75a6c...44c2d97.html" title="Last updated on Oct 31, 2024, 12:02 AM UTC (44c2d97)">Diff</a>