### PR TITLE
Some clarifications around uri templates

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1851,8 +1851,8 @@ A string ID is a sequence of bytes. Several variables are defined which are used
       The input id encoded as a [[rfc4648#section-7|base32hex]] string (using the digits 0-9, A-V) with padding
       omitted.  When the id is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
       but then all leading bytes that are equal to 0 are removed before encoding.  (For example, when the
-      integer is less than 256 only one byte is encoded.) When the input id is a string the raw bytes are
-      encoded as base32hex.
+      integer is less than 256 only one byte is encoded.) If the input id is 0 then one zero byte is encoded. When the input
+      id is a string the raw bytes are encoded as base32hex.
     </td>
   </tr>
   <tr>
@@ -1890,8 +1890,9 @@ A string ID is a sequence of bytes. Several variables are defined which are used
       (minus) and _ (underline)) with padding included. Because the padding character is '=', it must
       be URL-encoded as "%3D'.  When the id is an unsigned integer it must first be converted to a big
       endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding. 
-      (For example, when the integer is less than 256 only one byte is encoded.) When the input id is
-      a string its raw bytes are encoded as [[rfc4648#section-5|base64url]].
+      (For example, when the integer is less than 256 only one byte is encoded.) If the input id is 0 then one
+      zero byte is encoded. When the input id is a string its raw bytes are encoded as
+      [[rfc4648#section-5|base64url]].
     </td>
   </tr>
 </table>
@@ -1906,6 +1907,11 @@ Some example inputs and the corresponding expansions:
     <td>//foo.bar/{id}</td>
     <td>123</td>
     <td>//foo.bar/FC</td>
+  </tr>
+  <tr>
+    <td>//foo.bar/{id}</td>
+    <td>0</td>
+    <td>//foo.bar/00</td>
   </tr>
   <tr>
     <td>//foo.bar{/d1,d2,id}</td>
@@ -1936,6 +1942,11 @@ Some example inputs and the corresponding expansions:
     <td>//foo.bar{/id64}</td>
     <td>14,000,000</td>
     <td>//foo.bar/1Z-A</td>
+  </tr>
+  <tr>
+    <td>//foo.bar{/id64}</td>
+    <td>0</td>
+    <td>//foo.bar/AA%3D%3D</td>
   </tr>
   <tr>
     <td>//foo.bar{/id64}</td>

--- a/Overview.bs
+++ b/Overview.bs
@@ -1905,65 +1905,77 @@ A string ID is a sequence of bytes. Several variables are defined which are used
 Some example inputs and the corresponding expansions:
 
 <table>
-  <tr><th>Template</th><th>Input ID</th><th>Expansion</th></tr>
+  <tr><th>Template</th><th>Input ID</th><th>ID Type</th><th>Expansion</th></tr>
   <tr>
     <td>//foo.bar/{id}</td>
     <td>123</td>
+    <td>Integer</td>
     <td>//foo.bar/FC</td>
   </tr>
   <tr>
     <td>//foo.bar/{id}</td>
     <td>0</td>
+    <td>Integer</td>
     <td>//foo.bar/00</td>
   </tr>
   <tr>
     <td>//foo.bar{/d1,d2,id}</td>
     <td>478</td>
+    <td>Integer</td>
     <td>//foo.bar/0/F/07F0</td>
   </tr>
   <tr>
     <td>//foo.bar{/d1,d2,d3,id}</td>
     <td>123</td>
+    <td>Integer</td>
     <td>//foo.bar/C/F/_/FC</td>
   </tr>
   <tr>
     <td>//foo.bar{/d1,d2,d3,id}</td>
     <td>baz</td>
+    <td>String</td>
     <td>//foo.bar/K/N/G/C9GNK</td>
   </tr>
   <tr>
     <td>//foo.bar{/d1,d2,d3,id}</td>
     <td>z</td>
+    <td>String</td>
     <td>//foo.bar/8/F/_/F8</td>
   </tr>
   <tr>
     <td>//foo.bar{/d1,d2,d3,id}</td>
     <td>àbc</td>
+    <td>String</td>
     <td>//foo.bar/O/O/4/OEG64OO</td>
   </tr>
   <tr>
     <td>//foo.bar{/id64}</td>
     <td>14,000,000</td>
+    <td>Integer</td>
     <td>//foo.bar/1Z-A</td>
   </tr>
   <tr>
     <td>//foo.bar{/id64}</td>
     <td>0</td>
+    <td>Integer</td>
     <td>//foo.bar/AA%3D%3D</td>
   </tr>
   <tr>
     <td>//foo.bar{/id64}</td>
     <td>17,000,000</td>
+    <td>Integer</td>
     <td>//foo.bar/AQNmQA%3D%3D</td>
   </tr>
   <tr>
     <td>//foo.bar{/id64}</td>
     <td>àbc</td>
+    <td>String</td>
     <td>//foo.bar/w6BiYw%3D%3D</td>
   </tr>
   <tr>
     <td>//foo.bar/{+id64}</td>
     <td>àbcd</td>
+    <td>String</td>
     <td>//foo.bar/w6BiY2Q=</td>
   </tr>
 </table>

--- a/Overview.bs
+++ b/Overview.bs
@@ -1186,7 +1186,8 @@ The algorithm:
         [[open-type/cmap|cmap]] table of <var>font subset</var>. Ignore any glyph indices that are not mapped by [[open-type/cmap|cmap]].
         Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.
 
-    *  Convert <var>entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
+    *  Convert <var>entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]]. If
+        the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
 
@@ -1213,6 +1214,7 @@ The algorithm:
         [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
 
     *  Convert <var>mapped entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
+        If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the bit for <var>mapped entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this entry.
 
@@ -1264,6 +1266,7 @@ The algorithm:
         <var>entry index</var>.
 
     *  Convert <var>entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
+        If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the generated URI is equal to <var>patch URI</var> then set the bit for <var>entry index</var> in
         [=Format 1 Patch Map/appliedEntriesBitMap=] to 1.
@@ -1641,8 +1644,8 @@ The algorithm:
 
 11. If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.
 
-12. Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]]. Set the patch uri of
-     <var>entry</var> to the generated URI.
+12. Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]]. If the template expansion
+     results in an error (see: [[rfc6570#section-3]]) then, return an error. Set the patch uri of <var>entry</var> to the generated URI.
 
 13. Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, [=Mapping Entry/entryIdStringLength=] as
      <var>consumed id string bytes</var>, and <var>ignored</var>.

--- a/Overview.html
+++ b/Overview.html
@@ -4,9 +4,9 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Incremental Font Transfer</title>
   <meta content="WD" name="w3c-status">
-  <meta content="Bikeshed version c3a8ac783, updated Wed Jul 24 12:20:06 2024 -0700" name="generator">
+  <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="9596b0de5966ddaec03d90dba68ddf8502b48375" name="revision">
+  <meta content="de17c8b137076b8e3400e35d4c20dcc1c2952940" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -712,37 +712,15 @@ D50 2deg illuminant, L in [0,100], a and b in [-128, 128]
 4 = lab(85,5,15)
 5 = lab(85,-10,-50)
 6 = lab(85,35,-15)
-
-For darkmode:
-0 = oklab(50%   0%  108%)
-1 = oklab(50% -51%   51%)
-2 = oklab(50% -64%  -20%)
-3 = oklab(50%   6%   19%)
-4 = oklab(50% -12%  -64%)
-5 = oklab(50%  44%  -19%)  
-6 = oklab(50% 102%   38%)
 */
-
 [data-algorithm] var { cursor: pointer; }
-var[data-var-color] { background-color: var(--var-bg); box-shadow: 0 0 0 2px var(--var-bg); }
-
-var[data-var-color] { --var-bg: #F4D200; }
-var[data-var-color="1"] { --var-bg: #FF87A2; }
-var[data-var-color="2"] { --var-bg: #96E885; }
-var[data-var-color="3"] { --var-bg: #3EEED2; }
-var[data-var-color="4"] { --var-bg: #EACFB6; }
-var[data-var-color="5"] { --var-bg: #82DDFF; }
-var[data-var-color="6"] { --var-vg: #FFBCF2; }
-
-@media (prefers-color-scheme: dark) {
-	var[data-var-color] { --var-bg: #bc1a00; }
-	var[data-var-color="1"] { --var-bg: #007f00; }
-	var[data-var-color="2"] { --var-bg: #008698; }
-	var[data-var-color="3"] { --var-bg: #7f5b2b; }
-	var[data-var-color="4"] { --var-bg: #004df3; }
-	var[data-var-color="5"] { --var-bg: #a1248a; }
-	var[data-var-color="6"] { --var-vg: #ff0000; }
-}
+var[data-var-color="0"] { background-color: #F4D200; box-shadow: 0 0 0 2px #F4D200; }
+var[data-var-color="1"] { background-color: #FF87A2; box-shadow: 0 0 0 2px #FF87A2; }
+var[data-var-color="2"] { background-color: #96E885; box-shadow: 0 0 0 2px #96E885; }
+var[data-var-color="3"] { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEED2; }
+var[data-var-color="4"] { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
+var[data-var-color="5"] { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
+var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-WD" rel="stylesheet">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
@@ -2370,8 +2348,8 @@ A string ID is a sequence of bytes. Several variables are defined which are used
       <td> The input id encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a> string (using the digits 0-9, A-V) with padding
       omitted.  When the id is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
       but then all leading bytes that are equal to 0 are removed before encoding.  (For example, when the
-      integer is less than 256 only one byte is encoded.) When the input id is a string the raw bytes are
-      encoded as base32hex. 
+      integer is less than 256 only one byte is encoded.) If the input id is 0 then one zero byte is encoded. When the input
+      id is a string the raw bytes are encoded as base32hex. 
      <tr>
       <td><code>d1</code>
       <td> The last character of the string in the <code>id</code> variable.
@@ -2394,11 +2372,11 @@ A string ID is a sequence of bytes. Several variables are defined which are used
       (minus) and _ (underline)) with padding included. Because the padding character is '=', it must
       be URL-encoded as "%3D'.  When the id is an unsigned integer it must first be converted to a big
       endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding. 
-      (For example, when the integer is less than 256 only one byte is encoded.) When the input id is
-      a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
+      (For example, when the integer is less than 256 only one byte is encoded.) If the input id is 0 then one
+      zero byte is encoded. When the input id is a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
    </table>
-   <div class="example" id="example-96830d51">
-    <a class="self-link" href="#example-96830d51"></a> 
+   <div class="example" id="example-722fec72">
+    <a class="self-link" href="#example-722fec72"></a> 
     <p>Some example inputs and the corresponding expansions:</p>
     <table>
      <tbody>
@@ -2410,6 +2388,10 @@ A string ID is a sequence of bytes. Several variables are defined which are used
        <td>//foo.bar/{id}
        <td>123
        <td>//foo.bar/FC
+      <tr>
+       <td>//foo.bar/{id}
+       <td>0
+       <td>//foo.bar/00
       <tr>
        <td>//foo.bar{/d1,d2,id}
        <td>478
@@ -2434,6 +2416,10 @@ A string ID is a sequence of bytes. Several variables are defined which are used
        <td>//foo.bar{/id64}
        <td>14,000,000
        <td>//foo.bar/1Z-A
+      <tr>
+       <td>//foo.bar{/id64}
+       <td>0
+       <td>//foo.bar/AA%3D%3D
       <tr>
        <td>//foo.bar{/id64}
        <td>17,000,000
@@ -3090,379 +3076,202 @@ to be used by default in most shaper implementations. This list was assembled fr
     <tbody>
      <tr>
       <th>Tag
-      <th>Encoded As
-     <tr>
-      <td>aalt
-      <td>1
+      <th>Name
      <tr>
       <td>abvf
-      <td>default
+      <td>Above-base Forms
      <tr>
       <td>abvm
-      <td>default
+      <td>Above-base Mark Positioning
      <tr>
       <td>abvs
-      <td>default
-     <tr>
-      <td>afrc
-      <td>2
+      <td>Above-base Substitutions
      <tr>
       <td>akhn
-      <td>default
+      <td>Akhand
      <tr>
       <td>blwf
-      <td>default
+      <td>Below-base Forms
      <tr>
       <td>blwm
-      <td>default
+      <td>Below-base Mark Positioning
      <tr>
       <td>blws
-      <td>default
+      <td>Below-base Substitutions
      <tr>
       <td>calt
-      <td>default
-     <tr>
-      <td>case
-      <td>3
+      <td>Contextual Alternates
      <tr>
       <td>ccmp
-      <td>default
+      <td>Glyph Composition / Decomposition
      <tr>
       <td>cfar
-      <td>default
+      <td>Conjunct Form After Ro
      <tr>
       <td>chws
-      <td>default
+      <td>Contextual Half-width Spacing
      <tr>
       <td>cjct
-      <td>default
+      <td>Conjunct Forms
      <tr>
       <td>clig
-      <td>default
-     <tr>
-      <td>cpct
-      <td>4
-     <tr>
-      <td>cpsp
-      <td>5
+      <td>Contextual Ligatures
      <tr>
       <td>cswh
-      <td>default
+      <td>Contextual Swash
      <tr>
       <td>curs
-      <td>default
-     <tr>
-      <td>cv01-cv99
-      <td>6-104
-     <tr>
-      <td>c2pc
-      <td>105
-     <tr>
-      <td>c2sc
-      <td>106
+      <td>Cursive Positioning
      <tr>
       <td>dist
-      <td>default
-     <tr>
-      <td>dlig
-      <td>107
+      <td>Distances
      <tr>
       <td>dnom
-      <td>default
+      <td>Denominators
      <tr>
       <td>dtls
-      <td>default
-     <tr>
-      <td>expt
-      <td>108
-     <tr>
-      <td>falt
-      <td>109
+      <td>Dotless Forms
      <tr>
       <td>fin2
-      <td>default
+      <td>Terminal Forms #2
      <tr>
       <td>fin3
-      <td>default
+      <td>Terminal Forms #3
      <tr>
       <td>fina
-      <td>default
+      <td>Terminal Forms
      <tr>
       <td>flac
-      <td>default
+      <td>Flattened accent forms
      <tr>
       <td>frac
-      <td>default
-     <tr>
-      <td>fwid
-      <td>110
+      <td>Fractions
      <tr>
       <td>half
-      <td>default
+      <td>Half Forms
      <tr>
       <td>haln
-      <td>default
-     <tr>
-      <td>halt
-      <td>111
-     <tr>
-      <td>hist
-      <td>112
-     <tr>
-      <td>hkna
-      <td>113
-     <tr>
-      <td>hlig
-      <td>114
-     <tr>
-      <td>hngl
-      <td>115
-     <tr>
-      <td>hojo
-      <td>116
-     <tr>
-      <td>hwid
-      <td>117
+      <td>Halant Forms
      <tr>
       <td>init
-      <td>default
+      <td>Initial Forms
      <tr>
       <td>isol
-      <td>default
-     <tr>
-      <td>ital
-      <td>118
+      <td>Isolated Forms
      <tr>
       <td>jalt
-      <td>default
-     <tr>
-      <td>jp78
-      <td>119
-     <tr>
-      <td>jp83
-      <td>120
-     <tr>
-      <td>jp90
-      <td>121
-     <tr>
-      <td>jp04
-      <td>122
+      <td>Justification Alternates
      <tr>
       <td>kern
-      <td>default
-     <tr>
-      <td>lfbd
-      <td>123
+      <td>Kerning
      <tr>
       <td>liga
-      <td>default
+      <td>Standard Ligatures
      <tr>
       <td>ljmo
-      <td>default
-     <tr>
-      <td>lnum
-      <td>124
+      <td>Leading Jamo Forms
      <tr>
       <td>locl
-      <td>default
+      <td>Localized Forms
      <tr>
       <td>ltra
-      <td>default
+      <td>Left-to-right alternates
      <tr>
       <td>ltrm
-      <td>default
+      <td>Left-to-right mirrored forms
      <tr>
       <td>mark
-      <td>default
+      <td>Mark Positioning
      <tr>
       <td>med2
-      <td>default
+      <td>Medial Forms #2
      <tr>
       <td>medi
-      <td>default
-     <tr>
-      <td>mgrk
-      <td>125
+      <td>Medial Forms
      <tr>
       <td>mkmk
-      <td>default
+      <td>Mark to Mark Positioning
      <tr>
       <td>mset
-      <td>default
-     <tr>
-      <td>nalt
-      <td>126
-     <tr>
-      <td>nlck
-      <td>127
+      <td>Mark Positioning via Substitution
      <tr>
       <td>nukt
-      <td>default
+      <td>Nukta Forms
      <tr>
       <td>numr
-      <td>default
-     <tr>
-      <td>onum
-      <td>128
-     <tr>
-      <td>opbd
-      <td>129
-     <tr>
-      <td>ordn
-      <td>130
-     <tr>
-      <td>ornm
-      <td>131
-     <tr>
-      <td>palt
-      <td>132
-     <tr>
-      <td>pcap
-      <td>133
-     <tr>
-      <td>pkna
-      <td>134
-     <tr>
-      <td>pnum
-      <td>135
+      <td>Numerators
      <tr>
       <td>pref
-      <td>default
+      <td>Pre-Base Forms
      <tr>
       <td>pres
-      <td>default
+      <td>Pre-base Substitutions
      <tr>
       <td>pstf
-      <td>default
+      <td>Post-base Forms
      <tr>
       <td>psts
-      <td>default
-     <tr>
-      <td>pwid
-      <td>136
-     <tr>
-      <td>qwid
-      <td>137
+      <td>Post-base Substitutions
      <tr>
       <td>rand
-      <td>default
+      <td>Randomize
      <tr>
       <td>rclt
-      <td>default
+      <td>Required Contextual Alternates
      <tr>
       <td>rkrf
-      <td>default
+      <td>Rakar Forms
      <tr>
       <td>rlig
-      <td>default
+      <td>Required Ligatures
      <tr>
       <td>rphf
-      <td>default
-     <tr>
-      <td>rtbd
-      <td>138
+      <td>Reph Forms
      <tr>
       <td>rtla
-      <td>default
+      <td>Right-to-left alternates
      <tr>
       <td>rtlm
-      <td>default
-     <tr>
-      <td>ruby
-      <td>139
+      <td>Right-to-left mirrored forms
      <tr>
       <td>rvrn
-      <td>default
-     <tr>
-      <td>salt
-      <td>140
-     <tr>
-      <td>sinf
-      <td>141
-     <tr>
-      <td>size
-      <td>142
-     <tr>
-      <td>smcp
-      <td>143
-     <tr>
-      <td>smpl
-      <td>144
-     <tr>
-      <td>ss01-ss20
-      <td>145-164
+      <td>Required Variation Alternates
      <tr>
       <td>ssty
-      <td>default
+      <td>Math script style alternates
      <tr>
       <td>stch
-      <td>default
-     <tr>
-      <td>subs
-      <td>165
-     <tr>
-      <td>sups
-      <td>166
-     <tr>
-      <td>swsh
-      <td>167
-     <tr>
-      <td>titl
-      <td>168
+      <td>Stretching Glyph Decomposition
      <tr>
       <td>tjmo
-      <td>default
-     <tr>
-      <td>tnam
-      <td>169
-     <tr>
-      <td>tnum
-      <td>170
-     <tr>
-      <td>trad
-      <td>171
-     <tr>
-      <td>twid
-      <td>172
-     <tr>
-      <td>unic
-      <td>173
+      <td>Trailing Jamo Forms
      <tr>
       <td>valt
-      <td>default
+      <td>Alternate Vertical Metrics
      <tr>
       <td>vatu
-      <td>default
+      <td>Vattu Variants
      <tr>
       <td>vchw
-      <td>default
+      <td>Vertical Contextual Half-width Spacing
      <tr>
       <td>vert
-      <td>default
-     <tr>
-      <td>vhal
-      <td>174
+      <td>Vertical Writing
      <tr>
       <td>vjmo
-      <td>default
-     <tr>
-      <td>vkna
-      <td>175
+      <td>Vowel Jamo Forms
      <tr>
       <td>vkrn
-      <td>default
+      <td>Vertical Kerning
      <tr>
       <td>vpal
-      <td>default
+      <td>Proportional Alternate Vertical Metrics
      <tr>
       <td>vrt2
-      <td>default
+      <td>Vertical Alternates and Rotation
      <tr>
       <td>vrtr
-      <td>default
-     <tr>
-      <td>zero
-      <td>176
+      <td>Vertical Alternates for Rotation
    </table>
    <h2 class="heading settled" id="extension-example"><span class="content"> Appendix B: Extension Algorithm Example Execution</span><a class="self-link" href="#extension-example"></a></h2>
    <p>This appendix provides an example of how a typical IFT font would be processed by the <a href="#extend-font-subset">§ 4.3 Incremental Font Extension Algorithm</a> algorithm. In this example the IFT font

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="de17c8b137076b8e3400e35d4c20dcc1c2952940" name="revision">
+  <meta content="e6d03afe82e1e5f13f71f01143982405b9deb2b4" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1788,7 +1788,8 @@ index and do not build an entry for it.</p>
        <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
 Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
+       <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>. If
+the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
       <li data-md>
@@ -1808,7 +1809,8 @@ skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigne
       <li data-md>
        <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
       <li data-md>
-       <p>Convert <var>mapped entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
+       <p>Convert <var>mapped entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.
+If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this entry.</p>
       <li data-md>
@@ -1855,7 +1857,8 @@ change the number of bytes.</p>
       <li data-md>
        <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate②">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.</p>
+       <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate②">uriTemplate</a> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>.
+If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the generated URI is equal to <var>patch URI</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
      </ul>
@@ -2150,7 +2153,8 @@ failed then, this encoding is invalid return an error.</p>
     <li data-md>
      <p>If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
     <li data-md>
-     <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>. Set the patch uri of <var>entry</var> to the generated URI.</p>
+     <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 5.2.3 URI Templates</a>. If the template expansion
+ results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error. Set the patch uri of <var>entry</var> to the generated URI.</p>
     <li data-md>
      <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength①">entryIdStringLength</a> as <var>consumed id string bytes</var>, and <var>ignored</var>.</p>
    </ol>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="e6d03afe82e1e5f13f71f01143982405b9deb2b4" name="revision">
+  <meta content="f98e816af36cb32fc50cdd947bedaff2b3745fbe" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2379,62 +2379,75 @@ A string ID is a sequence of bytes. Several variables are defined which are used
       (For example, when the integer is less than 256 only one byte is encoded.) If the input id is 0 then one
       zero byte is encoded. When the input id is a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
    </table>
-   <div class="example" id="example-722fec72">
-    <a class="self-link" href="#example-722fec72"></a> 
+   <div class="example" id="example-76363920">
+    <a class="self-link" href="#example-76363920"></a> 
     <p>Some example inputs and the corresponding expansions:</p>
     <table>
      <tbody>
       <tr>
        <th>Template
        <th>Input ID
+       <th>ID Type
        <th>Expansion
       <tr>
        <td>//foo.bar/{id}
        <td>123
+       <td>Integer
        <td>//foo.bar/FC
       <tr>
        <td>//foo.bar/{id}
        <td>0
+       <td>Integer
        <td>//foo.bar/00
       <tr>
        <td>//foo.bar{/d1,d2,id}
        <td>478
+       <td>Integer
        <td>//foo.bar/0/F/07F0
       <tr>
        <td>//foo.bar{/d1,d2,d3,id}
        <td>123
+       <td>Integer
        <td>//foo.bar/C/F/_/FC
       <tr>
        <td>//foo.bar{/d1,d2,d3,id}
        <td>baz
+       <td>String
        <td>//foo.bar/K/N/G/C9GNK
       <tr>
        <td>//foo.bar{/d1,d2,d3,id}
        <td>z
+       <td>String
        <td>//foo.bar/8/F/_/F8
       <tr>
        <td>//foo.bar{/d1,d2,d3,id}
        <td>àbc
+       <td>String
        <td>//foo.bar/O/O/4/OEG64OO
       <tr>
        <td>//foo.bar{/id64}
        <td>14,000,000
+       <td>Integer
        <td>//foo.bar/1Z-A
       <tr>
        <td>//foo.bar{/id64}
        <td>0
+       <td>Integer
        <td>//foo.bar/AA%3D%3D
       <tr>
        <td>//foo.bar{/id64}
        <td>17,000,000
+       <td>Integer
        <td>//foo.bar/AQNmQA%3D%3D
       <tr>
        <td>//foo.bar{/id64}
        <td>àbc
+       <td>String
        <td>//foo.bar/w6BiYw%3D%3D
       <tr>
        <td>//foo.bar/{+id64}
        <td>àbcd
+       <td>String
        <td>//foo.bar/w6BiY2Q=
     </table>
    </div>


### PR DESCRIPTION
- Clarify how id 0 during substitution is handled. Previously this was a bit ambiguous as the text stated to strip all 0 bytes.
- Specify that when applying templates the substitution may fail due to a malformed template.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/249.html" title="Last updated on Jan 17, 2025, 6:52 PM UTC (b3183d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/249/de17c8b...b3183d6.html" title="Last updated on Jan 17, 2025, 6:52 PM UTC (b3183d6)">Diff</a>