### PR TITLE
Fix a couple of mistakes in the URI template examples.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1872,7 +1872,17 @@ Some example inputs and the corresponding expansions:
   <tr>
     <td>//foo.bar{/d1,d2,d3,id}</td>
     <td>àbc</td>
-    <td>//foo.bar/0/0/4/OEG64OO</td>
+    <td>//foo.bar/O/O/4/OEG64OO</td>
+  </tr>
+  <tr>
+    <td>//foo.bar{/id64}</td>
+    <td>14,000,000</td>
+    <td>//foo.bar/1Z-A</td>
+  </tr>
+  <tr>
+    <td>//foo.bar{/id64}</td>
+    <td>17,000,000</td>
+    <td>//foo.bar/AQNmQA%3D%3D</td>
   </tr>
   <tr>
     <td>//foo.bar{/id64}</td>
@@ -1880,7 +1890,7 @@ Some example inputs and the corresponding expansions:
     <td>//foo.bar/w6BiYw%3D%3D</td>
   </tr>
   <tr>
-    <td>//foo.bar{/+id64}</td>
+    <td>//foo.bar/{+id64}</td>
     <td>àbcd</td>
     <td>//foo.bar/w6BiY2Q=</td>
   </tr>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="f8ae95814f7c787037b1b027cd66cbb49962bcc2" name="revision">
+  <meta content="3fda23d1e46095fde9054426c2e48ca5cf3a6da6" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2324,8 +2324,8 @@ A string ID is a sequence of bytes. Several variables are defined which are used
       (For example, when the integer is less than 256 only one byte is encoded.) When the input id is
       a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
    </table>
-   <div class="example" id="example-73881657">
-    <a class="self-link" href="#example-73881657"></a> 
+   <div class="example" id="example-96830d51">
+    <a class="self-link" href="#example-96830d51"></a> 
     <p>Some example inputs and the corresponding expansions:</p>
     <table>
      <tbody>
@@ -2356,13 +2356,21 @@ A string ID is a sequence of bytes. Several variables are defined which are used
       <tr>
        <td>//foo.bar{/d1,d2,d3,id}
        <td>àbc
-       <td>//foo.bar/0/0/4/OEG64OO
+       <td>//foo.bar/O/O/4/OEG64OO
+      <tr>
+       <td>//foo.bar{/id64}
+       <td>14,000,000
+       <td>//foo.bar/1Z-A
+      <tr>
+       <td>//foo.bar{/id64}
+       <td>17,000,000
+       <td>//foo.bar/AQNmQA%3D%3D
       <tr>
        <td>//foo.bar{/id64}
        <td>àbc
        <td>//foo.bar/w6BiYw%3D%3D
       <tr>
-       <td>//foo.bar{/+id64}
+       <td>//foo.bar/{+id64}
        <td>àbcd
        <td>//foo.bar/w6BiY2Q=
     </table>


### PR DESCRIPTION
- Accidental swap of O with 0.
- Invalid template syntax {/+id64} changed to /{+id64}
- Added examples using numeric ids and id64 variable.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/236.html" title="Last updated on Nov 14, 2024, 12:10 AM UTC (c35a328)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/236/3fda23d...c35a328.html" title="Last updated on Nov 14, 2024, 12:10 AM UTC (c35a328)">Diff</a>