### PR TITLE
Add appendix B which contains an example of the extension algorithm execution.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -2884,7 +2884,7 @@ Inputs:
 
 Iteration 1:
 
-*  Steps 1 through 6 - applying the [$Check entry intersection$] check to all entries, the following patch entries intersect:
+*  Steps 1 through 6 - applying the [$Check entry intersection$] check to all entries in the initial font, the following patch entries intersect:
     * //foo.bar/01.tk
     * //foo.bar/02.tk
     * //foo.bar/04.tk
@@ -2928,7 +2928,8 @@ Iteration 1:
 
 Iteration 2:
 
-*  Steps 2 through 6 - applying the [$Check entry intersection$] check to all entries, the following patch entries intersect:
+*  Steps 2 through 6 - applying the [$Check entry intersection$] check to all entries in the updated font from the previous iteration, the following patch
+    entries intersect:
     * //foo.bar/01.gk
     * //foo.bar/04.gk
 
@@ -2943,7 +2944,8 @@ Iteration 2:
 
 Iteration 3:
 
-*  Steps 2 through 6 - applying the [$Check entry intersection$] check to all entries, the following patch entries intersect:
+*  Steps 2 through 6 - applying the [$Check entry intersection$] check to all entries in the updated font from the previous iteration, the following patch
+    entries intersect:
     * //foo.bar/04.gk
 
 *  Step 7 - one entry remains, it is selected.

--- a/Overview.bs
+++ b/Overview.bs
@@ -500,6 +500,10 @@ be needed in later iterations.
 Note: if the only remaining intersecting entries are no invalidation entries the intersection check in step 5 does not need to be repeated on each
 iteration since no invalidation patches won't change the list of available patches upon application (other then to remove the just applied patch).
 
+<div class="example">
+An example of the execution of the extension algorithm can be found in [[#extension-example]].
+</div>
+
 <dfn abstract-op>Check entry intersection</dfn>
 
 The inputs to this algorithm are:
@@ -2733,3 +2737,225 @@ to be used by default in most shaper implementations. This list was assembled fr
 <!-- Edit feature-registry.csv to update this table. -->
 path: feature-registry.html
 </pre>
+
+
+<h2 id="extension-example">
+Appendix B: Extension Algorithm Example Execution</h2>
+
+This appendix provides an example of how a typical IFT font would be processed by the [[#extend-font-subset]] algorithm. In this example the IFT font
+contains a mix of both [[#table-keyed]] and [[#glyph-keyed]] patches.
+
+<b>Initial font</b>: contains the following IFT and IFTX patch mappings. Note: when features and design space sets are unspecified in a subset definition
+they are defaulted to an empty set.
+
+<table>
+  <tr><th>Table = "IFT "</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0001</th></tr>
+  <tr><th>Subset Definition(s)</th><th>URI</th><th>Format Number</th>
+  <tr>
+    <td>
+      ```
+      code points: { 'a', 'b', ..., 'z' }
+      ```
+    </td>
+    <td>//foo.bar/01.tk</td>
+    <td>
+      2, Table Keyed - Partial Invalidation
+    </td>
+  </tr>
+  <tr>
+    <td>
+      ```
+      code points: { 'A', 'B', ..., 'Z' }
+      ```
+    </td>
+    <td>//foo.bar/02.tk</td>
+    <td>
+      2, Table Keyed - Partial Invalidation
+    </td>
+  </tr>
+  <tr>
+    <td>
+      ```
+      code points: { '0', '1', ..., '9' }
+      ```
+    </td>
+    <td>//foo.bar/03.tk</td>
+    <td>
+      2, Table Keyed - Partial Invalidation
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      ```
+      code points: { 'a', 'b', ..., 'z',
+                     'A', 'B', ..., 'Z' }
+      ```
+    </td>
+    <td>//foo.bar/04.tk</td>
+    <td>
+      2, Table Keyed - Partial Invalidation
+    </td>
+  </tr>
+  <tr>
+    <td>
+      ```
+      code points: { 'a', 'b', ..., 'z',
+                     'A', 'B', ..., 'Z',
+                     '0', '1', ..., '9' }
+      ```
+    </td>
+    <td>//foo.bar/05.tk</td>
+    <td>
+      2, Table Keyed - Partial Invalidation
+    </td>
+  </tr>
+</table>
+<br/>
+<table>
+  <tr><th>Table = "IFTX"</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0002</th></tr>
+  <tr><th>Subset Definition(s)</th><th>URI</th><th>Format Number</th>
+  <tr>
+    <td>
+      ```
+      code points: { 'a', 'b', ..., 'm' }
+      ```
+    </td>
+    <td>//foo.bar/01.gk</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+  </tr>
+  <tr>
+    <td>
+      ```
+      code points: { 'n', 'o', ..., 'z' }
+      ```
+    </td>
+    <td>//foo.bar/02.gk</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+  </tr>
+  <tr>
+    <td>
+      ```
+      code points: { 'A', 'B', ..., 'M' }
+      ```
+    </td>
+    <td>//foo.bar/03.gk</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+  </tr>
+  <tr>
+    <td>
+      ```
+      code points: { 'N', 'O', ..., 'Z' }
+      ```
+    </td>
+    <td>//foo.bar/04.gk</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+  </tr>
+  <tr>
+    <td>
+      ```
+      code points: { '0', '1', ..., '9' }
+      ```
+    </td>
+    <td>//foo.bar/05.gk</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+  </tr>
+</table>
+
+<b>Optimized Extension Example</b>
+
+Note: this example execution is described as it would be implemented in an optimized client which aims to reduce the number of round trips needing to be
+      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but preloads some URIs
+      that are expected to be needed ahead of time to reduce round trips.
+
+Inputs:
+*  Initial font with the IFT and IFTX tables as defined above.
+*  Target subset definition: code points = {'f', 'P'}
+
+Iteration 1:
+
+*  Steps 1 through 6 - applying the [$Check entry intersection$] check to all entries, the following patch entries intersect:
+    * //foo.bar/01.tk
+    * //foo.bar/02.tk
+    * //foo.bar/04.tk
+    * //foo.bar/05.tk
+    * //foo.bar/01.gk
+    * //foo.bar/04.gk
+
+<!-- TODO: once we have a section describing criteria for making selections within an invalidating group reference that here -->
+*  Step 7 - one entry from that set must be picked. There a no full invalidation entries, so one partial invalidation entry (//foo.bar/*.tk) must be
+    selected. //foo.bar/04.tk is the most likely best choice, since it fully covers the target subset definition (minimizing round trips) and should be
+    smaller than //foo.bar/05.tk which contains additional support for '0' through '9' which are not currently requested.
+
+*  Step 8 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
+    patches //foo.bar/01.gk and //foo.bar/04.gk. The table keyed patch //foo.bar/04.tk is partially invalidating which means the two glyph keyed patches
+    will be remain valid after the application of //foo.bar/04.tk. Thus the client can expect that the two glyph keyed patches will be required in future
+    iterations and preemptively begin the loads for those two patches.
+
+*  Step 9 - The fetched patch //foo.bar/04.tk is applied to the initial font. This patch updates all tables except for glyf and loca
+    to add support for code points 'a' through 'Z'. Additionally the mapping in the "IFT " table is updated to the following:
+
+    <table>
+      <tr><th>Table = "IFT "</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0006</th></tr>
+      <tr><th>Subset Definition(s)</th><th>URI</th><th>Format Number</th>
+      <tr>
+        <td>
+          ```
+          code points: { '0', '1', ..., '9' }
+          ```
+        </td>
+        <td>//foo.bar/08.tk</td>
+        <td>
+          2, Table Keyed - Partial Invalidation
+        </td>
+      </tr>
+    </table>
+
+    Note the following changes:
+    *  All entries that have data for 'a', ... 'z', and 'A', ..., 'Z' have been removed. Leaving just one entry for the remaining '0', ..., '9' code points.
+    *  The font binary has changed and thus the previously listed table keyed patches are no longer valid. As a result the compatibility ID has changed and
+        the URI for the remaining '0', ..., '9' entry has changed. The patch at the new URI, //foo.bar/08.tk, is compatible with the updated font.
+
+Iteration 2:
+
+*  Steps 2 through 6 - applying the [$Check entry intersection$] check to all entries, the following patch entries intersect:
+    * //foo.bar/01.gk
+    * //foo.bar/04.gk
+
+*  Step 7 - one entry from that set must be picked. Only no invalidation patches remain, the client is free to pick either one. In this case it selects
+    the first one //foo.bar/01.gk.
+
+*  Step 8 - the fetch for //foo.bar/01.gk was previously started during iteration 1.
+
+*  Step 9 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'z'
+    to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/01.gk. The compatibility ID
+    and URIs for other entries are unchanged.
+
+Iteration 3:
+
+*  Steps 2 through 6 - applying the [$Check entry intersection$] check to all entries, the following patch entries intersect:
+    * //foo.bar/04.gk
+
+*  Step 7 - one entry remains, it is selected.
+
+*  Step 8 - the fetch for //foo.bar/04.gk was previously started during iteration 1.
+
+*  Step 9 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'A' through 'Z'
+    to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/04.gk. The compatibility ID
+    and URIs for other entries are unchanged.
+
+
+Iteration 4:
+
+*  Steps 2 through 6 - there are no remaining intersecting entries so the algorithm terminates. The font subset is returned and now ready to render any
+    content covered by the target subset definition.

--- a/Overview.bs
+++ b/Overview.bs
@@ -2875,8 +2875,8 @@ they are defaulted to an empty set.
 <b>Optimized Extension Example</b>
 
 Note: this example execution is described as it would be implemented in an optimized client which aims to reduce the number of round trips needing to be
-      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but preloads some URIs
-      that are expected to be needed ahead of time to reduce round trips.
+      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but speculatively
+      loads some URIs (the glyph keyed URIs) that are expected to be needed ahead of time to reduce round trips.
 
 Inputs:
 *  Initial font with the IFT and IFTX tables as defined above.
@@ -2892,10 +2892,16 @@ Iteration 1:
     * //foo.bar/01.gk
     * //foo.bar/04.gk
 
-<!-- TODO: once we have a section describing criteria for making selections within an invalidating group reference that here -->
 *  Step 7 - one entry from that set must be picked. There a no full invalidation entries, so one partial invalidation entry (//foo.bar/*.tk) must be
-    selected. //foo.bar/04.tk is the most likely best choice, since it fully covers the target subset definition (minimizing round trips) and should be
-    smaller than //foo.bar/05.tk which contains additional support for '0' through '9' which are not currently requested.
+    selected. Following [[#invalidating-patch-selection]] the candidate entries have the following intersections with the target subset definition:
+
+    *  //foo.bar/01.tk - {'f'}
+    *  //foo.bar/02.tk - {'P'}
+    *  //foo.bar/04.tk - {'f', 'P'}
+    *  //foo.bar/05.tk - {'f', 'P'}
+
+    The intersections for //foo.bar/01.tk and //foo.bar/02.tk are both strict subsets of //foo.bar/04.tk and //foo.bar/05.tk, so they don't meet selection
+    criteria. That leaves either //foo.bar/04.tk or //foo.bar/05.tk. Since //foo.bar/04.tk is listed first in the patch map it is selected.
 
 *  Step 8 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
     patches //foo.bar/01.gk and //foo.bar/04.gk. The table keyed patch //foo.bar/04.tk is partially invalidating which means the two glyph keyed patches

--- a/Overview.bs
+++ b/Overview.bs
@@ -2893,7 +2893,7 @@ Iteration 1:
     * //foo.bar/01.gk
     * //foo.bar/04.gk
 
-*  Step 7 - one entry from that set must be picked. There a no full invalidation entries, so one partial invalidation entry (//foo.bar/*.tk) must be
+*  Step 8 - one entry from that set must be picked. There a no full invalidation entries, so one partial invalidation entry (//foo.bar/*.tk) must be
     selected. Following [[#invalidating-patch-selection]] the candidate entries have the following intersections with the target subset definition:
 
     *  //foo.bar/01.tk - {'f'}
@@ -2904,12 +2904,12 @@ Iteration 1:
     The intersections for //foo.bar/01.tk and //foo.bar/02.tk are both strict subsets of //foo.bar/04.tk and //foo.bar/05.tk, so they don't meet selection
     criteria. That leaves either //foo.bar/04.tk or //foo.bar/05.tk. Since //foo.bar/04.tk is listed first in the patch map it is selected.
 
-*  Step 8 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
+*  Step 9 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
     patches //foo.bar/01.gk and //foo.bar/04.gk. The table keyed patch //foo.bar/04.tk is partially invalidating which means the two glyph keyed patches
     will be remain valid after the application of //foo.bar/04.tk. Thus the client can expect that the two glyph keyed patches will be required in future
     iterations and begin the loads for those two patches at this time.
 
-*  Step 9 - The fetched patch //foo.bar/04.tk is applied to the initial font. This patch updates all tables except for glyf and loca
+*  Step 10 - The fetched patch //foo.bar/04.tk is applied to the initial font. This patch updates all tables except for glyf and loca
     to add support for code points 'a' through 'Z'. Additionally the mapping in the "IFT " table is updated to the following:
 
     <table>
@@ -2940,12 +2940,12 @@ Iteration 2:
     * //foo.bar/01.gk
     * //foo.bar/04.gk
 
-*  Step 7 - one entry from that set must be picked. Only no invalidation patches remain, the client is free to pick either one. In this case it selects
+*  Step 8 - one entry from that set must be picked. Only no invalidation patches remain, the client is free to pick either one. In this case it selects
     the first one //foo.bar/01.gk.
 
-*  Step 8 - the fetch for //foo.bar/01.gk was previously started during iteration 1.
+*  Step 9 - the fetch for //foo.bar/01.gk was previously started during iteration 1.
 
-*  Step 9 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'm'
+*  Step 10 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'm'
     to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/01.gk. The compatibility ID
     and URIs for other entries are unchanged.
 
@@ -2955,11 +2955,11 @@ Iteration 3:
     entries intersect:
     * //foo.bar/04.gk
 
-*  Step 7 - one entry remains, it is selected.
+*  Step 8 - one entry remains, it is selected.
 
-*  Step 8 - the fetch for //foo.bar/04.gk was previously started during iteration 1.
+*  Step 9 - the fetch for //foo.bar/04.gk was previously started during iteration 1.
 
-*  Step 9 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'N' through 'Z'
+*  Step 10 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'N' through 'Z'
     to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/04.gk. The compatibility ID
     and URIs for other entries are unchanged.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -2938,7 +2938,7 @@ Iteration 2:
 
 *  Step 8 - the fetch for //foo.bar/01.gk was previously started during iteration 1.
 
-*  Step 9 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'z'
+*  Step 9 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'm'
     to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/01.gk. The compatibility ID
     and URIs for other entries are unchanged.
 
@@ -2952,7 +2952,7 @@ Iteration 3:
 
 *  Step 8 - the fetch for //foo.bar/04.gk was previously started during iteration 1.
 
-*  Step 9 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'A' through 'Z'
+*  Step 9 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'N' through 'Z'
     to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/04.gk. The compatibility ID
     and URIs for other entries are unchanged.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -2875,8 +2875,9 @@ they are defaulted to an empty set.
 <b>Optimized Extension Example</b>
 
 Note: this example execution is described as it would be implemented in an optimized client which aims to reduce the number of round trips needing to be
-      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but speculatively
-      loads some URIs (the glyph keyed URIs) that are expected to be needed ahead of time to reduce round trips.
+      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but 
+      loads some URIs (the glyph keyed URIs) earlier than specified in the extension algorithm. This is allowed because these patches
+      will not be invalidated by the preceding table keyed patch.
 
 Inputs:
 *  Initial font with the IFT and IFTX tables as defined above.
@@ -2906,7 +2907,7 @@ Iteration 1:
 *  Step 8 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
     patches //foo.bar/01.gk and //foo.bar/04.gk. The table keyed patch //foo.bar/04.tk is partially invalidating which means the two glyph keyed patches
     will be remain valid after the application of //foo.bar/04.tk. Thus the client can expect that the two glyph keyed patches will be required in future
-    iterations and preemptively begin the loads for those two patches.
+    iterations and begin the loads for those two patches at this time.
 
 *  Step 9 - The fetched patch //foo.bar/04.tk is applied to the initial font. This patch updates all tables except for glyf and loca
     to add support for code points 'a' through 'Z'. Additionally the mapping in the "IFT " table is updated to the following:

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="457cd10d4c970516ed8660829674b1fb9aa1ad51" name="revision">
+  <meta content="0749597a35a9a1e16930a527cc44cb25ed40b1cc" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -3364,7 +3364,7 @@ they are defaulted to an empty set.</p>
    <p>Iteration 1:</p>
    <ul>
     <li data-md>
-     <p>Steps 1 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection②">Check entry intersection</a> check to all entries, the following patch entries intersect:</p>
+     <p>Steps 1 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection②">Check entry intersection</a> check to all entries in the initial font, the following patch entries intersect:</p>
      <ul>
       <li data-md>
        <p>//foo.bar/01.tk</p>
@@ -3419,7 +3419,8 @@ the URI for the remaining '0', ..., '9' entry has changed. The patch at the new 
    <p>Iteration 2:</p>
    <ul>
     <li data-md>
-     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection③">Check entry intersection</a> check to all entries, the following patch entries intersect:</p>
+     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection③">Check entry intersection</a> check to all entries in the updated font from the previous iteration, the following patch
+entries intersect:</p>
      <ul>
       <li data-md>
        <p>//foo.bar/01.gk</p>
@@ -3439,7 +3440,8 @@ and URIs for other entries are unchanged.</p>
    <p>Iteration 3:</p>
    <ul>
     <li data-md>
-     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection④">Check entry intersection</a> check to all entries, the following patch entries intersect:</p>
+     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection④">Check entry intersection</a> check to all entries in the updated font from the previous iteration, the following patch
+entries intersect:</p>
      <ul>
       <li data-md>
        <p>//foo.bar/04.gk</p>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="0749597a35a9a1e16930a527cc44cb25ed40b1cc" name="revision">
+  <meta content="2030b01ade0050f8d4bd0ec62d4f29297a8d2eeb" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -3433,7 +3433,7 @@ the first one //foo.bar/01.gk.</p>
     <li data-md>
      <p>Step 8 - the fetch for //foo.bar/01.gk was previously started during iteration 1.</p>
     <li data-md>
-     <p>Step 9 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'z'
+     <p>Step 9 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'm'
 to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/01.gk. The compatibility ID
 and URIs for other entries are unchanged.</p>
    </ul>
@@ -3451,7 +3451,7 @@ entries intersect:</p>
     <li data-md>
      <p>Step 8 - the fetch for //foo.bar/04.gk was previously started during iteration 1.</p>
     <li data-md>
-     <p>Step 9 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'A' through 'Z'
+     <p>Step 9 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'N' through 'Z'
 to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/04.gk. The compatibility ID
 and URIs for other entries are unchanged.</p>
    </ul>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="15741d106ff3a0fd6547c72aee890b78babf0340" name="revision">
+  <meta content="457cd10d4c970516ed8660829674b1fb9aa1ad51" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -876,6 +876,7 @@ be loaded over multiple requests where each request incrementally adds additiona
     <li><a href="#sec"><span class="secno">9</span> <span class="content">Security Considerations</span></a>
     <li><a href="#changes"><span class="secno">10</span> <span class="content">Changes</span></a>
     <li><a href="#feature-tag-list"><span class="secno"></span> <span class="content"> Appendix A: Default Feature Tags</span></a>
+    <li><a href="#extension-example"><span class="secno"></span> <span class="content"> Appendix B: Extension Algorithm Example Execution</span></a>
     <li>
      <a href="#w3c-conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
      <ol class="toc">
@@ -1223,6 +1224,7 @@ optimization which significantly improves performance by eliminating network rou
 be needed in later iterations.</p>
    <p class="note" role="note"><span class="marker">Note:</span> if the only remaining intersecting entries are no invalidation entries the intersection check in step 5 does not need to be repeated on each
 iteration since no invalidation patches won’t change the list of available patches upon application (other then to remove the just applied patch).</p>
+   <div class="example" id="example-2ebb408c"><a class="self-link" href="#example-2ebb408c"></a> An example of the execution of the extension algorithm can be found in <a href="#extension-example">Appendix B: Extension Algorithm Example Execution</a>. </div>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-check-entry-intersection">Check entry intersection</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
@@ -3259,6 +3261,204 @@ to be used by default in most shaper implementations. This list was assembled fr
       <td>vrtr
       <td>Vertical Alternates for Rotation
    </table>
+   <h2 class="heading settled" id="extension-example"><span class="content"> Appendix B: Extension Algorithm Example Execution</span><a class="self-link" href="#extension-example"></a></h2>
+   <p>This appendix provides an example of how a typical IFT font would be processed by the <a href="#extend-font-subset">§ 4.3 Incremental Font Extension Algorithm</a> algorithm. In this example the IFT font
+contains a mix of both <a href="#table-keyed">§ 6.2 Table Keyed</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches.</p>
+   <p><b>Initial font</b>: contains the following IFT and IFTX patch mappings. Note: when features and design space sets are unspecified in a subset definition
+they are defaulted to an empty set.</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Table = "IFT "
+      <th colspan="2">Compatibility ID = 0x0000_0000_0000_0001
+     <tr>
+      <th>Subset Definition(s)
+      <th>URI
+      <th>Format Number
+     <tr>
+      <td>
+<pre>code points: { 'a', 'b', ..., 'z' }
+</pre>
+      <td>//foo.bar/01.tk
+      <td> 2, Table Keyed - Partial Invalidation 
+     <tr>
+      <td>
+<pre>code points: { 'A', 'B', ..., 'Z' }
+</pre>
+      <td>//foo.bar/02.tk
+      <td> 2, Table Keyed - Partial Invalidation 
+     <tr>
+      <td>
+<pre>code points: { '0', '1', ..., '9' }
+</pre>
+      <td>//foo.bar/03.tk
+      <td> 2, Table Keyed - Partial Invalidation 
+     <tr>
+      <td>
+<pre>code points: { 'a', 'b', ..., 'z',
+               'A', 'B', ..., 'Z' }
+</pre>
+      <td>//foo.bar/04.tk
+      <td> 2, Table Keyed - Partial Invalidation 
+     <tr>
+      <td>
+<pre>code points: { 'a', 'b', ..., 'z',
+               'A', 'B', ..., 'Z',
+               '0', '1', ..., '9' }
+</pre>
+      <td>//foo.bar/05.tk
+      <td> 2, Table Keyed - Partial Invalidation 
+   </table>
+    <br> 
+   <table>
+    <tbody>
+     <tr>
+      <th>Table = "IFTX"
+      <th colspan="2">Compatibility ID = 0x0000_0000_0000_0002
+     <tr>
+      <th>Subset Definition(s)
+      <th>URI
+      <th>Format Number
+     <tr>
+      <td>
+<pre>code points: { 'a', 'b', ..., 'm' }
+</pre>
+      <td>//foo.bar/01.gk
+      <td> 3, Glyph Keyed 
+     <tr>
+      <td>
+<pre>code points: { 'n', 'o', ..., 'z' }
+</pre>
+      <td>//foo.bar/02.gk
+      <td> 3, Glyph Keyed 
+     <tr>
+      <td>
+<pre>code points: { 'A', 'B', ..., 'M' }
+</pre>
+      <td>//foo.bar/03.gk
+      <td> 3, Glyph Keyed 
+     <tr>
+      <td>
+<pre>code points: { 'N', 'O', ..., 'Z' }
+</pre>
+      <td>//foo.bar/04.gk
+      <td> 3, Glyph Keyed 
+     <tr>
+      <td>
+<pre>code points: { '0', '1', ..., '9' }
+</pre>
+      <td>//foo.bar/05.gk
+      <td> 3, Glyph Keyed 
+   </table>
+   <p><b>Optimized Extension Example</b></p>
+   <p class="note" role="note"><span class="marker">Note:</span> this example execution is described as it would be implemented in an optimized client which aims to reduce the number of round trips needing to be
+      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but preloads some URIs
+      that are expected to be needed ahead of time to reduce round trips.</p>
+   <p>Inputs:</p>
+   <ul>
+    <li data-md>
+     <p>Initial font with the IFT and IFTX tables as defined above.</p>
+    <li data-md>
+     <p>Target subset definition: code points = {'f', 'P'}</p>
+   </ul>
+   <p>Iteration 1:</p>
+   <ul>
+    <li data-md>
+     <p>Steps 1 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection②">Check entry intersection</a> check to all entries, the following patch entries intersect:</p>
+     <ul>
+      <li data-md>
+       <p>//foo.bar/01.tk</p>
+      <li data-md>
+       <p>//foo.bar/02.tk</p>
+      <li data-md>
+       <p>//foo.bar/04.tk</p>
+      <li data-md>
+       <p>//foo.bar/05.tk</p>
+      <li data-md>
+       <p>//foo.bar/01.gk</p>
+      <li data-md>
+       <p>//foo.bar/04.gk</p>
+     </ul>
+    <li data-md>
+     <p>Step 7 - one entry from that set must be picked. There a no full invalidation entries, so one partial invalidation entry (//foo.bar/*.tk) must be
+selected. //foo.bar/04.tk is the most likely best choice, since it fully covers the target subset definition (minimizing round trips) and should be
+smaller than //foo.bar/05.tk which contains additional support for '0' through '9' which are not currently requested.</p>
+    <li data-md>
+     <p>Step 8 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
+patches //foo.bar/01.gk and //foo.bar/04.gk. The table keyed patch //foo.bar/04.tk is partially invalidating which means the two glyph keyed patches
+will be remain valid after the application of //foo.bar/04.tk. Thus the client can expect that the two glyph keyed patches will be required in future
+iterations and preemptively begin the loads for those two patches.</p>
+    <li data-md>
+     <p>Step 9 - The fetched patch //foo.bar/04.tk is applied to the initial font. This patch updates all tables except for glyf and loca
+to add support for code points 'a' through 'Z'. Additionally the mapping in the "IFT " table is updated to the following:</p>
+     <table>
+      <tbody>
+       <tr>
+        <th>Table = "IFT "
+        <th colspan="2">Compatibility ID = 0x0000_0000_0000_0006
+       <tr>
+        <th>Subset Definition(s)
+        <th>URI
+        <th>Format Number
+       <tr>
+        <td>
+<pre>code points: { '0', '1', ..., '9' }
+</pre>
+        <td>//foo.bar/08.tk
+        <td> 2, Table Keyed - Partial Invalidation 
+     </table>
+     <p>Note the following changes:</p>
+     <ul>
+      <li data-md>
+       <p>All entries that have data for 'a', ... 'z', and 'A', ..., 'Z' have been removed. Leaving just one entry for the remaining '0', ..., '9' code points.</p>
+      <li data-md>
+       <p>The font binary has changed and thus the previously listed table keyed patches are no longer valid. As a result the compatibility ID has changed and
+the URI for the remaining '0', ..., '9' entry has changed. The patch at the new URI, //foo.bar/08.tk, is compatible with the updated font.</p>
+     </ul>
+   </ul>
+   <p>Iteration 2:</p>
+   <ul>
+    <li data-md>
+     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection③">Check entry intersection</a> check to all entries, the following patch entries intersect:</p>
+     <ul>
+      <li data-md>
+       <p>//foo.bar/01.gk</p>
+      <li data-md>
+       <p>//foo.bar/04.gk</p>
+     </ul>
+    <li data-md>
+     <p>Step 7 - one entry from that set must be picked. Only no invalidation patches remain, the client is free to pick either one. In this case it selects
+the first one //foo.bar/01.gk.</p>
+    <li data-md>
+     <p>Step 8 - the fetch for //foo.bar/01.gk was previously started during iteration 1.</p>
+    <li data-md>
+     <p>Step 9 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'z'
+to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/01.gk. The compatibility ID
+and URIs for other entries are unchanged.</p>
+   </ul>
+   <p>Iteration 3:</p>
+   <ul>
+    <li data-md>
+     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection④">Check entry intersection</a> check to all entries, the following patch entries intersect:</p>
+     <ul>
+      <li data-md>
+       <p>//foo.bar/04.gk</p>
+     </ul>
+    <li data-md>
+     <p>Step 7 - one entry remains, it is selected.</p>
+    <li data-md>
+     <p>Step 8 - the fetch for //foo.bar/04.gk was previously started during iteration 1.</p>
+    <li data-md>
+     <p>Step 9 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'A' through 'Z'
+to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/04.gk. The compatibility ID
+and URIs for other entries are unchanged.</p>
+   </ul>
+   <p>Iteration 4:</p>
+   <ul>
+    <li data-md>
+     <p>Steps 2 through 6 - there are no remaining intersecting entries so the algorithm terminates. The font subset is returned and now ready to render any
+content covered by the target subset definition.</p>
+   </ul>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="w3c-conformance"><span class="content">Conformance</span><a class="self-link" href="#w3c-conformance"></a></h2>
@@ -3691,7 +3891,7 @@ function parseHTML(markup) {
 let dfnPanelData = {
 "abstract-opdef-apply-glyph-keyed-patch": {"dfnID":"abstract-opdef-apply-glyph-keyed-patch","dfnText":"Apply glyph keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-glyph-keyed-patch"},
 "abstract-opdef-apply-table-keyed-patch": {"dfnID":"abstract-opdef-apply-table-keyed-patch","dfnText":"Apply table keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-table-keyed-patch"},
-"abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.7. Fully Expanding a Font"}],"url":"#abstract-opdef-check-entry-intersection"},
+"abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2461"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2462"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2463"}],"title":"\nAppendix B: Extension Algorithm Example Execution"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
 "abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"}],"title":"4.5. Target Subset Definition"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2464"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2465"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2466"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2467"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2468"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u24ea"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "abstract-opdef-fully-expand-a-font-subset": {"dfnID":"abstract-opdef-fully-expand-a-font-subset","dfnText":"Fully Expand a Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset"}],"title":"2.1. Offline Usage"},{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2460"},{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2461"}],"title":"7. Encoding"}],"url":"#abstract-opdef-fully-expand-a-font-subset"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="2030b01ade0050f8d4bd0ec62d4f29297a8d2eeb" name="revision">
+  <meta content="78bafa608f6bb264aa7b06d5c6eb915ffc2b7e93" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -3352,8 +3352,8 @@ they are defaulted to an empty set.</p>
    </table>
    <p><b>Optimized Extension Example</b></p>
    <p class="note" role="note"><span class="marker">Note:</span> this example execution is described as it would be implemented in an optimized client which aims to reduce the number of round trips needing to be
-      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but preloads some URIs
-      that are expected to be needed ahead of time to reduce round trips.</p>
+      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but speculatively
+      loads some URIs (the glyph keyed URIs) that are expected to be needed ahead of time to reduce round trips.</p>
    <p>Inputs:</p>
    <ul>
     <li data-md>
@@ -3381,8 +3381,19 @@ they are defaulted to an empty set.</p>
      </ul>
     <li data-md>
      <p>Step 7 - one entry from that set must be picked. There a no full invalidation entries, so one partial invalidation entry (//foo.bar/*.tk) must be
-selected. //foo.bar/04.tk is the most likely best choice, since it fully covers the target subset definition (minimizing round trips) and should be
-smaller than //foo.bar/05.tk which contains additional support for '0' through '9' which are not currently requested.</p>
+selected. Following <a href="#invalidating-patch-selection">§ 4.4 Selecting Invalidating Patches</a> the candidate entries have the following intersections with the target subset definition:</p>
+     <ul>
+      <li data-md>
+       <p>//foo.bar/01.tk - {'f'}</p>
+      <li data-md>
+       <p>//foo.bar/02.tk - {'P'}</p>
+      <li data-md>
+       <p>//foo.bar/04.tk - {'f', 'P'}</p>
+      <li data-md>
+       <p>//foo.bar/05.tk - {'f', 'P'}</p>
+     </ul>
+     <p>The intersections for //foo.bar/01.tk and //foo.bar/02.tk are both strict subsets of //foo.bar/04.tk and //foo.bar/05.tk, so they don’t meet selection
+criteria. That leaves either //foo.bar/04.tk or //foo.bar/05.tk. Since //foo.bar/04.tk is listed first in the patch map it is selected.</p>
     <li data-md>
      <p>Step 8 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
 patches //foo.bar/01.gk and //foo.bar/04.gk. The table keyed patch //foo.bar/04.tk is partially invalidating which means the two glyph keyed patches

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="78bafa608f6bb264aa7b06d5c6eb915ffc2b7e93" name="revision">
+  <meta content="4c5902ffe2738a3fadcfc83cec41f82df9dd604c" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -3352,8 +3352,9 @@ they are defaulted to an empty set.</p>
    </table>
    <p><b>Optimized Extension Example</b></p>
    <p class="note" role="note"><span class="marker">Note:</span> this example execution is described as it would be implemented in an optimized client which aims to reduce the number of round trips needing to be
-      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but speculatively
-      loads some URIs (the glyph keyed URIs) that are expected to be needed ahead of time to reduce round trips.</p>
+      made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but 
+      loads some URIs (the glyph keyed URIs) earlier than specified in the extension algorithm. This is allowed because these patches
+      will not be invalidated by the preceding table keyed patch.</p>
    <p>Inputs:</p>
    <ul>
     <li data-md>
@@ -3398,7 +3399,7 @@ criteria. That leaves either //foo.bar/04.tk or //foo.bar/05.tk. Since //foo.bar
      <p>Step 8 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
 patches //foo.bar/01.gk and //foo.bar/04.gk. The table keyed patch //foo.bar/04.tk is partially invalidating which means the two glyph keyed patches
 will be remain valid after the application of //foo.bar/04.tk. Thus the client can expect that the two glyph keyed patches will be required in future
-iterations and preemptively begin the loads for those two patches.</p>
+iterations and begin the loads for those two patches at this time.</p>
     <li data-md>
      <p>Step 9 - The fetched patch //foo.bar/04.tk is applied to the initial font. This patch updates all tables except for glyf and loca
 to add support for code points 'a' through 'Z'. Additionally the mapping in the "IFT " table is updated to the following:</p>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="4c5902ffe2738a3fadcfc83cec41f82df9dd604c" name="revision">
+  <meta content="4bba2910cf076dd602368b46ddeb45d74c0d748d" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -3381,7 +3381,7 @@ they are defaulted to an empty set.</p>
        <p>//foo.bar/04.gk</p>
      </ul>
     <li data-md>
-     <p>Step 7 - one entry from that set must be picked. There a no full invalidation entries, so one partial invalidation entry (//foo.bar/*.tk) must be
+     <p>Step 8 - one entry from that set must be picked. There a no full invalidation entries, so one partial invalidation entry (//foo.bar/*.tk) must be
 selected. Following <a href="#invalidating-patch-selection">§ 4.4 Selecting Invalidating Patches</a> the candidate entries have the following intersections with the target subset definition:</p>
      <ul>
       <li data-md>
@@ -3396,12 +3396,12 @@ selected. Following <a href="#invalidating-patch-selection">§ 4.4 Selecting I
      <p>The intersections for //foo.bar/01.tk and //foo.bar/02.tk are both strict subsets of //foo.bar/04.tk and //foo.bar/05.tk, so they don’t meet selection
 criteria. That leaves either //foo.bar/04.tk or //foo.bar/05.tk. Since //foo.bar/04.tk is listed first in the patch map it is selected.</p>
     <li data-md>
-     <p>Step 8 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
+     <p>Step 9 - the selected patch, //foo.bar/04.tk, is fetched. Additionally as an optimization fetches are simultaneously started for the two glyph keyed
 patches //foo.bar/01.gk and //foo.bar/04.gk. The table keyed patch //foo.bar/04.tk is partially invalidating which means the two glyph keyed patches
 will be remain valid after the application of //foo.bar/04.tk. Thus the client can expect that the two glyph keyed patches will be required in future
 iterations and begin the loads for those two patches at this time.</p>
     <li data-md>
-     <p>Step 9 - The fetched patch //foo.bar/04.tk is applied to the initial font. This patch updates all tables except for glyf and loca
+     <p>Step 10 - The fetched patch //foo.bar/04.tk is applied to the initial font. This patch updates all tables except for glyf and loca
 to add support for code points 'a' through 'Z'. Additionally the mapping in the "IFT " table is updated to the following:</p>
      <table>
       <tbody>
@@ -3440,12 +3440,12 @@ entries intersect:</p>
        <p>//foo.bar/04.gk</p>
      </ul>
     <li data-md>
-     <p>Step 7 - one entry from that set must be picked. Only no invalidation patches remain, the client is free to pick either one. In this case it selects
+     <p>Step 8 - one entry from that set must be picked. Only no invalidation patches remain, the client is free to pick either one. In this case it selects
 the first one //foo.bar/01.gk.</p>
     <li data-md>
-     <p>Step 8 - the fetch for //foo.bar/01.gk was previously started during iteration 1.</p>
+     <p>Step 9 - the fetch for //foo.bar/01.gk was previously started during iteration 1.</p>
     <li data-md>
-     <p>Step 9 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'm'
+     <p>Step 10 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'm'
 to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/01.gk. The compatibility ID
 and URIs for other entries are unchanged.</p>
    </ul>
@@ -3459,11 +3459,11 @@ entries intersect:</p>
        <p>//foo.bar/04.gk</p>
      </ul>
     <li data-md>
-     <p>Step 7 - one entry remains, it is selected.</p>
+     <p>Step 8 - one entry remains, it is selected.</p>
     <li data-md>
-     <p>Step 8 - the fetch for //foo.bar/04.gk was previously started during iteration 1.</p>
+     <p>Step 9 - the fetch for //foo.bar/04.gk was previously started during iteration 1.</p>
     <li data-md>
-     <p>Step 9 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'N' through 'Z'
+     <p>Step 10 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'N' through 'Z'
 to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/04.gk. The compatibility ID
 and URIs for other entries are unchanged.</p>
    </ul>


### PR DESCRIPTION
The example shows howed a mixed (table + glyph keyed) IFT font would typically be processed by a client.

For #216


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/237.html" title="Last updated on Dec 3, 2024, 5:01 PM UTC (b918bb4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/237/457cd10...b918bb4.html" title="Last updated on Dec 3, 2024, 5:01 PM UTC (b918bb4)">Diff</a>