### PR TITLE
Consistently Use 'patch format' instead of 'patch encoding'.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -989,7 +989,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">patchEncoding</dfn></td>
+    <td><dfn for="Format 1 Patch Map">patchFormat</dfn></td>
     <td>
       Specifies the format of the patches linked to by uriTemplate.
       Must be set to one of the format numbers from  the [[#font-patch-formats-summary]] table.
@@ -1159,7 +1159,7 @@ The algorithm:
     *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
 
     *  Add an [=patch map entries|entry=] to <var>entry list</var> with one subset definition which contains only the Unicode code point
-        set and maps to the generated URI, the patch encoding specified by [=Format 1 Patch Map/patchEncoding=], and
+        set and maps to the generated URI, the patch format specified by [=Format 1 Patch Map/patchFormat=], and
         [=Format 1 Patch Map/compatibilityId=].
 
 3.  If [=Format 1 Patch Map/featureMapOffset=] is not null then, for each [=FeatureRecord=] and associated [=EntryMapRecord=] in
@@ -1197,8 +1197,8 @@ The algorithm:
 
     *  If the constructed set of Unicode code points is empty then, this [=EntryMapRecord=] is invalid skip it.
 
-    *  Add an [=patch map entries|entry=] to <var>entry list</var> which  maps to the generated URI, the patch encoding
-        specified by [=Format 1 Patch Map/patchEncoding=], and [=Format 1 Patch Map/compatibilityId=]; or if there is an existing
+    *  Add an [=patch map entries|entry=] to <var>entry list</var> which  maps to the generated URI, the patch format
+        specified by [=Format 1 Patch Map/patchFormat=], and [=Format 1 Patch Map/compatibilityId=]; or if there is an existing
         [=patch map entries|entry=] in <var>entry list</var> which has the same patch URI as the generated URI then
         instead modify the existing entry. Add the constructed set of Unicode code points and [=FeatureRecord/featureTag=] to the new or
         existing entry's single subset definition.
@@ -1264,7 +1264,7 @@ The algorithm:
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 2 Patch Map">defaultPatchEncoding</dfn></td>
+    <td><dfn for="Format 2 Patch Map">defaultPatchFormat</dfn></td>
     <td>
       Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
       Must be set to one of the format numbers from the [[#font-patch-formats-summary]] table.
@@ -1405,10 +1405,10 @@ The algorithm:
 
   <tr>
     <td>uint8</td>
-    <td><dfn for="Mapping Entry">patchEncoding</dfn></td>
+    <td><dfn for="Mapping Entry">patchFormat</dfn></td>
     <td>
       Specifies the format of the patch linked to by this entry. Uses the ID numbers from the [[#font-patch-formats-summary]] table.
-      Overrides [=Format 2 Patch Map/defaultPatchEncoding=].
+      Overrides [=Format 2 Patch Map/defaultPatchFormat=].
       Only present if [=Mapping Entry/formatFlags=] bit 3 is set.
     </td>
   </tr>
@@ -1501,7 +1501,7 @@ The algorithm:
          the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entryIdStringData=][<var>current id string byte</var>]
          to the end of <var>patch map</var> if [=Format 2 Patch Map/entryIdStringData=] is non zero,
          <var>last entry id</var>,
-         [=Format 2 Patch Map/defaultPatchEncoding=], and
+         [=Format 2 Patch Map/defaultPatchFormat=], and
          [=Format 2 Patch Map/uriTemplate=].
 
      *  Set <var>last entry id</var> to the returned entry id.
@@ -1525,7 +1525,7 @@ The inputs to this algorithm are:
 
 * <var>last entry id</var>: the entry id of the entry preceding this one.
 
-* <var>default patch encoding</var>: the default patch encoding if one isn't specified.
+* <var>default patch format</var>: the default patch format if one isn't specified.
 
 * <var>uri template</var>: the URI template used to locate patches.
 
@@ -1549,7 +1549,7 @@ The algorithm:
 2.  If <var>id string bytes</var> is not present then, set <var>entry id</var> = <var>last entry id</var> + 1. Otherwise set
      <var>entry id</var> = <var>last entry id</var>.
 
-3.  Set the patch encoding of <var>entry</var> to <var>default patch encoding</var>.
+3.  Set the patch format of <var>entry</var> to <var>default patch format</var>.
 
 4.  Add a single [=font subset definition=] to <var>entry</var> with all sets initialized to be empty.
 
@@ -1586,9 +1586,9 @@ The algorithm:
     *  Otherwise if <var>id string bytes</var> is present then, read [=Mapping Entry/entryIdStringLength=] bytes from
         <var>id string bytes</var> and set <var>entry id</var> to the result.
 
-8.  If [=Mapping Entry/formatFlags=] bit 3 is set, then a patch encoding is present. Read the encoding specified by
-     [=Mapping Entry/patchEncoding=] from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.
-     If [=Mapping Entry/patchEncoding=] is not one of the values in [[#font-patch-formats-summary]] then, this encoding is invalid
+8.  If [=Mapping Entry/formatFlags=] bit 3 is set, then a patch format is present. Read the format specified by
+     [=Mapping Entry/patchFormat=] from <var>entry bytes</var> and set the patch format of <var>entry</var> to the read value.
+     If [=Mapping Entry/patchFormat=] is not one of the values in [[#font-patch-formats-summary]] then, this encoding is invalid
      return an error.
 
 9.  If one or both of [=Mapping Entry/formatFlags=] bit 4 and bit 5 are set, then a code point list is present:
@@ -1988,7 +1988,7 @@ or remove tables in a [=font subset=].
   <tr>
     <td>Tag</td>
     <td>format</td>
-    <td>Identifies the encoding as table keyed, must be set to 'iftk'</td>
+    <td>Identifies the format as table keyed, must be set to 'iftk'</td>
   </tr>
   <tr>
     <td>uint32</td>
@@ -2125,7 +2125,7 @@ A glyph keyed patch contains a collection of data chunks that are each associate
   <tr>
     <td>Tag</td>
     <td>format</td>
-    <td>Identifies the encoding as glyph keyed, must be set to 'ifgk'</td>
+    <td>Identifies the format as glyph keyed, must be set to 'ifgk'</td>
   </tr>
   <tr>
     <td>uint32</td>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="d19123ffff6ce69b0fe4981951a35751cd0cc42f" name="revision">
+  <meta content="1aa27d883abc43585e0313bb9bc3c1b8707c4224" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1632,7 +1632,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchencoding">patchEncoding</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchformat">patchFormat</dfn>
       <td> Specifies the format of the patches linked to by uriTemplate.
       Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
    </table>
@@ -1764,7 +1764,7 @@ Multiple code points may map to the same glyph id. All code points associated wi
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
       <li data-md>
        <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> to <var>entry list</var> with one subset definition which contains only the Unicode code point
-set and maps to the generated URI, the patch encoding specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
+set and maps to the generated URI, the patch format specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#format-1-patch-map-featuremapoffset" id="ref-for-format-1-patch-map-featuremapoffset">featureMapOffset</a> is not null then, for each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords②">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
@@ -1795,8 +1795,8 @@ associated code points as if it wasn’t skipped.</p>
       <li data-md>
        <p>If the constructed set of Unicode code points is empty then, this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑧">EntryMapRecord</a> is invalid skip it.</p>
       <li data-md>
-       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> to <var>entry list</var> which  maps to the generated URI, the patch encoding
-specified by <a data-link-type="dfn" href="#format-1-patch-map-patchencoding" id="ref-for-format-1-patch-map-patchencoding①">patchEncoding</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">entry</a> in <var>entry list</var> which has the same patch URI as the generated URI then
+       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> to <var>entry list</var> which  maps to the generated URI, the patch format
+specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat①">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">entry</a> in <var>entry list</var> which has the same patch URI as the generated URI then
 instead modify the existing entry. Add the constructed set of Unicode code points and <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag③">featureTag</a> to the new or
 existing entry’s single subset definition.</p>
      </ul>
@@ -1854,7 +1854,7 @@ change the number of bytes.</p>
       value. The encoder should set it to a random value which has not previously been used while encoding the IFT font. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchformat">defaultPatchFormat</dfn>
       <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
       Must be set to one of the format numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
      <tr>
@@ -1944,9 +1944,9 @@ change the number of bytes.</p>
       present the length is assumed to be 0. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchencoding">patchEncoding</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchformat">patchFormat</dfn>
       <td> Specifies the format of the patch linked to by this entry. Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.
-      Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a>.
+      Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat">defaultPatchFormat</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 3 is set. 
      <tr>
       <td>uint16/uint24
@@ -2013,7 +2013,7 @@ being requested.</p>
        <p>pass in the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
  the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a>[<var>current id string byte</var>]
- to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑤">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchencoding" id="ref-for-format-2-patch-map-defaultpatchencoding①">defaultPatchEncoding</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
+ to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑤">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
@@ -2036,7 +2036,7 @@ being requested.</p>
     <li data-md>
      <p><var>last entry id</var>: the entry id of the entry preceding this one.</p>
     <li data-md>
-     <p><var>default patch encoding</var>: the default patch encoding if one isn’t specified.</p>
+     <p><var>default patch format</var>: the default patch format if one isn’t specified.</p>
     <li data-md>
      <p><var>uri template</var>: the URI template used to locate patches.</p>
    </ul>
@@ -2061,7 +2061,7 @@ being requested.</p>
     <li data-md>
      <p>If <var>id string bytes</var> is not present then, set <var>entry id</var> = <var>last entry id</var> + 1. Otherwise set <var>entry id</var> = <var>last entry id</var>.</p>
     <li data-md>
-     <p>Set the patch encoding of <var>entry</var> to <var>default patch encoding</var>.</p>
+     <p>Set the patch format of <var>entry</var> to <var>default patch format</var>.</p>
     <li data-md>
      <p>Add a single <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> to <var>entry</var> with all sets initialized to be empty.</p>
     <li data-md>
@@ -2097,8 +2097,8 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
        <p>Otherwise if <var>id string bytes</var> is present then, read <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength">entryIdStringLength</a> bytes from <var>id string bytes</var> and set <var>entry id</var> to the result.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①④">formatFlags</a> bit 3 is set, then a patch encoding is present. Read the encoding specified by <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding">patchEncoding</a> from <var>entry bytes</var> and set the patch encoding of <var>entry</var> to the read value.
- If <a data-link-type="dfn" href="#mapping-entry-patchencoding" id="ref-for-mapping-entry-patchencoding①">patchEncoding</a> is not one of the values in <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> then, this encoding is invalid
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①④">formatFlags</a> bit 3 is set, then a patch format is present. Read the format specified by <a data-link-type="dfn" href="#mapping-entry-patchformat" id="ref-for-mapping-entry-patchformat">patchFormat</a> from <var>entry bytes</var> and set the patch format of <var>entry</var> to the read value.
+ If <a data-link-type="dfn" href="#mapping-entry-patchformat" id="ref-for-mapping-entry-patchformat①">patchFormat</a> is not one of the values in <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> then, this encoding is invalid
  return an error.</p>
     <li data-md>
      <p>If one or both of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑤">formatFlags</a> bit 4 and bit 5 are set, then a code point list is present:</p>
@@ -2444,7 +2444,7 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
      <tr>
       <td>Tag
       <td>format
-      <td>Identifies the encoding as table keyed, must be set to 'iftk'
+      <td>Identifies the format as table keyed, must be set to 'iftk'
      <tr>
       <td>uint32
       <td>reserved
@@ -2558,7 +2558,7 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
      <tr>
       <td>Tag
       <td>format
-      <td>Identifies the encoding as glyph keyed, must be set to 'ifgk'
+      <td>Identifies the format as glyph keyed, must be set to 'ifgk'
      <tr>
       <td>uint32
       <td>reserved
@@ -3305,7 +3305,7 @@ to be used by default in most shaper implementations. This list was assembled fr
    <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-copymodeandcount">copyModeAndCount</a><span>, in § 5.2.2</span>
    <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 5.2.2.3</span>
-   <li><a href="#format-2-patch-map-defaultpatchencoding">defaultPatchEncoding</a><span>, in § 5.2.2</span>
+   <li><a href="#format-2-patch-map-defaultpatchformat">defaultPatchFormat</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 5.2.2</span>
    <li><a href="#design-space-segment">Design Space Segment</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-designspacesegments">designSpaceSegments</a><span>, in § 5.2.2</span>
@@ -3388,14 +3388,14 @@ to be used by default in most shaper implementations. This list was assembled fr
    <li><a href="#no-invalidation">No Invalidation</a><span>, in § 4.1</span>
    <li><a href="#partial-invalidation">Partial Invalidation</a><span>, in § 4.1</span>
    <li><a href="#patch-application-algorithm">patch application algorithm</a><span>, in § 3.2</span>
-   <li>
-    patchEncoding
-    <ul>
-     <li><a href="#format-1-patch-map-patchencoding">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
-     <li><a href="#mapping-entry-patchencoding">dfn for Mapping Entry</a><span>, in § 5.2.2</span>
-    </ul>
    <li><a href="#table-keyed-patch-patches">patches</a><span>, in § 6.2</span>
    <li><a href="#patch-format">patch format</a><span>, in § 3.2</span>
+   <li>
+    patchFormat
+    <ul>
+     <li><a href="#format-1-patch-map-patchformat">dfn for Format 1 Patch Map</a><span>, in § 5.2.1</span>
+     <li><a href="#mapping-entry-patchformat">dfn for Mapping Entry</a><span>, in § 5.2.2</span>
+    </ul>
    <li><a href="#patch-map">patch map</a><span>, in § 3.3</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.2.1.2</span>
@@ -3700,11 +3700,11 @@ let dfnPanelData = {
 "format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"},{"id":"ref-for-format-1-patch-map-glyphcount\u2460"}],"title":"5.2.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
 "format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.2.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
 "format-1-patch-map-maxglyphmapentryindex": {"dfnID":"format-1-patch-map-maxglyphmapentryindex","dfnText":"maxGlyphMapEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxglyphmapentryindex"},
-"format-1-patch-map-patchencoding": {"dfnID":"format-1-patch-map-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchencoding"},{"id":"ref-for-format-1-patch-map-patchencoding\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchencoding"},
+"format-1-patch-map-patchformat": {"dfnID":"format-1-patch-map-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchformat"},{"id":"ref-for-format-1-patch-map-patchformat\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchformat"},
 "format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
 "format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.2.2.2. Remove Entries from Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2461"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#format-2-patch-map"},
 "format-2-patch-map-compatibilityid": {"dfnID":"format-2-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-compatibilityid"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-compatibilityid"},
-"format-2-patch-map-defaultpatchencoding": {"dfnID":"format-2-patch-map-defaultpatchencoding","dfnText":"defaultPatchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchencoding"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchencoding\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-defaultpatchencoding"},
+"format-2-patch-map-defaultpatchformat": {"dfnID":"format-2-patch-map-defaultpatchformat","dfnText":"defaultPatchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-defaultpatchformat"},
 "format-2-patch-map-entries": {"dfnID":"format-2-patch-map-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entries"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entries"},
 "format-2-patch-map-entrycount": {"dfnID":"format-2-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entrycount"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entrycount\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entrycount"},
 "format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
@@ -3741,7 +3741,7 @@ let dfnPanelData = {
 "mapping-entry-featurecount": {"dfnID":"mapping-entry-featurecount","dfnText":"featureCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featurecount"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featurecount"},
 "mapping-entry-featuretags": {"dfnID":"mapping-entry-featuretags","dfnText":"featureTags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featuretags"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featuretags"},
 "mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#mapping-entry-formatflags"},
-"mapping-entry-patchencoding": {"dfnID":"mapping-entry-patchencoding","dfnText":"patchEncoding","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchencoding"},{"id":"ref-for-mapping-entry-patchencoding\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchencoding"},
+"mapping-entry-patchformat": {"dfnID":"mapping-entry-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchformat"},{"id":"ref-for-mapping-entry-patchformat\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchformat"},
 "no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-no-invalidation\u2461"}],"title":"7.1. Encoding Considerations"}],"url":"#no-invalidation"},
 "partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"},{"id":"ref-for-partial-invalidation\u2460"},{"id":"ref-for-partial-invalidation\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2462"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2463"},{"id":"ref-for-partial-invalidation\u2464"},{"id":"ref-for-partial-invalidation\u2465"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
 "patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
@@ -4181,11 +4181,11 @@ let refsData = {
 "#format-1-patch-map-glyphcount": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyphcount","type":"dfn","url":"#format-1-patch-map-glyphcount"},
 "#format-1-patch-map-maxentryindex": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxentryindex","type":"dfn","url":"#format-1-patch-map-maxentryindex"},
 "#format-1-patch-map-maxglyphmapentryindex": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxglyphmapentryindex","type":"dfn","url":"#format-1-patch-map-maxglyphmapentryindex"},
-"#format-1-patch-map-patchencoding": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchencoding","type":"dfn","url":"#format-1-patch-map-patchencoding"},
+"#format-1-patch-map-patchformat": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchformat","type":"dfn","url":"#format-1-patch-map-patchformat"},
 "#format-1-patch-map-uritemplate": {"export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-1-patch-map-uritemplate"},
 "#format-2-patch-map": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 2 patch map","type":"dfn","url":"#format-2-patch-map"},
 "#format-2-patch-map-compatibilityid": {"export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#format-2-patch-map-compatibilityid"},
-"#format-2-patch-map-defaultpatchencoding": {"export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"defaultpatchencoding","type":"dfn","url":"#format-2-patch-map-defaultpatchencoding"},
+"#format-2-patch-map-defaultpatchformat": {"export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"defaultpatchformat","type":"dfn","url":"#format-2-patch-map-defaultpatchformat"},
 "#format-2-patch-map-entries": {"export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entries","type":"dfn","url":"#format-2-patch-map-entries"},
 "#format-2-patch-map-entrycount": {"export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrycount","type":"dfn","url":"#format-2-patch-map-entrycount"},
 "#format-2-patch-map-entryidstringdata": {"export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entryidstringdata","type":"dfn","url":"#format-2-patch-map-entryidstringdata"},
@@ -4222,7 +4222,7 @@ let refsData = {
 "#mapping-entry-featurecount": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featurecount","type":"dfn","url":"#mapping-entry-featurecount"},
 "#mapping-entry-featuretags": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featuretags","type":"dfn","url":"#mapping-entry-featuretags"},
 "#mapping-entry-formatflags": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"formatflags","type":"dfn","url":"#mapping-entry-formatflags"},
-"#mapping-entry-patchencoding": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchencoding","type":"dfn","url":"#mapping-entry-patchencoding"},
+"#mapping-entry-patchformat": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchformat","type":"dfn","url":"#mapping-entry-patchformat"},
 "#no-invalidation": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"no invalidation","type":"dfn","url":"#no-invalidation"},
 "#partial-invalidation": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"partial invalidation","type":"dfn","url":"#partial-invalidation"},
 "#patch-application-algorithm": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch application algorithm","type":"dfn","url":"#patch-application-algorithm"},


### PR DESCRIPTION
Fixes #234


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/241.html" title="Last updated on Nov 21, 2024, 11:46 PM UTC (40de31e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/241/1aa27d8...40de31e.html" title="Last updated on Nov 21, 2024, 11:46 PM UTC (40de31e)">Diff</a>