### PR TITLE
Rework the copy indices mechanism

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -342,19 +342,18 @@ Patch Map {#patch-map-dfn}
 A <dfn dfn>patch map</dfn> is an [[open-type/otff#table-directory|open type table]] which encodes a collection of mappings from
 [=font subset definition|font subset definitions=] to URIs which host [[#font-patch-formats|patches]] that extend the
 [=incremental font=]. A [=patch map=] table encodes a list of <dfn dfn>patch map entries</dfn>, where each entry has a key and value.
-The key is a [=font subset definition=], zero or more references to other entries and the value is a URI, the [[#font-patch-formats]]
-used by the data at the URI, and the [[#font-patch-invalidations|compatibility ID]] of the patch map table. More details of the format
-of patch maps can be found in [[#font-format-extensions]].
+The key of an entry defines the coverage of the entry, which is information on what subset definitions will match it. The value specifies
+information about the patch which should be applied when the entry is matched. [=patch map entries|Patch Map Entry=] summary:
 
-[=patch map entries|Patch Map Entry=] summary:
 <table>
   <tr><th>Key</th><th>Value</th></tr>
   <tr>
     <td>
-      * [=font subset definition=]
-      * Reference to zero or more other Patch Map Entries.
-      * Prior entry match mode, which can be either conjunctive or disjunctive.
-
+      * [=font subset definition=]: defines the basic coverage.
+      * References to zero or more child [=patch map entries|Patch Map Entry=]'s:<br/>
+         these child entries are used to extend the coverage.
+      * Child entry match mode, which can be either conjunctive or disjunctive.
+      
     </td>
     <td>
       * Patch URI
@@ -364,6 +363,8 @@ of patch maps can be found in [[#font-format-extensions]].
     </td>
   </tr>
 </table>
+
+More details of the format of patch maps can be found in [[#font-format-extensions]].
 
 Explanation of Data Types {#data-types}
 ---------------------------------------
@@ -544,11 +545,11 @@ The algorithm:
 
 2. If one or more sets checked in step 1 did not intersect, then return false for <var>intersects</var>.
 
-3. If there are no entry references in <var>mapping entry</var>, then return true for <var>intersects</var>.
+3. If there are no child entries in <var>mapping entry</var>, then return true for <var>intersects</var>.
 
-4. Invoke [$Check entry intersection$] for each prior entry referenced in <var>mapping entry</var> with <var>subset definition</var> as an input. If prior
-    entry match mode is conjunctive, then return true for <var>intersects</var> if all invocations return true. Otherwise return true if at least one
-    invocation returns true.
+4. Invoke [$Check entry intersection$] for each child entry referenced in <var>mapping entry</var> with <var>subset definition</var>
+    as an input. If child entry match mode is conjunctive, then return true for <var>intersects</var> only if all invocations return true.
+    Otherwise return true only if at least one invocation returns true.
 
 <div class=example>
 
@@ -562,7 +563,7 @@ The algorithm:
       feature tags: {},
       design space: {}
     },
-    prior entries: {},
+    child entries: {},
     match mode: disjunctive,
     ```
     </td>
@@ -583,7 +584,7 @@ The algorithm:
       feature tags: {},
       design space: {}
     },
-    prior entries: {},
+    child entries: {},
     match mode: disjunctive,
     ```
     </td>
@@ -603,7 +604,7 @@ The algorithm:
       feature tags: {},
       design space: {}
     },
-    prior entries: {},
+    child entries: {},
     match mode: disjunctive,
     ```
     </td>
@@ -623,7 +624,7 @@ The algorithm:
       feature tags: {},
       design space: {}
     },
-    prior entries: {},
+    child entries: {},
     match mode: disjunctive,
     ```
     </td>
@@ -644,14 +645,14 @@ The algorithm:
       feature tags: {},
       design space: {}
     },
-    prior entries: [
+    child entries: [
       {
         subset definition {
           code points: {1, 2, 3},
           feature tags: {},
           design space: {}
         },
-        prior entries: {},
+        child entries: {},
         match mode: disjunctive,
       },
       {
@@ -660,7 +661,7 @@ The algorithm:
           feature tags: {},
           design space: {}
         },
-        prior entries: {},
+        child entries: {},
         match mode: disjunctive,
       },
     ],
@@ -684,14 +685,14 @@ The algorithm:
       feature tags: {},
       design space: {}
     },
-    prior entries: [
+    child entries: [
       {
         subset definition {
           code points: {1, 2, 3},
           feature tags: {},
           design space: {}
         },
-        prior entries: {},
+        child entries: {},
         match mode: disjunctive,
       },
       {
@@ -700,7 +701,7 @@ The algorithm:
           feature tags: {},
           design space: {}
         },
-        prior entries: {},
+        child entries: {},
         match mode: disjunctive,
       },
     ],
@@ -769,8 +770,8 @@ round trips.
 The following selection criteria minimizes round trips and must be used by the client when selecting a single partial or full invalidation patch in step 8
 of [$Extend an Incremental Font Subset$]:
 
-1.  For each candidate entry compute a total subset definition by unioning that entry's subset definition and the subset definition of any other entries
-     reachable via the graph of referenced prior entries.
+1.  For each candidate entry compute a total subset definition by unioning that entry's subset definition and the subset definition of all child entries
+     reachable via the graph of referenced child entries.
 
 2.  For each candidate entry compute the set intersection between the total subset definition and the target subset definition.
    
@@ -1437,20 +1438,20 @@ The algorithm:
 
   <tr>
     <td>uint8</td>
-    <td><dfn for="Mapping Entry">priorEntryMatchModeAndCount</dfn></td>
+    <td><dfn for="Mapping Entry">childEntryMatchModeAndCount</dfn></td>
     <td>
       This and the following field are used to add conditions to the intersection check for this entry that depend on whether prior entries intersect.
       The most significant bit is used to indicate the matching mode. If the bit is set the condition is conjunctive otherwise it is disjunctive. The
-      remaining 7 bits are interpreted as a unsigned integer and represent the number of entry indices in the priorEntryIndices list. This field is only
+      remaining 7 bits are interpreted as a unsigned integer and represent the number of entry indices in the childEntryIndices list. This field is only
       present if [=Mapping Entry/formatFlags=] bit 1 is set.
     </td>
   </tr>
   <tr>
     <td>uint24</td>
-    <td><dfn for="Mapping Entry">priorEntryIndices</dfn>[0b01111111 & priorEntryMatchModeAndCount]</td>
+    <td><dfn for="Mapping Entry">childEntryIndices</dfn>[0b01111111 & childEntryMatchModeAndCount]</td>
     <td>
       Each value is the index of an entry in [=Mapping Entries/entries=] array whose intersection will be checked to determine this entries intersection.
-      Only references entries that occurred prior to this [=Mapping Entry=] in [=Mapping Entries/entries=] and only present if
+      Only entries that occurred prior to this [=Mapping Entry=] in [=Mapping Entries/entries=] can be referenced. Only present if
       [=Mapping Entry/formatFlags=] bit 1 is set.
     </td>
   </tr>
@@ -1583,6 +1584,7 @@ The algorithm:
 
      *  If the returned value of ignored is false, then set the compatibility ID of the returned entry to
          [=Format 2 Patch Map/compatibilityId=] and add the  entry to <var>entry list</var>.
+         <!-- TODO XXXXX need to change ignored handling to work with the child entries mechanism. -->
 
 4.  Return <var>entry list</var>.
 
@@ -1641,15 +1643,15 @@ The algorithm:
 
 6.  If [=Mapping Entry/formatFlags=] bit 1 is set, then the copy indices list is present:
 
-    *  If the most significant bit of [=Mapping Entry/priorEntryMatchModeAndCount=] is set then set <var>entry</var>'s match mode to conjunctive,
+    *  If the most significant bit of [=Mapping Entry/childEntryMatchModeAndCount=] is set then set <var>entry</var>'s match mode to conjunctive,
          otherwise to disjunctive.
 
-    *  Read the prior entry indices list specified by [=Mapping Entry/priorEntryMatchModeAndCount=] and [=Mapping Entry/priorEntryIndices=] from
+    *  Read the child entry indices list specified by [=Mapping Entry/childEntryMatchModeAndCount=] and [=Mapping Entry/childEntryIndices=] from
          <var>entry bytes</var>.
 
-    *  The prior entry indices refer to previously loaded entries. 0 is the first [=Mapping Entry=] in <var>prior entry list</var>, 1 the second
-         and so on. For each value in [=Mapping Entry/priorEntryIndices=] locate the entry in <var>prior entry list</var> with a matching index.
-         Add a reference to that entry into </var>entry</var>. If a [=Mapping Entry/priorEntryIndices=] is greater than or equal to the length
+    *  The child entry indices refer to previously loaded entries. 0 is the first [=Mapping Entry=] in <var>prior entry list</var>, 1 the second
+         and so on. For each value in [=Mapping Entry/childEntryIndices=] locate the entry in <var>prior entry list</var> with a matching index.
+         Add a reference to that entry into </var>entry</var>. If a [=Mapping Entry/childEntryIndices=] is greater than or equal to the length
          of <var>prior entry list</var> then, this encoding is invalid return an error.
 
 7.  If [=Mapping Entry/formatFlags=] bit 2 is set, then an id delta or id string length is present:
@@ -2660,7 +2662,7 @@ when loading the patches for two or more segments.  There are five main strategi
      modifier code point which triggers a glyph substitution when paired with many other code points. Given the large number of alternate
      glyphs it's desirable to keep them in their own patches which are only loaded when both the modifier code point and appropriate base
      code point(s) are present. This can be achieved by using a [[#patch-map-format-2|Format 2 Patch Map]] and multiple entry matching
-     via [=Mapping Entry/priorEntryIndices=]. For the entry one subset definition should contain the modifier code point and a
+     via [=Mapping Entry/childEntryIndices=]. For the entry one subset definition should contain the modifier code point and a
      second one has the base code point(s).
 
 4.  Alternatively, the glyph can be included in more than one of the patches that correspond to those segments at the cost of duplicating
@@ -2815,6 +2817,8 @@ path: feature-registry.html
 
 <h2 id="extension-example">
 Appendix B: Extension Algorithm Example Execution</h2>
+
+<!-- TODO add an example that utilizes prior entry indices (such as UVS specific patches)  -->
 
 This appendix provides an example of how a typical IFT font would be processed by the [[#extend-font-subset]] algorithm. In this example the IFT font
 contains a mix of both [[#table-keyed]] and [[#glyph-keyed]] patches.

--- a/Overview.bs
+++ b/Overview.bs
@@ -1566,9 +1566,11 @@ The algorithm:
 2.  If the [=Format 2 Patch Map/entryIdStringData=] offset is 0 then initialize <var>last entry id</var> to 0. Otherwise initialize
      it to an empty byte string. Set <var>current byte</var> to 0, and <var>current id string byte</var> to 0.
 
-3.  Invoke [$Interpret Format 2 Patch Map Entry$], [=Format 2 Patch Map/entryCount=] times. For each invocation:
+3.  Initialize <var>entry list</var> and <var>prior entry list</var> to empty lists.
 
-     *  pass in <var>entry list</var>, the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entries=][<var>current byte</var>] to
+4.  Invoke [$Interpret Format 2 Patch Map Entry$], [=Format 2 Patch Map/entryCount=] times. For each invocation:
+
+     *  pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entries=][<var>current byte</var>] to
          the end of <var>patch map</var>,
          the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entryIdStringData=][<var>current id string byte</var>]
          to the end of <var>patch map</var> if [=Format 2 Patch Map/entryIdStringData=] is non zero,
@@ -1582,11 +1584,12 @@ The algorithm:
 
      *  Add the returned consumed id string byte count to <var>current id string byte</var>.
 
+     *  Add the returned entry to <var>prior entry list</var>.
+
      *  If the returned value of ignored is false, then set the compatibility ID of the returned entry to
          [=Format 2 Patch Map/compatibilityId=] and add the  entry to <var>entry list</var>.
-         <!-- TODO XXXXX need to change ignored handling to work with the child entries mechanism. -->
 
-4.  Return <var>entry list</var>.
+5.  Return <var>entry list</var>.
 
 <dfn abstract-op>Interpret Format 2 Patch Map Entry</dfn>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -342,16 +342,18 @@ Patch Map {#patch-map-dfn}
 A <dfn dfn>patch map</dfn> is an [[open-type/otff#table-directory|open type table]] which encodes a collection of mappings from
 [=font subset definition|font subset definitions=] to URIs which host [[#font-patch-formats|patches]] that extend the
 [=incremental font=]. A [=patch map=] table encodes a list of <dfn dfn>patch map entries</dfn>, where each entry has a key and value.
-The key is one or more [=font subset definition=] and the value is a URI, the [[#font-patch-formats]] used by the data at the URI, and
-the [[#font-patch-invalidations|compatibility ID]] of the patch map table. More details of the format of patch maps can be found
-in [[#font-format-extensions]].
+The key is a [=font subset definition=], zero or more references to other entries and the value is a URI, the [[#font-patch-formats]]
+used by the data at the URI, and the [[#font-patch-invalidations|compatibility ID]] of the patch map table. More details of the format
+of patch maps can be found in [[#font-format-extensions]].
 
 [=patch map entries|Patch Map Entry=] summary:
 <table>
   <tr><th>Key</th><th>Value</th></tr>
   <tr>
     <td>
-      * One or more [=font subset definition=]
+      * [=font subset definition=]
+      * Reference to zero or more other Patch Map Entries.
+      * Prior entry match mode, which can be either conjunctive or disjunctive.
 
     </td>
     <td>
@@ -468,7 +470,7 @@ The algorithm:
 
 8.  Pick one <var>entry</var> with the following procedure:
 
-    *  If <var>full invalidation entry list</var> is not empty then, select exactly one of the contained entries. Follow the criteria in
+    *  If <var>full invalidation entry list</var> is not empty, then select exactly one of the contained entries. Follow the criteria in
         [[#invalidating-patch-selection]] to select the single entry.
 
     *  Otherwise if <var>partial invalidation entry list</var> is not empty then, select exactly one of the contained entries.
@@ -521,8 +523,8 @@ The algorithm outputs:
 
 The algorithm:
 
-1.  For each subset definition in <var>mapping entry</var> and each set in <var>subset definition</var> (code points, feature tags,
-     design space) check if the set intersects the corresponding set from the <var>mapping entry</var> subset definition. A set
+1.  For each set in <var>subset definition</var> (code points, feature tags,
+     design space) check if the set intersects the corresponding set from <var>mapping entry</var>'s subset definition. A set
      intersects when:
 
      <table>
@@ -540,8 +542,13 @@ The algorithm:
      When checking design space sets for intersection, they intersect if there is at least one pair of intersecting segments
      (tags are equal and the ranges intersect).
 
-2. If all sets checked in step 1 intersect, then return true for <var>intersects</var> otherwise false.
+2. If one or more sets checked in step 1 did not intersect, then return false for <var>intersects</var>.
 
+3. If there are no entry references in <var>mapping entry</var>, then return true for <var>intersects</var>.
+
+4. Invoke [$Check entry intersection$] for each prior entry referenced in <var>mapping entry</var> with <var>subset definition</var> as an input. If prior
+    entry match mode is conjunctive, then return true for <var>intersects</var> if all invocations return true. Otherwise return true if at least one
+    invocation returns true.
 
 <div class=example>
 
@@ -550,13 +557,13 @@ The algorithm:
   <tr>
     <td>
     ```
-    subset definitions: [
-      {
-        code points: {1, 2, 3},
-        feature tags: {},
-        design space: {}
-      },
-    ],
+    subset definition {
+      code points: {1, 2, 3},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: {},
+    match mode: disjunctive,
     ```
     </td>
     <td>
@@ -571,13 +578,13 @@ The algorithm:
   <tr>
     <td>
     ```
-    subset definitions: [
-      {
-        code points: {1, 2, 3},
-        feature tags: {},
-        design space: {}
-      },
-    ],
+    subset definition {
+      code points: {1, 2, 3},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: {},
+    match mode: disjunctive,
     ```
     </td>
     <td>
@@ -591,13 +598,13 @@ The algorithm:
   </tr>
   <td>
     ```
-    subset definitions: [
-      {
-        code points: {1, 2, 3},
-        feature tags: {},
-        design space: {}
-      },
-    ],
+    subset definition {
+      code points: {1, 2, 3},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: {},
+    match mode: disjunctive,
     ```
     </td>
     <td>
@@ -611,13 +618,13 @@ The algorithm:
   </tr>
   <td>
     ```
-    subset definitions: [
-      {
-        code points: {1, 2, 3},
-        feature tags: {},
-        design space: {}
-      },
-    ],
+    subset definition: {
+      code points: {1, 2, 3},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: {},
+    match mode: disjunctive,
     ```
     </td>
     <td>
@@ -632,18 +639,32 @@ The algorithm:
   <tr>
     <td>
     ```
-    subset definitions: [
+    subset definition: {
+      code points: {},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: [
       {
-        code points: {1, 2, 3},
-        feature tags: {},
-        design space: {}
+        subset definition {
+          code points: {1, 2, 3},
+          feature tags: {},
+          design space: {}
+        },
+        prior entries: {},
+        match mode: disjunctive,
       },
       {
-        code points: {4, 5, 6},
-        feature tags: {},
-        design space: {}
+        subset definition {
+          code points: {4, 5, 6},
+          feature tags: {},
+          design space: {}
+        },
+        prior entries: {},
+        match mode: disjunctive,
       },
     ],
+    match mode: conjunctive,
     ```
     </td>
     <td>
@@ -658,18 +679,32 @@ The algorithm:
   <tr>
     <td>
     ```
-    subset definitions: [
+    subset definition: {
+      code points: {},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: [
       {
-        code points: {1, 2, 3},
-        feature tags: {},
-        design space: {}
+        subset definition {
+          code points: {1, 2, 3},
+          feature tags: {},
+          design space: {}
+        },
+        prior entries: {},
+        match mode: disjunctive,
       },
       {
-        code points: {4, 5, 6},
-        feature tags: {},
-        design space: {}
+        subset definition {
+          code points: {4, 5, 6},
+          feature tags: {},
+          design space: {}
+        },
+        prior entries: {},
+        match mode: disjunctive,
       },
     ],
+    match mode: conjunctive,
     ```
     </td>
     <td>
@@ -734,17 +769,18 @@ round trips.
 The following selection criteria minimizes round trips and must be used by the client when selecting a single partial or full invalidation patch in step 8
 of [$Extend an Incremental Font Subset$]:
 
-1.  For each candidate entry compute the set intersection between each subset definition in the entry and the target subset definition. Union
-     the resulting intersections together into a single subset definition.
-   
-2.  Find an entry whose intersection subset definition from step 1 is not a strict subset of any other intersection subset definition.
+1.  For each candidate entry compute a total subset definition by unioning that entry's subset definition and the subset definition of any other entries
+     reachable via the graph of referenced prior entries.
 
-3.  Locate any additional entries that are in the same [=patch map=] and have the same intersection as the entry found in step 2. From the this set of
-     entries (including the step 2 pick) the final selection is the entry which is listed first in the [=patch map=]. For [[#patch-map-format-1]] this is the
+2.  For each candidate entry compute the set intersection between the total subset definition and the target subset definition.
+   
+3.  Find an entry whose intersection from step 2 is not a strict subset of any other intersection.
+
+4.  Locate any additional entries that are in the same [=patch map=] and have the same intersection as the entry found in step 3. From the this set of
+     entries (including the step 3 pick) the final selection is the entry which is listed first in the [=patch map=]. For [[#patch-map-format-1]] this is the
      entry with the lowest entry index. For [[#patch-map-format-2]] this is the entry that appears first in the [=Mapping Entries/entries=] array.
 
-
-Note: a fast and efficient way to find an entry which satisfies the criteria for step 2 is to sort the entries (descending) by the size of the code point
+Note: a fast and efficient way to find an entry which satisfies the criteria for step 3 is to sort the entries (descending) by the size of the code point
 set intersection, then the size of feature tag set intersection, and finally the size of the design space intersection. The first entry in this sorting is
 guaranteed to not be a strict subset of any other entries, since any strict super sets would have to be at least one item larger. This approach also has
 the added benefit that it selects the patch which will add the most data which the client is currently requesting.
@@ -1190,7 +1226,7 @@ The algorithm:
 
     *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
 
-    *  Add an [=patch map entries|entry=] to <var>entry list</var> with one subset definition which contains only the Unicode code point
+    *  Add an [=patch map entries|entry=] to <var>entry list</var> with a subset definition which contains only the Unicode code point
         set and maps to the generated URI, the patch format specified by [=Format 1 Patch Map/patchFormat=], and
         [=Format 1 Patch Map/compatibilityId=].
 
@@ -1234,7 +1270,7 @@ The algorithm:
         specified by [=Format 1 Patch Map/patchFormat=], and [=Format 1 Patch Map/compatibilityId=]; or if there is an existing
         [=patch map entries|entry=] in <var>entry list</var> which has the same patch URI as the generated URI then
         instead modify the existing entry. Add the constructed set of Unicode code points and [=FeatureRecord/featureTag=] to the new or
-        existing entry's single subset definition.
+        existing entry's subset definition.
 
 4.  Return <var>entry list</var>.
 
@@ -1401,19 +1437,20 @@ The algorithm:
 
   <tr>
     <td>uint8</td>
-    <td><dfn for="Mapping Entry">copyModeAndCount</dfn></td>
+    <td><dfn for="Mapping Entry">priorEntryMatchModeAndCount</dfn></td>
     <td>
-      The most significant bit is used to indicate the copy mode, if the bit is set copy mode is "append" otherwise it is "union".
-      The remaining 7 bits are interpreted as a unsigned integer and represent the number of entries in the copyIndices list. This
-      field is only present if [=Mapping Entry/formatFlags=] bit 1 is set.
+      This and the following field are used to add conditions to the intersection check for this entry that depend on whether prior entries intersect.
+      The most significant bit is used to indicate the matching mode. If the bit is set the condition is conjunctive otherwise it is disjunctive. The
+      remaining 7 bits are interpreted as a unsigned integer and represent the number of entry indices in the priorEntryIndices list. This field is only
+      present if [=Mapping Entry/formatFlags=] bit 1 is set.
     </td>
   </tr>
   <tr>
     <td>uint24</td>
-    <td><dfn for="Mapping Entry">copyIndices</dfn>[copyModeAndCount]</td>
+    <td><dfn for="Mapping Entry">priorEntryIndices</dfn>[0b01111111 & priorEntryMatchModeAndCount]</td>
     <td>
-      List of indices from the [=Mapping Entries/entries=] array whose [=font subset definition=] should be copied into this entry. May
-      only reference entries that occurred prior to this [=Mapping Entry=] in [=Mapping Entries/entries=]. Only present if
+      Each value is the index of an entry in [=Mapping Entries/entries=] array whose intersection will be checked to determine this entries intersection.
+      Only references entries that occurred prior to this [=Mapping Entry=] in [=Mapping Entries/entries=] and only present if
       [=Mapping Entry/formatFlags=] bit 1 is set.
     </td>
   </tr>
@@ -1530,7 +1567,7 @@ The algorithm:
 
 3.  Invoke [$Interpret Format 2 Patch Map Entry$], [=Format 2 Patch Map/entryCount=] times. For each invocation:
 
-     *  pass in the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entries=][<var>current byte</var>] to
+     *  pass in <var>entry list</var>, the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entries=][<var>current byte</var>] to
          the end of <var>patch map</var>,
          the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entryIdStringData=][<var>current id string byte</var>]
          to the end of <var>patch map</var> if [=Format 2 Patch Map/entryIdStringData=] is non zero,
@@ -1552,6 +1589,8 @@ The algorithm:
 <dfn abstract-op>Interpret Format 2 Patch Map Entry</dfn>
 
 The inputs to this algorithm are:
+
+* <var>prior entry list</var>: a list of entries prior to this one.
 
 * <var>entry bytes</var>: a byte array that contains an encoded [=Mapping Entry=].
 
@@ -1602,15 +1641,16 @@ The algorithm:
 
 6.  If [=Mapping Entry/formatFlags=] bit 1 is set, then the copy indices list is present:
 
-    *  Read the copy indices list specified by [=Mapping Entry/copyModeAndCount=] and [=Mapping Entry/copyIndices=] from
+    *  If the most significant bit of [=Mapping Entry/priorEntryMatchModeAndCount=] is set then set <var>entry</var>'s match mode to conjunctive,
+         otherwise to disjunctive.
+
+    *  Read the prior entry indices list specified by [=Mapping Entry/priorEntryMatchModeAndCount=] and [=Mapping Entry/priorEntryIndices=] from
          <var>entry bytes</var>.
 
-    *  The copy indices refer to previously loaded entries. 0 is the first [=Mapping Entry=] in [=Mapping Entries/entries=], 1 the second
-         and so on. For each index in [=Mapping Entry/copyIndices=] locate the previously loaded entry with a matching index.
-         If the most significant bit of [=Mapping Entry/copyModeAndCount=] is set then append all [=font subset definition=]s from
-         the previous entry to <var>entry</var>. Otherwise union all code points, feature tags, and design space segments from
-         all [=font subset definition=]s in the previous entry into the first [=font subset definition=] in <var>entry</var>. If a
-         [=Mapping Entry/copyIndices=] is greater than or equal to the index of this entry then, this encoding is invalid return an error.
+    *  The prior entry indices refer to previously loaded entries. 0 is the first [=Mapping Entry=] in <var>prior entry list</var>, 1 the second
+         and so on. For each value in [=Mapping Entry/priorEntryIndices=] locate the entry in <var>prior entry list</var> with a matching index.
+         Add a reference to that entry into </var>entry</var>. If a [=Mapping Entry/priorEntryIndices=] is greater than or equal to the length
+         of <var>prior entry list</var> then, this encoding is invalid return an error.
 
 7.  If [=Mapping Entry/formatFlags=] bit 2 is set, then an id delta or id string length is present:
 
@@ -2619,8 +2659,8 @@ when loading the patches for two or more segments.  There are five main strategi
 3.  In some cases, such as with [[open-type/cmap#format-14-unicode-variation-sequences|Unicode variation selectors]], there will be a
      modifier code point which triggers a glyph substitution when paired with many other code points. Given the large number of alternate
      glyphs it's desirable to keep them in their own patches which are only loaded when both the modifier code point and appropriate base
-     code point(s) are present. This can be achieved by using a [[#patch-map-format-2|Format 2 Patch Map]] and multiple subset definitions
-     per entry via [=Mapping Entry/copyModeAndCount=]. For the entry one subset definition should contain the modifier code point and a
+     code point(s) are present. This can be achieved by using a [[#patch-map-format-2|Format 2 Patch Map]] and multiple entry matching
+     via [=Mapping Entry/priorEntryIndices=]. For the entry one subset definition should contain the modifier code point and a
      second one has the base code point(s).
 
 4.  Alternatively, the glyph can be included in more than one of the patches that correspond to those segments at the cost of duplicating

--- a/Overview.bs
+++ b/Overview.bs
@@ -736,7 +736,7 @@ of [$Extend an Incremental Font Subset$]:
 1.  For each candidate entry: compute a total subset definition by unioning that entry's subset definition and the subset definition of all child entries
      reachable via the graph of referenced child entries.
 
-2.  For each candidate entry compute the set intersection between the total subset definition and the target subset definition.
+2.  For each candidate entry: compute the set intersection between the total subset definition and the target subset definition.
    
 3.  Find an entry whose intersection from step 2 is not a strict subset of any other intersection.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -349,7 +349,7 @@ information about the patch which should be applied when the entry is matched. [
   <tr><th>Key</th><th>Value</th></tr>
   <tr>
     <td>
-      * [=font subset definition=]: defines the basic coverage.
+      * [=font subset definition=]: defines the base coverage.
       * References to zero or more child [=patch map entries|Patch Map Entry=]'s:<br/>
          these child entries are used to extend the coverage.
       * Child entry match mode, which can be either conjunctive or disjunctive.
@@ -553,166 +553,129 @@ The algorithm:
 
 <div class=example>
 
+The table below represents a patch mapping and shows the expected result of an intersection check against various entries. In these examples
+when a set (ie. code points, feature tags, design space, child entries) is not specified it is assumed to be the empty set.
+
 <table>
-  <tr><th>mapping entry</th><th>subset definition</th><th>intersects?</th></tr>
+  <tr><th>index</th><th>mapping entry</th><th>subset definition</th><th>intersects?</th></tr>
   <tr>
+    <td>0</td>
     <td>
     ```
     subset definition {
       code points: {1, 2, 3},
-      feature tags: {},
-      design space: {}
     },
-    child entries: {},
     match mode: disjunctive,
     ```
     </td>
     <td>
     ```
     code points: {2},
-    feature tags: {},
-    design space: {},
     ```
     </td>
     <td>true</td>
   </tr>
   <tr>
+    <td>1</td>
+    <td>
+    ```
+    subset definition {
+      code points: {4, 5, 6},
+    },
+    match mode: disjunctive,
+    ```
+    </td>
+    <td>
+    ```
+    code points: {2},
+    ```
+    </td>
+    <td>false</td>
+  </tr>
+  <tr>
+    <td>2</td>
     <td>
     ```
     subset definition {
       code points: {1, 2, 3},
-      feature tags: {},
-      design space: {}
     },
-    child entries: {},
+    match mode: disjunctive,
+    ```
+    </td>
+    <td>
+    ```
+    code points: {2},
+    feature tags: {smcp},
+    ```
+    </td>
+    <td>true</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>
+    ```
+    subset definition: {
+      code points: {1, 2, 3},
+    },
+    match mode: disjunctive,
+    ```
+    </td>
+    <td>
+    ```
+    feature tags: {smcp},
+    ```
+    </td>
+    <td>false</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>
+    ```
+    subset definition: {
+      code points: {1, 2, 3},
+    },
+    child entry indices: {1},
     match mode: disjunctive,
     ```
     </td>
     <td>
     ```
     code points: {5},
-    feature tags: {},
-    design space: {},
     ```
     </td>
     <td>false</td>
   </tr>
-  <td>
-    ```
-    subset definition {
-      code points: {1, 2, 3},
-      feature tags: {},
-      design space: {}
-    },
-    child entries: {},
-    match mode: disjunctive,
-    ```
-    </td>
-    <td>
-    ```
-    code points: {2},
-    feature tags: {smcp},
-    design space: {},
-    ```
-    </td>
-    <td>true</td>
-  </tr>
-  <td>
-    ```
-    subset definition: {
-      code points: {1, 2, 3},
-      feature tags: {},
-      design space: {}
-    },
-    child entries: {},
-    match mode: disjunctive,
-    ```
-    </td>
-    <td>
-    ```
-    code points: {},
-    feature tags: {smcp},
-    design space: {},
-    ```
-    </td>
-    <td>false</td>
-  </tr>
+
   <tr>
+    <td>5</td>
     <td>
     ```
     subset definition: {
-      code points: {},
-      feature tags: {},
-      design space: {}
     },
-    child entries: [
-      {
-        subset definition {
-          code points: {1, 2, 3},
-          feature tags: {},
-          design space: {}
-        },
-        child entries: {},
-        match mode: disjunctive,
-      },
-      {
-        subset definition {
-          code points: {4, 5, 6},
-          feature tags: {},
-          design space: {}
-        },
-        child entries: {},
-        match mode: disjunctive,
-      },
-    ],
+    child entry indices: {0, 1},
     match mode: conjunctive,
     ```
     </td>
     <td>
     ```
     code points: {2},
-    feature tags: {},
-    design space: {},
     ```
     </td>
     <td>false</td>
   </tr>
   <tr>
+    <td>6</td>
     <td>
     ```
     subset definition: {
-      code points: {},
-      feature tags: {},
-      design space: {}
     },
-    child entries: [
-      {
-        subset definition {
-          code points: {1, 2, 3},
-          feature tags: {},
-          design space: {}
-        },
-        child entries: {},
-        match mode: disjunctive,
-      },
-      {
-        subset definition {
-          code points: {4, 5, 6},
-          feature tags: {},
-          design space: {}
-        },
-        child entries: {},
-        match mode: disjunctive,
-      },
-    ],
+    child entry indices: {0, 1},
     match mode: conjunctive,
     ```
     </td>
     <td>
     ```
     code points: {2, 6},
-    feature tags: {},
-    design space: {},
     ```
     </td>
     <td>true</td>
@@ -770,7 +733,7 @@ round trips.
 The following selection criteria minimizes round trips and must be used by the client when selecting a single partial or full invalidation patch in step 8
 of [$Extend an Incremental Font Subset$]:
 
-1.  For each candidate entry compute a total subset definition by unioning that entry's subset definition and the subset definition of all child entries
+1.  For each candidate entry: compute a total subset definition by unioning that entry's subset definition and the subset definition of all child entries
      reachable via the graph of referenced child entries.
 
 2.  For each candidate entry compute the set intersection between the total subset definition and the target subset definition.

--- a/Overview.bs
+++ b/Overview.bs
@@ -2665,8 +2665,7 @@ when loading the patches for two or more segments.  There are five main strategi
      modifier code point which triggers a glyph substitution when paired with many other code points. Given the large number of alternate
      glyphs it's desirable to keep them in their own patches which are only loaded when both the modifier code point and appropriate base
      code point(s) are present. This can be achieved by using a [[#patch-map-format-2|Format 2 Patch Map]] and multiple entry matching
-     via [=Mapping Entry/childEntryIndices=]. For the entry one subset definition should contain the modifier code point and a
-     second one has the base code point(s).
+     via [=Mapping Entry/childEntryIndices=]. See [[#appendix-b-example-2]] for an example of how this can be set up.
 
 4.  Alternatively, the glyph can be included in more than one of the patches that correspond to those segments at the cost of duplicating
      the glyph's data into multiple patches.
@@ -2821,17 +2820,19 @@ path: feature-registry.html
 <h2 id="extension-example">
 Appendix B: Extension Algorithm Example Execution</h2>
 
-<!-- TODO add an example that utilizes prior entry indices (such as UVS specific patches)  -->
+This appendix provides examples of how a typical IFT font would be processed by the [[#extend-font-subset]] algorithm.
 
-This appendix provides an example of how a typical IFT font would be processed by the [[#extend-font-subset]] algorithm. In this example the IFT font
-contains a mix of both [[#table-keyed]] and [[#glyph-keyed]] patches.
+Example 1: Table and Glyph Keyed Patches {#appendix-b-example-1}
+----------------------------------------------------------------
+
+In this example the IFT font contains a mix of both [[#table-keyed]] and [[#glyph-keyed]] patches.
 
 <b>Initial font</b>: contains the following IFT and IFTX patch mappings. Note: when features and design space sets are unspecified in a subset definition
 they are defaulted to an empty set.
 
 <table>
   <tr><th>Table = "IFT "</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0001</th></tr>
-  <tr><th>Subset Definition(s)</th><th>URI</th><th>Format Number</th>
+  <tr><th>Subset Definition</th><th>URI</th><th>Format Number</th>
   <tr>
     <td>
       ```
@@ -2895,7 +2896,7 @@ they are defaulted to an empty set.
 <br/>
 <table>
   <tr><th>Table = "IFTX"</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0002</th></tr>
-  <tr><th>Subset Definition(s)</th><th>URI</th><th>Format Number</th>
+  <tr><th>Subset Definition</th><th>URI</th><th>Format Number</th>
   <tr>
     <td>
       ```
@@ -2995,7 +2996,7 @@ Iteration 1:
 
     <table>
       <tr><th>Table = "IFT "</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0006</th></tr>
-      <tr><th>Subset Definition(s)</th><th>URI</th><th>Format Number</th>
+      <tr><th>Subset Definition</th><th>URI</th><th>Format Number</th>
       <tr>
         <td>
           ```
@@ -3046,6 +3047,142 @@ Iteration 3:
 
 
 Iteration 4:
+
+*  Steps 2 through 6 - there are no remaining intersecting entries so the algorithm terminates. The font subset is returned and now ready to render any
+    content covered by the target subset definition.
+
+
+Example 2: Glyph Keyed Patches with Child Entries {#appendix-b-example-2}
+-------------------------------------------------------------------------
+
+In this example the IFT font contains a set of [[#glyph-keyed]] patches which utilize child entries to correctly handle the inclusion of patches
+for [[open-type/cmap#format-14-unicode-variation-sequences|UVS]] substitutions. For each set of base glyphs there are a set of alternate glyphs
+which are substituted in via a variation selector. These are kept in a separate patch. The alternate glyph patches are configured (via child entries)
+to load only when the base glyphs and the variation selector are present simultaneously.
+
+<b>Initial font</b>: contains the following IFT  patch mapping. Note: when codepoint, features, design space, or child entry sets are unspecified in
+a subset definition they are defaulted to an empty set.
+
+<table>
+  <tr><th>Table = "IFT "</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0001</th></tr>
+  <tr><th>Subset Definition</th><th>URI</th><th>Format Number</th><th>Ignored?</th><th>Notes</th>
+  <tr>
+    <td>
+      ```
+      code points:
+        { 'a', 'b', ..., 'm' }
+      ```
+    </td>
+    <td>//foo.bar/01.gk</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+    <td>No</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>
+      ```
+      code points:
+        { 'n', 'o', ..., 'z' }
+      ```
+    </td>
+    <td>//foo.bar/02.gk</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+    <td>No</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>
+      ```
+      code points: { VS1 }
+      ```
+    </td>
+    <td>N/A</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+    <td>Yes</td>
+  </tr>
+
+  <tr>
+    <td>
+      ```
+      child entries: [0, 2],
+      match mode: conjunctive
+      ```
+    </td>
+    <td>//foo.bar/03.gk</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+    <td>No</td>
+    <td>Has alternate glyphs for {'a', ..., 'm'} that are activated by VS1</td>
+  </tr>
+
+  <tr>
+    <td>
+      ```
+      child entries: [1, 2],
+      match mode: conjunctive
+      ```
+    </td>
+    <td>//foo.bar/04.gk</td>
+    <td>
+      3, Glyph Keyed
+    </td>
+    <td>No</td>
+    <td>Has alternate glyphs for {'n', ..., 'z'} that are activated by VS1</td>
+  </tr>
+ 
+</table>
+
+<b>Extension Example 1</b>
+
+Inputs:
+*  Initial font with an IFT table as defined above.
+*  Target subset definition: code points = {'f'}
+
+Iteration 1:
+
+*  Steps 1 through 6 - applying the [$Check entry intersection$] check to all entries in the initial font, the following patch entries intersect:
+    * //foo.bar/01.gk
+
+*  Step 8 through 10 - there is only one patch, //foo.bar/01.gk, is is selected, loaded, and applied.
+
+Iteration 2:
+
+*  Steps 2 through 6 - there are no remaining intersecting entries so the algorithm terminates. The font subset is returned and now ready to render any
+    content covered by the target subset definition.
+
+<b>Extension Example 2</b>
+
+Inputs:
+*  Initial font with an IFT table as defined above.
+*  Target subset definition: code points = {'f', VS1}
+
+Iteration 1:
+
+*  Steps 1 through 6 - applying the [$Check entry intersection$] check to all entries in the initial font, the following patch entries intersect:
+    * //foo.bar/01.gk
+    * //foo.bar/03.gk
+
+*  Step 8 - one entry must be selected, in this case the client implementation is free to pick either. //foo.bar/01.gk is selected.
+
+*  Step 9 - since both intersecting entries are no invalidation both can be simultaneously loaded.
+
+*  Step 10 - //foo.bar/01.gk is applied to the font. The mapping table is updated to mark the entry for //foo.bar/01.gk as ignored.
+
+Iteration 2:
+
+*  Steps 1 through 6 - applying the [$Check entry intersection$] check to all entries in the current font, the following patch entries intersect:
+    * //foo.bar/03.gk
+
+*  Step 8 through 10 - there is only one patch, //foo.bar/03.gk, is is selected, and applied (it was loaded during the previous iteration).
+
+Iteration 3:
 
 *  Steps 2 through 6 - there are no remaining intersecting entries so the algorithm terminates. The font subset is returned and now ready to render any
     content covered by the target subset definition.

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="f4577995ae19c1b0c727efad814e0507f4331dd9" name="revision">
+  <meta content="26c10f7ce2788870cc3aba7252cef5acc8efb222" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -868,7 +868,12 @@ to complex scripts like Indic or Arabic.</p>
     <li><a href="#sec"><span class="secno">9</span> <span class="content">Security Considerations</span></a>
     <li><a href="#changes"><span class="secno">10</span> <span class="content">Changes</span></a>
     <li><a href="#feature-tag-list"><span class="secno"></span> <span class="content"> Appendix A: Default Feature Tags</span></a>
-    <li><a href="#extension-example"><span class="secno"></span> <span class="content"> Appendix B: Extension Algorithm Example Execution</span></a>
+    <li>
+     <a href="#extension-example"><span class="secno"></span> <span class="content"> Appendix B: Extension Algorithm Example Execution</span></a>
+     <ol class="toc">
+      <li><a href="#appendix-b-example-1"><span class="secno"></span> <span class="content">Example 1: Table and Glyph Keyed Patches</span></a>
+      <li><a href="#appendix-b-example-2"><span class="secno"></span> <span class="content">Example 2: Glyph Keyed Patches with Child Entries</span></a>
+     </ol>
     <li>
      <a href="#w3c-conformance"><span class="secno"></span> <span class="content">Conformance</span></a>
      <ol class="toc">
@@ -3012,8 +3017,7 @@ when loading the patches for two or more segments.  There are five main strategi
  modifier code point which triggers a glyph substitution when paired with many other code points. Given the large number of alternate
  glyphs it’s desirable to keep them in their own patches which are only loaded when both the modifier code point and appropriate base
  code point(s) are present. This can be achieved by using a <a href="#patch-map-format-2">Format 2 Patch Map</a> and multiple entry matching
- via <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices③">childEntryIndices</a>. For the entry one subset definition should contain the modifier code point and a
- second one has the base code point(s).</p>
+ via <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices③">childEntryIndices</a>. See <a href="#appendix-b-example-2">Example 2: Glyph Keyed Patches with Child Entries</a> for an example of how this can be set up.</p>
     <li data-md>
      <p>Alternatively, the glyph can be included in more than one of the patches that correspond to those segments at the cost of duplicating
  the glyph’s data into multiple patches.</p>
@@ -3332,8 +3336,9 @@ to be used by default in most shaper implementations. This list was assembled fr
       <td>Vertical Alternates for Rotation
    </table>
    <h2 class="heading settled" id="extension-example"><span class="content"> Appendix B: Extension Algorithm Example Execution</span><a class="self-link" href="#extension-example"></a></h2>
-   <p>This appendix provides an example of how a typical IFT font would be processed by the <a href="#extend-font-subset">§ 4.3 Incremental Font Extension Algorithm</a> algorithm. In this example the IFT font
-contains a mix of both <a href="#table-keyed">§ 6.2 Table Keyed</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches.</p>
+   <p>This appendix provides examples of how a typical IFT font would be processed by the <a href="#extend-font-subset">§ 4.3 Incremental Font Extension Algorithm</a> algorithm.</p>
+   <h3 class="heading settled" id="appendix-b-example-1"><span class="content">Example 1: Table and Glyph Keyed Patches</span><a class="self-link" href="#appendix-b-example-1"></a></h3>
+   <p>In this example the IFT font contains a mix of both <a href="#table-keyed">§ 6.2 Table Keyed</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches.</p>
    <p><b>Initial font</b>: contains the following IFT and IFTX patch mappings. Note: when features and design space sets are unspecified in a subset definition
 they are defaulted to an empty set.</p>
    <table>
@@ -3342,7 +3347,7 @@ they are defaulted to an empty set.</p>
       <th>Table = "IFT "
       <th colspan="2">Compatibility ID = 0x0000_0000_0000_0001
      <tr>
-      <th>Subset Definition(s)
+      <th>Subset Definition
       <th>URI
       <th>Format Number
      <tr>
@@ -3386,7 +3391,7 @@ they are defaulted to an empty set.</p>
       <th>Table = "IFTX"
       <th colspan="2">Compatibility ID = 0x0000_0000_0000_0002
      <tr>
-      <th>Subset Definition(s)
+      <th>Subset Definition
       <th>URI
       <th>Format Number
      <tr>
@@ -3479,7 +3484,7 @@ to add support for code points 'a' through 'Z'. Additionally the mapping in the 
         <th>Table = "IFT "
         <th colspan="2">Compatibility ID = 0x0000_0000_0000_0006
        <tr>
-        <th>Subset Definition(s)
+        <th>Subset Definition
         <th>URI
         <th>Format Number
        <tr>
@@ -3538,6 +3543,135 @@ to the glyf and loca tables. Additionally the mapping in the "IFTX" table is upd
 and URIs for other entries are unchanged.</p>
    </ul>
    <p>Iteration 4:</p>
+   <ul>
+    <li data-md>
+     <p>Steps 2 through 6 - there are no remaining intersecting entries so the algorithm terminates. The font subset is returned and now ready to render any
+content covered by the target subset definition.</p>
+   </ul>
+   <h3 class="heading settled" id="appendix-b-example-2"><span class="content">Example 2: Glyph Keyed Patches with Child Entries</span><a class="self-link" href="#appendix-b-example-2"></a></h3>
+   <p>In this example the IFT font contains a set of <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches which utilize child entries to correctly handle the inclusion of patches
+for <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences">UVS</a> substitutions. For each set of base glyphs there are a set of alternate glyphs
+which are substituted in via a variation selector. These are kept in a separate patch. The alternate glyph patches are configured (via child entries)
+to load only when the base glyphs and the variation selector are present simultaneously.</p>
+   <p><b>Initial font</b>: contains the following IFT  patch mapping. Note: when codepoint, features, design space, or child entry sets are unspecified in
+a subset definition they are defaulted to an empty set.</p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Table = "IFT "
+      <th colspan="2">Compatibility ID = 0x0000_0000_0000_0001
+     <tr>
+      <th>Subset Definition
+      <th>URI
+      <th>Format Number
+      <th>Ignored?
+      <th>Notes
+     <tr>
+      <td>
+<pre>code points:
+  { 'a', 'b', ..., 'm' }
+</pre>
+      <td>//foo.bar/01.gk
+      <td> 3, Glyph Keyed 
+      <td>No
+      <td>
+     <tr>
+      <td>
+<pre>code points:
+  { 'n', 'o', ..., 'z' }
+</pre>
+      <td>//foo.bar/02.gk
+      <td> 3, Glyph Keyed 
+      <td>No
+      <td>
+     <tr>
+      <td>
+<pre>code points: { VS1 }
+</pre>
+      <td>N/A
+      <td> 3, Glyph Keyed 
+      <td>Yes
+     <tr>
+      <td>
+<pre>child entries: [0, 2],
+match mode: conjunctive
+</pre>
+      <td>//foo.bar/03.gk
+      <td> 3, Glyph Keyed 
+      <td>No
+      <td>Has alternate glyphs for {'a', ..., 'm'} that are activated by VS1
+     <tr>
+      <td>
+<pre>child entries: [1, 2],
+match mode: conjunctive
+</pre>
+      <td>//foo.bar/04.gk
+      <td> 3, Glyph Keyed 
+      <td>No
+      <td>Has alternate glyphs for {'n', ..., 'z'} that are activated by VS1
+   </table>
+   <p><b>Extension Example 1</b></p>
+   <p>Inputs:</p>
+   <ul>
+    <li data-md>
+     <p>Initial font with an IFT table as defined above.</p>
+    <li data-md>
+     <p>Target subset definition: code points = {'f'}</p>
+   </ul>
+   <p>Iteration 1:</p>
+   <ul>
+    <li data-md>
+     <p>Steps 1 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection⑥">Check entry intersection</a> check to all entries in the initial font, the following patch entries intersect:</p>
+     <ul>
+      <li data-md>
+       <p>//foo.bar/01.gk</p>
+     </ul>
+    <li data-md>
+     <p>Step 8 through 10 - there is only one patch, //foo.bar/01.gk, is is selected, loaded, and applied.</p>
+   </ul>
+   <p>Iteration 2:</p>
+   <ul>
+    <li data-md>
+     <p>Steps 2 through 6 - there are no remaining intersecting entries so the algorithm terminates. The font subset is returned and now ready to render any
+content covered by the target subset definition.</p>
+   </ul>
+   <p><b>Extension Example 2</b></p>
+   <p>Inputs:</p>
+   <ul>
+    <li data-md>
+     <p>Initial font with an IFT table as defined above.</p>
+    <li data-md>
+     <p>Target subset definition: code points = {'f', VS1}</p>
+   </ul>
+   <p>Iteration 1:</p>
+   <ul>
+    <li data-md>
+     <p>Steps 1 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection⑦">Check entry intersection</a> check to all entries in the initial font, the following patch entries intersect:</p>
+     <ul>
+      <li data-md>
+       <p>//foo.bar/01.gk</p>
+      <li data-md>
+       <p>//foo.bar/03.gk</p>
+     </ul>
+    <li data-md>
+     <p>Step 8 - one entry must be selected, in this case the client implementation is free to pick either. //foo.bar/01.gk is selected.</p>
+    <li data-md>
+     <p>Step 9 - since both intersecting entries are no invalidation both can be simultaneously loaded.</p>
+    <li data-md>
+     <p>Step 10 - //foo.bar/01.gk is applied to the font. The mapping table is updated to mark the entry for //foo.bar/01.gk as ignored.</p>
+   </ul>
+   <p>Iteration 2:</p>
+   <ul>
+    <li data-md>
+     <p>Steps 1 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection⑧">Check entry intersection</a> check to all entries in the current font, the following patch entries intersect:</p>
+     <ul>
+      <li data-md>
+       <p>//foo.bar/03.gk</p>
+     </ul>
+    <li data-md>
+     <p>Step 8 through 10 - there is only one patch, //foo.bar/03.gk, is is selected, and applied (it was loaded during the previous iteration).</p>
+   </ul>
+   <p>Iteration 3:</p>
    <ul>
     <li data-md>
      <p>Steps 2 through 6 - there are no remaining intersecting entries so the algorithm terminates. The font subset is returned and now ready to render any
@@ -3975,7 +4109,7 @@ function parseHTML(markup) {
 let dfnPanelData = {
 "abstract-opdef-apply-glyph-keyed-patch": {"dfnID":"abstract-opdef-apply-glyph-keyed-patch","dfnText":"Apply glyph keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-glyph-keyed-patch"},
 "abstract-opdef-apply-table-keyed-patch": {"dfnID":"abstract-opdef-apply-table-keyed-patch","dfnText":"Apply table keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-table-keyed-patch"},
-"abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2461"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2462"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2463"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2464"}],"title":"\nAppendix B: Extension Algorithm Example Execution"}],"url":"#abstract-opdef-check-entry-intersection"},
+"abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2461"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2462"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2463"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2464"}],"title":"Example 1: Table and Glyph Keyed Patches"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2465"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2466"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2467"}],"title":"Example 2: Glyph Keyed Patches with Child Entries"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
 "abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"}],"title":"4.5. Target Subset Definition"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2464"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2465"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2466"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2467"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2468"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u24ea"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "abstract-opdef-fully-expand-a-font-subset": {"dfnID":"abstract-opdef-fully-expand-a-font-subset","dfnText":"Fully Expand a Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset"}],"title":"2.1. Offline Usage"},{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2460"},{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2461"}],"title":"7. Encoding"}],"url":"#abstract-opdef-fully-expand-a-font-subset"},

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="5b111dab0eb14bfd8b46e59e317ac2a6002d8b42" name="revision">
+  <meta content="f4577995ae19c1b0c727efad814e0507f4331dd9" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -2066,10 +2066,12 @@ being requested.</p>
      <p>If the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a> offset is 0 then initialize <var>last entry id</var> to 0. Otherwise initialize
  it to an empty byte string. Set <var>current byte</var> to 0, and <var>current id string byte</var> to 0.</p>
     <li data-md>
+     <p>Initialize <var>entry list</var> and <var>prior entry list</var> to empty lists.</p>
+    <li data-md>
      <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry①">Interpret Format 2 Patch Map Entry</a>, <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount①">entryCount</a> times. For each invocation:</p>
      <ul>
       <li data-md>
-       <p>pass in <var>entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
+       <p>pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
  the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a>[<var>current id string byte</var>]
  to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑤">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
@@ -2079,6 +2081,8 @@ being requested.</p>
        <p>Add the returned consumed byte count to <var>current byte</var>.</p>
       <li data-md>
        <p>Add the returned consumed id string byte count to <var>current id string byte</var>.</p>
+      <li data-md>
+       <p>Add the returned entry to <var>prior entry list</var>.</p>
       <li data-md>
        <p>If the returned value of ignored is false, then set the compatibility ID of the returned entry to <a data-link-type="dfn" href="#format-2-patch-map-compatibilityid" id="ref-for-format-2-patch-map-compatibilityid">compatibilityId</a> and add the  entry to <var>entry list</var>.</p>
      </ul>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="c4cc866818188c7bf910b5571522409433e28b8b" name="revision">
+  <meta content="e2dca1dc0f12b17aeee7efd12dc8e3008016b195" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -728,7 +728,7 @@ var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBC
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2025-02-06">6 February 2025</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2025-02-07">7 February 2025</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1413,7 +1413,7 @@ of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-f
      <p>For each candidate entry: compute a total subset definition by unioning that entry’s subset definition and the subset definition of all child entries
  reachable via the graph of referenced child entries.</p>
     <li data-md>
-     <p>For each candidate entry compute the set intersection between the total subset definition and the target subset definition.</p>
+     <p>For each candidate entry: compute the set intersection between the total subset definition and the target subset definition.</p>
     <li data-md>
      <p>Find an entry whose intersection from step 2 is not a strict subset of any other intersection.</p>
     <li data-md>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="69094a202d6402b4968a6d667b25e3fad4dcd3af" name="revision">
+  <meta content="b592442b9ca3a8ad89aab33afd05638da23ac9b9" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -728,7 +728,7 @@ var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBC
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2025-01-31">31 January 2025</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2025-02-05">5 February 2025</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1071,9 +1071,8 @@ an existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset�
 changes encoded according to the format is a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Each <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
    <h3 class="heading settled" data-level="3.3" id="patch-map-dfn"><span class="secno">3.3. </span><span class="content">Patch Map</span><a class="self-link" href="#patch-map-dfn"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map">patch map</dfn> is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">open type table</a> which encodes a collection of mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which host <a href="#font-patch-formats">patches</a> that extend the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental font</a>. A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map">patch map</a> table encodes a list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map-entries">patch map entries</dfn>, where each entry has a key and value.
-The key is one or more <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a> and the value is a URI, the <a href="#font-patch-formats">§ 6 Font Patch Formats</a> used by the data at the URI, and
-the <a href="#font-patch-invalidations">compatibility ID</a> of the patch map table. More details of the format of patch maps can be found
-in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a>.</p>
+The key is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a>, zero or more references to other entries and the value is a URI, the <a href="#font-patch-formats">§ 6 Font Patch Formats</a> used by the data at the URI, and the <a href="#font-patch-invalidations">compatibility ID</a> of the patch map table. More details of the format
+of patch maps can be found in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a>.</p>
    <p><a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries">Patch Map Entry</a> summary:</p>
    <table>
     <tbody>
@@ -1084,7 +1083,11 @@ in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a>.</
       <td>
        <ul>
         <li data-md>
-         <p>One or more <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">font subset definition</a></p>
+         <p><a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">font subset definition</a></p>
+        <li data-md>
+         <p>Reference to zero or more other Patch Map Entries.</p>
+        <li data-md>
+         <p>Prior entry match mode, which can be either conjunctive or disjunctive.</p>
        </ul>
       <td>
        <ul>
@@ -1187,7 +1190,7 @@ any entries in <var>entry list</var> which have a patch URI which was loaded and
      <p>Pick one <var>entry</var> with the following procedure:</p>
      <ul>
       <li data-md>
-       <p>If <var>full invalidation entry list</var> is not empty then, select exactly one of the contained entries. Follow the criteria in <a href="#invalidating-patch-selection">§ 4.4 Selecting Invalidating Patches</a> to select the single entry.</p>
+       <p>If <var>full invalidation entry list</var> is not empty, then select exactly one of the contained entries. Follow the criteria in <a href="#invalidating-patch-selection">§ 4.4 Selecting Invalidating Patches</a> to select the single entry.</p>
       <li data-md>
        <p>Otherwise if <var>partial invalidation entry list</var> is not empty then, select exactly one of the contained entries.
 Follow the criteria in <a href="#invalidating-patch-selection">§ 4.4 Selecting Invalidating Patches</a> to select the single entry.</p>
@@ -1233,8 +1236,8 @@ iteration since no invalidation patches won’t change the list of available pat
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>For each subset definition in <var>mapping entry</var> and each set in <var>subset definition</var> (code points, feature tags,
- design space) check if the set intersects the corresponding set from the <var>mapping entry</var> subset definition. A set
+     <p>For each set in <var>subset definition</var> (code points, feature tags,
+ design space) check if the set intersects the corresponding set from <var>mapping entry</var>’s subset definition. A set
  intersects when:</p>
      <table>
       <tbody>
@@ -1254,10 +1257,16 @@ iteration since no invalidation patches won’t change the list of available pat
      <p>When checking design space sets for intersection, they intersect if there is at least one pair of intersecting segments
  (tags are equal and the ranges intersect).</p>
     <li data-md>
-     <p>If all sets checked in step 1 intersect, then return true for <var>intersects</var> otherwise false.</p>
+     <p>If one or more sets checked in step 1 did not intersect, then return false for <var>intersects</var>.</p>
+    <li data-md>
+     <p>If there are no entry references in <var>mapping entry</var>, then return true for <var>intersects</var>.</p>
+    <li data-md>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> for each prior entry referenced in <var>mapping entry</var> with <var>subset definition</var> as an input. If prior
+entry match mode is conjunctive, then return true for <var>intersects</var> if all invocations return true. Otherwise return true if at least one
+invocation returns true.</p>
    </ol>
-   <div class="example" id="example-fc4eb029">
-    <a class="self-link" href="#example-fc4eb029"></a> 
+   <div class="example" id="example-90618f86">
+    <a class="self-link" href="#example-90618f86"></a> 
     <table>
      <tbody>
       <tr>
@@ -1266,13 +1275,13 @@ iteration since no invalidation patches won’t change the list of available pat
        <th>intersects?
       <tr>
        <td>
-<pre>subset definitions: [
-  {
-    code points: {1, 2, 3},
-    feature tags: {},
-    design space: {}
-  },
-],
+<pre>subset definition {
+  code points: {1, 2, 3},
+  feature tags: {},
+  design space: {}
+},
+prior entries: {},
+match mode: disjunctive,
 </pre>
        <td>
 <pre>code points: {2},
@@ -1282,13 +1291,13 @@ design space: {},
        <td>true
       <tr>
        <td>
-<pre>subset definitions: [
-  {
-    code points: {1, 2, 3},
-    feature tags: {},
-    design space: {}
-  },
-],
+<pre>subset definition {
+  code points: {1, 2, 3},
+  feature tags: {},
+  design space: {}
+},
+prior entries: {},
+match mode: disjunctive,
 </pre>
        <td>
 <pre>code points: {5},
@@ -1298,13 +1307,13 @@ design space: {},
        <td>false
       <tr>
        <td>
-<pre>subset definitions: [
-  {
-    code points: {1, 2, 3},
-    feature tags: {},
-    design space: {}
-  },
-],
+<pre>subset definition {
+  code points: {1, 2, 3},
+  feature tags: {},
+  design space: {}
+},
+prior entries: {},
+match mode: disjunctive,
 </pre>
        <td>
 <pre>code points: {2},
@@ -1314,13 +1323,13 @@ design space: {},
        <td>true
       <tr>
        <td>
-<pre>subset definitions: [
-  {
-    code points: {1, 2, 3},
-    feature tags: {},
-    design space: {}
-  },
-],
+<pre>subset definition: {
+  code points: {1, 2, 3},
+  feature tags: {},
+  design space: {}
+},
+prior entries: {},
+match mode: disjunctive,
 </pre>
        <td>
 <pre>code points: {},
@@ -1330,18 +1339,32 @@ design space: {},
        <td>false
       <tr>
        <td>
-<pre>subset definitions: [
+<pre>subset definition: {
+  code points: {},
+  feature tags: {},
+  design space: {}
+},
+prior entries: [
   {
-    code points: {1, 2, 3},
-    feature tags: {},
-    design space: {}
+    subset definition {
+      code points: {1, 2, 3},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: {},
+    match mode: disjunctive,
   },
   {
-    code points: {4, 5, 6},
-    feature tags: {},
-    design space: {}
+    subset definition {
+      code points: {4, 5, 6},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: {},
+    match mode: disjunctive,
   },
 ],
+match mode: conjunctive,
 </pre>
        <td>
 <pre>code points: {2},
@@ -1351,18 +1374,32 @@ design space: {},
        <td>false
       <tr>
        <td>
-<pre>subset definitions: [
+<pre>subset definition: {
+  code points: {},
+  feature tags: {},
+  design space: {}
+},
+prior entries: [
   {
-    code points: {1, 2, 3},
-    feature tags: {},
-    design space: {}
+    subset definition {
+      code points: {1, 2, 3},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: {},
+    match mode: disjunctive,
   },
   {
-    code points: {4, 5, 6},
-    feature tags: {},
-    design space: {}
+    subset definition {
+      code points: {4, 5, 6},
+      feature tags: {},
+      design space: {}
+    },
+    prior entries: {},
+    match mode: disjunctive,
   },
 ],
+match mode: conjunctive,
 </pre>
        <td>
 <pre>code points: {2, 6},
@@ -1414,16 +1451,18 @@ round trips.</p>
 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①">Extend an Incremental Font Subset</a>:</p>
    <ol>
     <li data-md>
-     <p>For each candidate entry compute the set intersection between each subset definition in the entry and the target subset definition. Union
- the resulting intersections together into a single subset definition.</p>
+     <p>For each candidate entry compute a total subset definition by unioning that entry’s subset definition and the subset definition of any other entries
+ reachable via the graph of referenced prior entries.</p>
     <li data-md>
-     <p>Find an entry whose intersection subset definition from step 1 is not a strict subset of any other intersection subset definition.</p>
+     <p>For each candidate entry compute the set intersection between the total subset definition and the target subset definition.</p>
     <li data-md>
-     <p>Locate any additional entries that are in the same <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①">patch map</a> and have the same intersection as the entry found in step 2. From the this set of
- entries (including the step 2 pick) the final selection is the entry which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map②">patch map</a>. For <a href="#patch-map-format-1">§ 5.2.1 Patch Map Table: Format 1</a> this is the
+     <p>Find an entry whose intersection from step 2 is not a strict subset of any other intersection.</p>
+    <li data-md>
+     <p>Locate any additional entries that are in the same <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①">patch map</a> and have the same intersection as the entry found in step 3. From the this set of
+ entries (including the step 3 pick) the final selection is the entry which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map②">patch map</a>. For <a href="#patch-map-format-1">§ 5.2.1 Patch Map Table: Format 1</a> this is the
  entry with the lowest entry index. For <a href="#patch-map-format-2">§ 5.2.2 Patch Map Table: Format 2</a> this is the entry that appears first in the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array.</p>
    </ol>
-   <p class="note" role="note"><span class="marker">Note:</span> a fast and efficient way to find an entry which satisfies the criteria for step 2 is to sort the entries (descending) by the size of the code point
+   <p class="note" role="note"><span class="marker">Note:</span> a fast and efficient way to find an entry which satisfies the criteria for step 3 is to sort the entries (descending) by the size of the code point
 set intersection, then the size of feature tag set intersection, and finally the size of the design space intersection. The first entry in this sorting is
 guaranteed to not be a strict subset of any other entries, since any strict super sets would have to be at least one item larger. This approach also has
 the added benefit that it selects the patch which will add the most data which the client is currently requesting.</p>
@@ -1538,7 +1577,7 @@ patches to be applied.</p>
    <ol>
     <li data-md>
      <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑥">Extend an Incremental Font Subset</a> with <var>font subset</var>. The input target subset definition is a special one which
-is considered to intersect all entries in the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> step. Return the resulting font subset as
+is considered to intersect all entries in the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection②">Check entry intersection</a> step. Return the resulting font subset as
 the <var>expanded font</var>.</p>
    </ol>
    <h3 class="heading settled" data-level="4.8" id="caching-incremental-fonts"><span class="secno">4.8. </span><span class="content">Caching Extended Incremental Fonts</span><a class="self-link" href="#caching-incremental-fonts"></a></h3>
@@ -1781,7 +1820,7 @@ the template expansion results in an error (see: <a href="https://www.rfc-editor
       <li data-md>
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
       <li data-md>
-       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">entry</a> to <var>entry list</var> with one subset definition which contains only the Unicode code point
+       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">entry</a> to <var>entry list</var> with a subset definition which contains only the Unicode code point
 set and maps to the generated URI, the patch format specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
      </ul>
     <li data-md>
@@ -1817,7 +1856,7 @@ associated code points as if it wasn’t skipped.</p>
        <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">entry</a> to <var>entry list</var> which  maps to the generated URI, the patch format
 specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat①">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> in <var>entry list</var> which has the same patch URI as the generated URI then
 instead modify the existing entry. Add the constructed set of Unicode code points and <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag③">featureTag</a> to the new or
-existing entry’s single subset definition.</p>
+existing entry’s subset definition.</p>
      </ul>
     <li data-md>
      <p>Return <var>entry list</var>.</p>
@@ -1943,15 +1982,16 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
       <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copymodeandcount">copyModeAndCount</dfn>
-      <td> The most significant bit is used to indicate the copy mode, if the bit is set copy mode is "append" otherwise it is "union".
-      The remaining 7 bits are interpreted as a unsigned integer and represent the number of entries in the copyIndices list. This
-      field is only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags④">formatFlags</a> bit 1 is set. 
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-priorentrymatchmodeandcount">priorEntryMatchModeAndCount</dfn>
+      <td> This and the following field are used to add conditions to the intersection check for this entry that depend on whether prior entries intersect.
+      The most significant bit is used to indicate the matching mode. If the bit is set the condition is conjunctive otherwise it is disjunctive. The
+      remaining 7 bits are interpreted as a unsigned integer and represent the number of entry indices in the priorEntryIndices list. This field is only
+      present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags④">formatFlags</a> bit 1 is set. 
      <tr>
       <td>uint24
-      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-copyindices">copyIndices</dfn>[copyModeAndCount]
-      <td> List of indices from the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a> array whose <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a> should be copied into this entry. May
-      only reference entries that occurred prior to this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries②">entries</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-priorentryindices">priorEntryIndices</dfn>[0b01111111 &amp; priorEntryMatchModeAndCount]
+      <td> Each value is the index of an entry in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a> array whose intersection will be checked to determine this entries intersection.
+      Only references entries that occurred prior to this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries②">entries</a> and only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
      <tr>
       <td>int24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>
@@ -2030,7 +2070,7 @@ being requested.</p>
      <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry①">Interpret Format 2 Patch Map Entry</a>, <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount①">entryCount</a> times. For each invocation:</p>
      <ul>
       <li data-md>
-       <p>pass in the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
+       <p>pass in <var>entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
  the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a>[<var>current id string byte</var>]
  to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑤">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
@@ -2049,6 +2089,8 @@ being requested.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
+    <li data-md>
+     <p><var>prior entry list</var>: a list of entries prior to this one.</p>
     <li data-md>
      <p><var>entry bytes</var>: a byte array that contains an encoded <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry③">Mapping Entry</a>.</p>
     <li data-md>
@@ -2083,16 +2125,16 @@ being requested.</p>
     <li data-md>
      <p>Set the patch format of <var>entry</var> to <var>default patch format</var>.</p>
     <li data-md>
-     <p>Add a single <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> to <var>entry</var> with all sets initialized to be empty.</p>
+     <p>Add a single <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a> to <var>entry</var> with all sets initialized to be empty.</p>
     <li data-md>
      <p>Read <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⓪">formatFlags</a> from <var>entry bytes</var>.</p>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①①">formatFlags</a> bit 0 is set, then the feature tag and design space lists are present:</p>
      <ul>
       <li data-md>
-       <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①②">font subset definition</a> in <var>entry</var>.</p>
+       <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> in <var>entry</var>.</p>
       <li data-md>
-       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> in <var>entry</var>. Each
+       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①②">font subset definition</a> in <var>entry</var>. Each
 segment defines an interval from <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start">start</a> to <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end">end</a> inclusive for the axis identified
 by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-space-segment-tag">tag</a>. If any segment has a <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start①">start</a> which is greater than <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end①">end</a> then, this encoding is invalid return an error.</p>
      </ul>
@@ -2100,13 +2142,15 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①②">formatFlags</a> bit 1 is set, then the copy indices list is present:</p>
      <ul>
       <li data-md>
-       <p>Read the copy indices list specified by <a data-link-type="dfn" href="#mapping-entry-copymodeandcount" id="ref-for-mapping-entry-copymodeandcount">copyModeAndCount</a> and <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices">copyIndices</a> from <var>entry bytes</var>.</p>
+       <p>If the most significant bit of <a data-link-type="dfn" href="#mapping-entry-priorentrymatchmodeandcount" id="ref-for-mapping-entry-priorentrymatchmodeandcount">priorEntryMatchModeAndCount</a> is set then set <var>entry</var>’s match mode to conjunctive,
+ otherwise to disjunctive.</p>
       <li data-md>
-       <p>The copy indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry④">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries③">entries</a>, 1 the second
- and so on. For each index in <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices①">copyIndices</a> locate the previously loaded entry with a matching index.
- If the most significant bit of <a data-link-type="dfn" href="#mapping-entry-copymodeandcount" id="ref-for-mapping-entry-copymodeandcount①">copyModeAndCount</a> is set then append all <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①④">font subset definition</a>s from
- the previous entry to <var>entry</var>. Otherwise union all code points, feature tags, and design space segments from
- all <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑤">font subset definition</a>s in the previous entry into the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a> in <var>entry</var>. If a <a data-link-type="dfn" href="#mapping-entry-copyindices" id="ref-for-mapping-entry-copyindices②">copyIndices</a> is greater than or equal to the index of this entry then, this encoding is invalid return an error.</p>
+       <p>Read the prior entry indices list specified by <a data-link-type="dfn" href="#mapping-entry-priorentrymatchmodeandcount" id="ref-for-mapping-entry-priorentrymatchmodeandcount①">priorEntryMatchModeAndCount</a> and <a data-link-type="dfn" href="#mapping-entry-priorentryindices" id="ref-for-mapping-entry-priorentryindices">priorEntryIndices</a> from <var>entry bytes</var>.</p>
+      <li data-md>
+       <p>The prior entry indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry④">Mapping Entry</a> in <var>prior entry list</var>, 1 the second
+ and so on. For each value in <a data-link-type="dfn" href="#mapping-entry-priorentryindices" id="ref-for-mapping-entry-priorentryindices①">priorEntryIndices</a> locate the entry in <var>prior entry list</var> with a matching index.
+ Add a reference to that entry into entry. If a <a data-link-type="dfn" href="#mapping-entry-priorentryindices" id="ref-for-mapping-entry-priorentryindices②">priorEntryIndices</a> is greater than or equal to the length
+ of <var>prior entry list</var> then, this encoding is invalid return an error.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①③">formatFlags</a> bit 2 is set, then an id delta or id string length is present:</p>
@@ -2133,7 +2177,7 @@ from <var>entry bytes</var>.</p>
        <p>Otherwise the bias is 0.</p>
       <li data-md>
        <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codePoints</a> from <var>entry bytes</var> with bias following <a href="#sparse-bit-set-decoding">§ 5.2.2.3 Sparse Bit Set</a>.
-Add the resulting code point set to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑦">font subset definition</a> in <var>entry</var>. If the sparse bit set decoding
+Add the resulting code point set to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> in <var>entry</var>. If the sparse bit set decoding
 failed then, this encoding is invalid return an error.</p>
      </ul>
     <li data-md>
@@ -2736,7 +2780,7 @@ The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-fon
     <li data-md>
      <p>Must meet all of the requirements in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 6 Font Patch Formats</a>.</p>
     <li data-md>
-     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑧">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑧">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
+     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①④">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑧">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
 of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a>.</p>
     <li data-md>
      <p>Must respect patch invalidation criteria. Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑦">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
@@ -2878,7 +2922,7 @@ The next two subsections discuss maintaining functional equivalent using the dif
    <p>When preparing <a href="#table-keyed">§ 6.2 Table Keyed</a> patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.</p>
-   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑨">font subset definition</a>. The practice of reliably
+   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑤">font subset definition</a>. The practice of reliably
 subsetting a font is well understood and has multiple open-source implementations (a full formal description is
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
@@ -2923,17 +2967,17 @@ sections.</p>
    <p><b><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches</b></p>
    <p>Specifically because they are parameterized by code points and feature tags but can be applied independently of one another, <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches have additional requirements and cannot be directly derived by using a subsetter implementation.  However,
 such an implementation can help clarify what an encoder needs to do to maintain functional equivalence when producing this type
-of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②⓪">font subset definition</a>. We can define
-the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②①">font subset definition</a> as the full set of glyphs included in the subset, which the
+of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a>. We can define
+the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑦">font subset definition</a> as the full set of glyphs included in the subset, which the
 subsetter has determined is needed to render any combination of the described code points and layout features.</p>
    <p>Using that definition, the <b>glyph closure requirement</b> on the full set <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches is:</p>
    <ul>
     <li data-md>
-     <p>The set of glyphs contained in the patches loaded for a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②②">font subset definition</a> through the patch map tables must be a superset
-of those in the <a data-link-type="dfn" href="#glyph-closure" id="ref-for-glyph-closure">glyph closure</a> of the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②③">font subset definition</a>.</p>
+     <p>The set of glyphs contained in the patches loaded for a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑧">font subset definition</a> through the patch map tables must be a superset
+of those in the <a data-link-type="dfn" href="#glyph-closure" id="ref-for-glyph-closure">glyph closure</a> of the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑨">font subset definition</a>.</p>
    </ul>
    <p>Assuming the subsetter does its job accurately, the glyph closure requirement is a consequence of the requirement for equivalent
-behavior: Suppose there is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②④">font subset definition</a> such that the subsetter includes glyph *i* in its subset, but an encoder that
+behavior: Suppose there is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②⓪">font subset definition</a> such that the subsetter includes glyph *i* in its subset, but an encoder that
 produces <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches omits glyph *i* from the set of patches that correspond to that definition. If the subsetter is
 right, that glyph must be present to retain equivalent behavior when rendering some combination of the code points and features in 
 the definition, which means that the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑨">incremental font</a> will not behave equivalently when rendering that combination.</p>
@@ -2964,8 +3008,8 @@ when loading the patches for two or more segments.  There are five main strategi
      <p>In some cases, such as with <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences">Unicode variation selectors</a>, there will be a
  modifier code point which triggers a glyph substitution when paired with many other code points. Given the large number of alternate
  glyphs it’s desirable to keep them in their own patches which are only loaded when both the modifier code point and appropriate base
- code point(s) are present. This can be achieved by using a <a href="#patch-map-format-2">Format 2 Patch Map</a> and multiple subset definitions
- per entry via <a data-link-type="dfn" href="#mapping-entry-copymodeandcount" id="ref-for-mapping-entry-copymodeandcount②">copyModeAndCount</a>. For the entry one subset definition should contain the modifier code point and a
+ code point(s) are present. This can be achieved by using a <a href="#patch-map-format-2">Format 2 Patch Map</a> and multiple entry matching
+ via <a data-link-type="dfn" href="#mapping-entry-priorentryindices" id="ref-for-mapping-entry-priorentryindices③">priorEntryIndices</a>. For the entry one subset definition should contain the modifier code point and a
  second one has the base code point(s).</p>
     <li data-md>
      <p>Alternatively, the glyph can be included in more than one of the patches that correspond to those segments at the cost of duplicating
@@ -3388,7 +3432,7 @@ they are defaulted to an empty set.</p>
    <p>Iteration 1:</p>
    <ul>
     <li data-md>
-     <p>Steps 1 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection②">Check entry intersection</a> check to all entries in the initial font, the following patch entries intersect:</p>
+     <p>Steps 1 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection③">Check entry intersection</a> check to all entries in the initial font, the following patch entries intersect:</p>
      <ul>
       <li data-md>
        <p>//foo.bar/01.tk</p>
@@ -3454,7 +3498,7 @@ the URI for the remaining '0', ..., '9' entry has changed. The patch at the new 
    <p>Iteration 2:</p>
    <ul>
     <li data-md>
-     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection③">Check entry intersection</a> check to all entries in the updated font from the previous iteration, the following patch
+     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection④">Check entry intersection</a> check to all entries in the updated font from the previous iteration, the following patch
 entries intersect:</p>
      <ul>
       <li data-md>
@@ -3475,7 +3519,7 @@ and URIs for other entries are unchanged.</p>
    <p>Iteration 3:</p>
    <ul>
     <li data-md>
-     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection④">Check entry intersection</a> check to all entries in the updated font from the previous iteration, the following patch
+     <p>Steps 2 through 6 - applying the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection⑤">Check entry intersection</a> check to all entries in the updated font from the previous iteration, the following patch
 entries intersect:</p>
      <ul>
       <li data-md>
@@ -3565,8 +3609,6 @@ content covered by the target subset definition.</p>
      <li><a href="#glyph-keyed-patch-compatibilityid">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
      <li><a href="#table-keyed-patch-compatibilityid">dfn for Table keyed patch</a><span>, in § 6.2</span>
     </ul>
-   <li><a href="#mapping-entry-copyindices">copyIndices</a><span>, in § 5.2.2</span>
-   <li><a href="#mapping-entry-copymodeandcount">copyModeAndCount</a><span>, in § 5.2.2</span>
    <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 5.2.2.3</span>
    <li><a href="#format-2-patch-map-defaultpatchformat">defaultPatchFormat</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 5.2.2</span>
@@ -3661,6 +3703,8 @@ content covered by the target subset definition.</p>
     </ul>
    <li><a href="#patch-map">patch map</a><span>, in § 3.3</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
+   <li><a href="#mapping-entry-priorentryindices">priorEntryIndices</a><span>, in § 5.2.2</span>
+   <li><a href="#mapping-entry-priorentrymatchmodeandcount">priorEntryMatchModeAndCount</a><span>, in § 5.2.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.2.1.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 5.2.2.2</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.2.2.3</span>
@@ -3928,7 +3972,7 @@ function parseHTML(markup) {
 let dfnPanelData = {
 "abstract-opdef-apply-glyph-keyed-patch": {"dfnID":"abstract-opdef-apply-glyph-keyed-patch","dfnText":"Apply glyph keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-glyph-keyed-patch"},
 "abstract-opdef-apply-table-keyed-patch": {"dfnID":"abstract-opdef-apply-table-keyed-patch","dfnText":"Apply table keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-table-keyed-patch"},
-"abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2461"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2462"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2463"}],"title":"\nAppendix B: Extension Algorithm Example Execution"}],"url":"#abstract-opdef-check-entry-intersection"},
+"abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2461"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2462"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2463"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2464"}],"title":"\nAppendix B: Extension Algorithm Example Execution"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
 "abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"}],"title":"4.5. Target Subset Definition"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2464"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2465"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2466"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2467"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2468"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u24ea"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "abstract-opdef-fully-expand-a-font-subset": {"dfnID":"abstract-opdef-fully-expand-a-font-subset","dfnText":"Fully Expand a Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset"}],"title":"2.1. Offline Usage"},{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2460"},{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2461"}],"title":"7. Encoding"}],"url":"#abstract-opdef-fully-expand-a-font-subset"},
@@ -3956,7 +4000,7 @@ let dfnPanelData = {
 "featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"},{"id":"ref-for-featurerecord-firstnewentryindex\u2460"},{"id":"ref-for-featurerecord-firstnewentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
 "font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2464"},{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2467"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2468"},{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2461"},{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
-"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2463"},{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2467"},{"id":"ref-for-font-subset-definition\u2468"},{"id":"ref-for-font-subset-definition\u2460\u24ea"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"},{"id":"ref-for-font-subset-definition\u2460\u2462"},{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"},{"id":"ref-for-font-subset-definition\u2460\u2466"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2467"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2468"},{"id":"ref-for-font-subset-definition\u2461\u24ea"},{"id":"ref-for-font-subset-definition\u2461\u2460"},{"id":"ref-for-font-subset-definition\u2461\u2461"},{"id":"ref-for-font-subset-definition\u2461\u2462"},{"id":"ref-for-font-subset-definition\u2461\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
+"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2463"},{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2467"},{"id":"ref-for-font-subset-definition\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u24ea"},{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"},{"id":"ref-for-font-subset-definition\u2460\u2462"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2463"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"},{"id":"ref-for-font-subset-definition\u2460\u2466"},{"id":"ref-for-font-subset-definition\u2460\u2467"},{"id":"ref-for-font-subset-definition\u2460\u2468"},{"id":"ref-for-font-subset-definition\u2461\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
 "format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
@@ -3993,12 +4037,10 @@ let dfnPanelData = {
 "glyphpatches-tables": {"dfnID":"glyphpatches-tables","dfnText":"tables","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-tables"},{"id":"ref-for-glyphpatches-tables\u2460"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-tables\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-tables"},
 "incremental-font": {"dfnID":"incremental-font","dfnText":"incremental font","external":false,"refSections":[{"refs":[{"id":"ref-for-incremental-font"}],"title":"1.2. Overview"},{"refs":[{"id":"ref-for-incremental-font\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-incremental-font\u2461"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-incremental-font\u2462"},{"id":"ref-for-incremental-font\u2463"},{"id":"ref-for-incremental-font\u2464"},{"id":"ref-for-incremental-font\u2465"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-incremental-font\u2466"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-incremental-font\u2467"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-incremental-font\u2468"},{"id":"ref-for-incremental-font\u2460\u24ea"},{"id":"ref-for-incremental-font\u2460\u2460"},{"id":"ref-for-incremental-font\u2460\u2461"},{"id":"ref-for-incremental-font\u2460\u2462"},{"id":"ref-for-incremental-font\u2460\u2463"},{"id":"ref-for-incremental-font\u2460\u2464"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-incremental-font\u2460\u2465"},{"id":"ref-for-incremental-font\u2460\u2466"},{"id":"ref-for-incremental-font\u2460\u2467"},{"id":"ref-for-incremental-font\u2460\u2468"},{"id":"ref-for-incremental-font\u2461\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#incremental-font"},
 "mapping-entries": {"dfnID":"mapping-entries","dfnText":"Mapping Entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#mapping-entries"},
-"mapping-entries-entries": {"dfnID":"mapping-entries-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries-entries"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2460"},{"id":"ref-for-mapping-entries-entries\u2461"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2462"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entries-entries"},
+"mapping-entries-entries": {"dfnID":"mapping-entries-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries-entries"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2460"},{"id":"ref-for-mapping-entries-entries\u2461"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#mapping-entries-entries"},
 "mapping-entry": {"dfnID":"mapping-entry","dfnText":"Mapping Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry"},{"id":"ref-for-mapping-entry\u2460"},{"id":"ref-for-mapping-entry\u2461"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry\u2462"},{"id":"ref-for-mapping-entry\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry"},
 "mapping-entry-bias": {"dfnID":"mapping-entry-bias","dfnText":"bias","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-bias"},{"id":"ref-for-mapping-entry-bias\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-bias"},
 "mapping-entry-codepoints": {"dfnID":"mapping-entry-codepoints","dfnText":"codePoints","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-codepoints"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-codepoints"},
-"mapping-entry-copyindices": {"dfnID":"mapping-entry-copyindices","dfnText":"copyIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-copyindices"},{"id":"ref-for-mapping-entry-copyindices\u2460"},{"id":"ref-for-mapping-entry-copyindices\u2461"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-copyindices"},
-"mapping-entry-copymodeandcount": {"dfnID":"mapping-entry-copymodeandcount","dfnText":"copyModeAndCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-copymodeandcount"},{"id":"ref-for-mapping-entry-copymodeandcount\u2460"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-copymodeandcount\u2461"}],"title":"7.1. Encoding Considerations"}],"url":"#mapping-entry-copymodeandcount"},
 "mapping-entry-designspacecount": {"dfnID":"mapping-entry-designspacecount","dfnText":"designSpaceCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacecount"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacecount"},
 "mapping-entry-designspacesegments": {"dfnID":"mapping-entry-designspacesegments","dfnText":"designSpaceSegments","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacesegments"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacesegments"},
 "mapping-entry-entryiddelta": {"dfnID":"mapping-entry-entryiddelta","dfnText":"entryIdDelta","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryiddelta"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-entryiddelta\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-entryiddelta"},
@@ -4007,6 +4049,8 @@ let dfnPanelData = {
 "mapping-entry-featuretags": {"dfnID":"mapping-entry-featuretags","dfnText":"featureTags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featuretags"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featuretags"},
 "mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#mapping-entry-formatflags"},
 "mapping-entry-patchformat": {"dfnID":"mapping-entry-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchformat"},{"id":"ref-for-mapping-entry-patchformat\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchformat"},
+"mapping-entry-priorentryindices": {"dfnID":"mapping-entry-priorentryindices","dfnText":"priorEntryIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-priorentryindices"},{"id":"ref-for-mapping-entry-priorentryindices\u2460"},{"id":"ref-for-mapping-entry-priorentryindices\u2461"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-priorentryindices\u2462"}],"title":"7.1. Encoding Considerations"}],"url":"#mapping-entry-priorentryindices"},
+"mapping-entry-priorentrymatchmodeandcount": {"dfnID":"mapping-entry-priorentrymatchmodeandcount","dfnText":"priorEntryMatchModeAndCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-priorentrymatchmodeandcount"},{"id":"ref-for-mapping-entry-priorentrymatchmodeandcount\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-priorentrymatchmodeandcount"},
 "no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"7.1. Encoding Considerations"}],"url":"#no-invalidation"},
 "partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2461"},{"id":"ref-for-partial-invalidation\u2462"},{"id":"ref-for-partial-invalidation\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
 "patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
@@ -4478,8 +4522,6 @@ let refsData = {
 "#mapping-entry": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"mapping entry","type":"dfn","url":"#mapping-entry"},
 "#mapping-entry-bias": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"bias","type":"dfn","url":"#mapping-entry-bias"},
 "#mapping-entry-codepoints": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"codepoints","type":"dfn","url":"#mapping-entry-codepoints"},
-"#mapping-entry-copyindices": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"copyindices","type":"dfn","url":"#mapping-entry-copyindices"},
-"#mapping-entry-copymodeandcount": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"copymodeandcount","type":"dfn","url":"#mapping-entry-copymodeandcount"},
 "#mapping-entry-designspacecount": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"designspacecount","type":"dfn","url":"#mapping-entry-designspacecount"},
 "#mapping-entry-designspacesegments": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"designspacesegments","type":"dfn","url":"#mapping-entry-designspacesegments"},
 "#mapping-entry-entryiddelta": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entryiddelta","type":"dfn","url":"#mapping-entry-entryiddelta"},
@@ -4488,6 +4530,8 @@ let refsData = {
 "#mapping-entry-featuretags": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featuretags","type":"dfn","url":"#mapping-entry-featuretags"},
 "#mapping-entry-formatflags": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"formatflags","type":"dfn","url":"#mapping-entry-formatflags"},
 "#mapping-entry-patchformat": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchformat","type":"dfn","url":"#mapping-entry-patchformat"},
+"#mapping-entry-priorentryindices": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"priorentryindices","type":"dfn","url":"#mapping-entry-priorentryindices"},
+"#mapping-entry-priorentrymatchmodeandcount": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"priorentrymatchmodeandcount","type":"dfn","url":"#mapping-entry-priorentrymatchmodeandcount"},
 "#no-invalidation": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"no invalidation","type":"dfn","url":"#no-invalidation"},
 "#partial-invalidation": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"partial invalidation","type":"dfn","url":"#partial-invalidation"},
 "#patch-application-algorithm": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch application algorithm","type":"dfn","url":"#patch-application-algorithm"},

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="26c10f7ce2788870cc3aba7252cef5acc8efb222" name="revision">
+  <meta content="c4cc866818188c7bf910b5571522409433e28b8b" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -728,7 +728,7 @@ var[data-var-color="6"] { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBC
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2025-02-05">5 February 2025</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">Editor’s Draft</a>, <time class="dt-updated" datetime="2025-02-06">6 February 2025</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1087,7 +1087,7 @@ information about the patch which should be applied when the entry is matched. <
       <td>
        <ul>
         <li data-md>
-         <p><a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a>: defines the basic coverage.</p>
+         <p><a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a>: defines the base coverage.</p>
         <li data-md>
          <p>References to zero or more child <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①">Patch Map Entry</a>'s:<br> these child entries are used to extend the coverage.</p>
         <li data-md>
@@ -1269,146 +1269,101 @@ iteration since no invalidation patches won’t change the list of available pat
      <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> for each child entry referenced in <var>mapping entry</var> with <var>subset definition</var> as an input. If child entry match mode is conjunctive, then return true for <var>intersects</var> only if all invocations return true.
 Otherwise return true only if at least one invocation returns true.</p>
    </ol>
-   <div class="example" id="example-74f82fb7">
-    <a class="self-link" href="#example-74f82fb7"></a> 
+   <div class="example" id="example-8269bfc5">
+    <a class="self-link" href="#example-8269bfc5"></a> 
+    <p>The table below represents a patch mapping and shows the expected result of an intersection check against various entries. In these examples
+when a set (ie. code points, feature tags, design space, child entries) is not specified it is assumed to be the empty set.</p>
     <table>
      <tbody>
       <tr>
+       <th>index
        <th>mapping entry
        <th>subset definition
        <th>intersects?
       <tr>
+       <td>0
        <td>
 <pre>subset definition {
   code points: {1, 2, 3},
-  feature tags: {},
-  design space: {}
 },
-child entries: {},
 match mode: disjunctive,
 </pre>
        <td>
 <pre>code points: {2},
-feature tags: {},
-design space: {},
 </pre>
        <td>true
       <tr>
+       <td>1
+       <td>
+<pre>subset definition {
+  code points: {4, 5, 6},
+},
+match mode: disjunctive,
+</pre>
+       <td>
+<pre>code points: {2},
+</pre>
+       <td>false
+      <tr>
+       <td>2
        <td>
 <pre>subset definition {
   code points: {1, 2, 3},
-  feature tags: {},
-  design space: {}
 },
-child entries: {},
+match mode: disjunctive,
+</pre>
+       <td>
+<pre>code points: {2},
+feature tags: {smcp},
+</pre>
+       <td>true
+      <tr>
+       <td>3
+       <td>
+<pre>subset definition: {
+  code points: {1, 2, 3},
+},
+match mode: disjunctive,
+</pre>
+       <td>
+<pre>feature tags: {smcp},
+</pre>
+       <td>false
+      <tr>
+       <td>4
+       <td>
+<pre>subset definition: {
+  code points: {1, 2, 3},
+},
+child entry indices: {1},
 match mode: disjunctive,
 </pre>
        <td>
 <pre>code points: {5},
-feature tags: {},
-design space: {},
 </pre>
        <td>false
       <tr>
-       <td>
-<pre>subset definition {
-  code points: {1, 2, 3},
-  feature tags: {},
-  design space: {}
-},
-child entries: {},
-match mode: disjunctive,
-</pre>
-       <td>
-<pre>code points: {2},
-feature tags: {smcp},
-design space: {},
-</pre>
-       <td>true
-      <tr>
+       <td>5
        <td>
 <pre>subset definition: {
-  code points: {1, 2, 3},
-  feature tags: {},
-  design space: {}
 },
-child entries: {},
-match mode: disjunctive,
-</pre>
-       <td>
-<pre>code points: {},
-feature tags: {smcp},
-design space: {},
-</pre>
-       <td>false
-      <tr>
-       <td>
-<pre>subset definition: {
-  code points: {},
-  feature tags: {},
-  design space: {}
-},
-child entries: [
-  {
-    subset definition {
-      code points: {1, 2, 3},
-      feature tags: {},
-      design space: {}
-    },
-    child entries: {},
-    match mode: disjunctive,
-  },
-  {
-    subset definition {
-      code points: {4, 5, 6},
-      feature tags: {},
-      design space: {}
-    },
-    child entries: {},
-    match mode: disjunctive,
-  },
-],
+child entry indices: {0, 1},
 match mode: conjunctive,
 </pre>
        <td>
 <pre>code points: {2},
-feature tags: {},
-design space: {},
 </pre>
        <td>false
       <tr>
+       <td>6
        <td>
 <pre>subset definition: {
-  code points: {},
-  feature tags: {},
-  design space: {}
 },
-child entries: [
-  {
-    subset definition {
-      code points: {1, 2, 3},
-      feature tags: {},
-      design space: {}
-    },
-    child entries: {},
-    match mode: disjunctive,
-  },
-  {
-    subset definition {
-      code points: {4, 5, 6},
-      feature tags: {},
-      design space: {}
-    },
-    child entries: {},
-    match mode: disjunctive,
-  },
-],
+child entry indices: {0, 1},
 match mode: conjunctive,
 </pre>
        <td>
 <pre>code points: {2, 6},
-feature tags: {},
-design space: {},
 </pre>
        <td>true
     </table>
@@ -1455,7 +1410,7 @@ round trips.</p>
 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①">Extend an Incremental Font Subset</a>:</p>
    <ol>
     <li data-md>
-     <p>For each candidate entry compute a total subset definition by unioning that entry’s subset definition and the subset definition of all child entries
+     <p>For each candidate entry: compute a total subset definition by unioning that entry’s subset definition and the subset definition of all child entries
  reachable via the graph of referenced child entries.</p>
     <li data-md>
      <p>For each candidate entry compute the set intersection between the total subset definition and the target subset definition.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d765c696b, updated Fri Mar 8 15:58:52 2024 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="b592442b9ca3a8ad89aab33afd05638da23ac9b9" name="revision">
+  <meta content="5b111dab0eb14bfd8b46e59e317ac2a6002d8b42" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -1071,9 +1071,8 @@ an existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset�
 changes encoded according to the format is a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Each <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
    <h3 class="heading settled" data-level="3.3" id="patch-map-dfn"><span class="secno">3.3. </span><span class="content">Patch Map</span><a class="self-link" href="#patch-map-dfn"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map">patch map</dfn> is an <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">open type table</a> which encodes a collection of mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which host <a href="#font-patch-formats">patches</a> that extend the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental font</a>. A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map">patch map</a> table encodes a list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map-entries">patch map entries</dfn>, where each entry has a key and value.
-The key is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a>, zero or more references to other entries and the value is a URI, the <a href="#font-patch-formats">§ 6 Font Patch Formats</a> used by the data at the URI, and the <a href="#font-patch-invalidations">compatibility ID</a> of the patch map table. More details of the format
-of patch maps can be found in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a>.</p>
-   <p><a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries">Patch Map Entry</a> summary:</p>
+The key of an entry defines the coverage of the entry, which is information on what subset definitions will match it. The value specifies
+information about the patch which should be applied when the entry is matched. <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries">Patch Map Entry</a> summary:</p>
    <table>
     <tbody>
      <tr>
@@ -1083,11 +1082,11 @@ of patch maps can be found in <a href="#font-format-extensions">§ 5 Extension
       <td>
        <ul>
         <li data-md>
-         <p><a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">font subset definition</a></p>
+         <p><a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a>: defines the basic coverage.</p>
         <li data-md>
-         <p>Reference to zero or more other Patch Map Entries.</p>
+         <p>References to zero or more child <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①">Patch Map Entry</a>'s:<br> these child entries are used to extend the coverage.</p>
         <li data-md>
-         <p>Prior entry match mode, which can be either conjunctive or disjunctive.</p>
+         <p>Child entry match mode, which can be either conjunctive or disjunctive.</p>
        </ul>
       <td>
        <ul>
@@ -1099,6 +1098,7 @@ of patch maps can be found in <a href="#font-format-extensions">§ 5 Extension
          <p><a href="#font-patch-invalidations">compatibility ID</a></p>
        </ul>
    </table>
+   <p>More details of the format of patch maps can be found in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a>.</p>
    <h3 class="heading settled" data-level="3.4" id="data-types"><span class="secno">3.4. </span><span class="content">Explanation of Data Types</span><a class="self-link" href="#data-types"></a></h3>
    <p>Encoded data structures in the remainder of this specification are described in terms of the data types defined
 in <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#data-types">OpenType Specification § otff#data-types</a>. As with the rest of OpenType, all fields use "big-endian" byte ordering.</p>
@@ -1139,7 +1139,7 @@ The compatibility ID of only the <a href="#patch-map-table">§ 5.2 Patch Map T
    <h3 class="heading settled" data-level="4.2" id="default-layout-features"><span class="secno">4.2. </span><span class="content">Default Layout Features</span><a class="self-link" href="#default-layout-features"></a></h3>
    <p>Most text shapers have a set of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout features</a> which are always enabled and thus always required in an
 incrementally loaded font. <a href="#feature-tag-list">Appendix A: Default Feature Tags</a> collects a list of features that at the time of writing are known to be required
-by default in common shaper implementations. When forming a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a> as input to the extension algorithm the client
+by default in common shaper implementations. When forming a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②">font subset definition</a> as input to the extension algorithm the client
 should typically include all features found in <a href="#feature-tag-list">Appendix A: Default Feature Tags</a> in the subset definition. However, in some cases the client might
 know that the specific shaper which will be used may not make use of some features in <a href="#feature-tag-list">Appendix A: Default Feature Tags</a> and may
 opt to exclude those unused features from the subset definition.</p>
@@ -1158,7 +1158,7 @@ and will not be invalidated by the next patch to be applied according to <a href
      <p><var>initial font subset URI</var>: an <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">absolute URI</a> which identifies the location of the initial incremental
 font that <var>font subset</var> was derived from.</p>
     <li data-md>
-     <p><var>target subset definition</var>: the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition④">font subset definition</a> that the client wants to extend <var>font subset</var> to cover.</p>
+     <p><var>target subset definition</var>: the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a> that the client wants to extend <var>font subset</var> to cover.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1224,9 +1224,9 @@ iteration since no invalidation patches won’t change the list of available pat
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>mapping entry</var>: a <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①">patch map entry</a>.</p>
+     <p><var>mapping entry</var>: a <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries②">patch map entry</a>.</p>
     <li data-md>
-     <p><var>subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definition</a>.</p>
+     <p><var>subset definition</var>: a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition④">font subset definition</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -1259,14 +1259,13 @@ iteration since no invalidation patches won’t change the list of available pat
     <li data-md>
      <p>If one or more sets checked in step 1 did not intersect, then return false for <var>intersects</var>.</p>
     <li data-md>
-     <p>If there are no entry references in <var>mapping entry</var>, then return true for <var>intersects</var>.</p>
+     <p>If there are no child entries in <var>mapping entry</var>, then return true for <var>intersects</var>.</p>
     <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> for each prior entry referenced in <var>mapping entry</var> with <var>subset definition</var> as an input. If prior
-entry match mode is conjunctive, then return true for <var>intersects</var> if all invocations return true. Otherwise return true if at least one
-invocation returns true.</p>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> for each child entry referenced in <var>mapping entry</var> with <var>subset definition</var> as an input. If child entry match mode is conjunctive, then return true for <var>intersects</var> only if all invocations return true.
+Otherwise return true only if at least one invocation returns true.</p>
    </ol>
-   <div class="example" id="example-90618f86">
-    <a class="self-link" href="#example-90618f86"></a> 
+   <div class="example" id="example-74f82fb7">
+    <a class="self-link" href="#example-74f82fb7"></a> 
     <table>
      <tbody>
       <tr>
@@ -1280,7 +1279,7 @@ invocation returns true.</p>
   feature tags: {},
   design space: {}
 },
-prior entries: {},
+child entries: {},
 match mode: disjunctive,
 </pre>
        <td>
@@ -1296,7 +1295,7 @@ design space: {},
   feature tags: {},
   design space: {}
 },
-prior entries: {},
+child entries: {},
 match mode: disjunctive,
 </pre>
        <td>
@@ -1312,7 +1311,7 @@ design space: {},
   feature tags: {},
   design space: {}
 },
-prior entries: {},
+child entries: {},
 match mode: disjunctive,
 </pre>
        <td>
@@ -1328,7 +1327,7 @@ design space: {},
   feature tags: {},
   design space: {}
 },
-prior entries: {},
+child entries: {},
 match mode: disjunctive,
 </pre>
        <td>
@@ -1344,14 +1343,14 @@ design space: {},
   feature tags: {},
   design space: {}
 },
-prior entries: [
+child entries: [
   {
     subset definition {
       code points: {1, 2, 3},
       feature tags: {},
       design space: {}
     },
-    prior entries: {},
+    child entries: {},
     match mode: disjunctive,
   },
   {
@@ -1360,7 +1359,7 @@ prior entries: [
       feature tags: {},
       design space: {}
     },
-    prior entries: {},
+    child entries: {},
     match mode: disjunctive,
   },
 ],
@@ -1379,14 +1378,14 @@ design space: {},
   feature tags: {},
   design space: {}
 },
-prior entries: [
+child entries: [
   {
     subset definition {
       code points: {1, 2, 3},
       feature tags: {},
       design space: {}
     },
-    prior entries: {},
+    child entries: {},
     match mode: disjunctive,
   },
   {
@@ -1395,7 +1394,7 @@ prior entries: [
       feature tags: {},
       design space: {}
     },
-    prior entries: {},
+    child entries: {},
     match mode: disjunctive,
   },
 ],
@@ -1451,8 +1450,8 @@ round trips.</p>
 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①">Extend an Incremental Font Subset</a>:</p>
    <ol>
     <li data-md>
-     <p>For each candidate entry compute a total subset definition by unioning that entry’s subset definition and the subset definition of any other entries
- reachable via the graph of referenced prior entries.</p>
+     <p>For each candidate entry compute a total subset definition by unioning that entry’s subset definition and the subset definition of all child entries
+ reachable via the graph of referenced child entries.</p>
     <li data-md>
      <p>For each candidate entry compute the set intersection between the total subset definition and the target subset definition.</p>
     <li data-md>
@@ -1497,7 +1496,7 @@ shaping.</p>
        <p>First, if for any code point in the shaping unit there is not a <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> entry for it, or the entry maps to glyph
 0 then the incremental font does not fully support rendering the shaping unit.</p>
       <li data-md>
-       <p>Second, compute the corresponding <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑥">font subset definition</a> and execute the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset③">Extend an Incremental Font Subset</a> algorithm,
+       <p>Second, compute the corresponding <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definition</a> and execute the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset③">Extend an Incremental Font Subset</a> algorithm,
 stopping at step 6. If the entry list is not empty then the incremental font does not fully support rendering the shaping unit.</p>
      </ul>
     <li data-md>
@@ -1618,7 +1617,7 @@ file, the compressed font needs to be decoded before attempting to extend it.</p
    <ul>
     <li data-md>
      <p>Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URIs. It does
-not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
+not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑥">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
     <li data-md>
      <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
 is typically less compact than format 1.</p>
@@ -1780,7 +1779,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
    </table>
    <p>An entry map record matches any entry indices that are greater than or equal to firstEntryIndex and less than or equal to  lastEntryIndex.</p>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 1" data-level="5.2.1.1" id="interpreting-patch-map-format-1"><span class="secno">5.2.1.1. </span><span class="content">Interpreting Format 1</span><a class="self-link" href="#interpreting-patch-map-format-1"></a></h5>
-   <p>This algorithm is used to convert a format 1 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries②">patch map entries</a>.</p>
+   <p>This algorithm is used to convert a format 1 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries③">patch map entries</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
@@ -1792,7 +1791,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries③">patch map entries</a>.</p>
+     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1820,7 +1819,7 @@ the template expansion results in an error (see: <a href="https://www.rfc-editor
       <li data-md>
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
       <li data-md>
-       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">entry</a> to <var>entry list</var> with a subset definition which contains only the Unicode code point
+       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">entry</a> to <var>entry list</var> with a subset definition which contains only the Unicode code point
 set and maps to the generated URI, the patch format specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
      </ul>
     <li data-md>
@@ -1853,8 +1852,8 @@ associated code points as if it wasn’t skipped.</p>
       <li data-md>
        <p>If the constructed set of Unicode code points is empty then, this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑧">EntryMapRecord</a> is invalid skip it.</p>
       <li data-md>
-       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">entry</a> to <var>entry list</var> which  maps to the generated URI, the patch format
-specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat①">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> in <var>entry list</var> which has the same patch URI as the generated URI then
+       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> to <var>entry list</var> which  maps to the generated URI, the patch format
+specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat①">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> in <var>entry list</var> which has the same patch URI as the generated URI then
 instead modify the existing entry. Add the constructed set of Unicode code points and <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag③">featureTag</a> to the new or
 existing entry’s subset definition.</p>
      </ul>
@@ -1971,7 +1970,7 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
      <tr>
       <td>Tag
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags</dfn>[featureCount]
-      <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set. 
+      <td> List of <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set. 
      <tr>
       <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount</dfn>
@@ -1979,19 +1978,19 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
      <tr>
       <td><a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment">Design Space Segment</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments</dfn>[designSpaceCount]
-      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set. 
+      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-priorentrymatchmodeandcount">priorEntryMatchModeAndCount</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-childentrymatchmodeandcount">childEntryMatchModeAndCount</dfn>
       <td> This and the following field are used to add conditions to the intersection check for this entry that depend on whether prior entries intersect.
       The most significant bit is used to indicate the matching mode. If the bit is set the condition is conjunctive otherwise it is disjunctive. The
-      remaining 7 bits are interpreted as a unsigned integer and represent the number of entry indices in the priorEntryIndices list. This field is only
+      remaining 7 bits are interpreted as a unsigned integer and represent the number of entry indices in the childEntryIndices list. This field is only
       present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags④">formatFlags</a> bit 1 is set. 
      <tr>
       <td>uint24
-      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-priorentryindices">priorEntryIndices</dfn>[0b01111111 &amp; priorEntryMatchModeAndCount]
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-childentryindices">childEntryIndices</dfn>[0b01111111 &amp; childEntryMatchModeAndCount]
       <td> Each value is the index of an entry in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a> array whose intersection will be checked to determine this entries intersection.
-      Only references entries that occurred prior to this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries②">entries</a> and only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
+      Only entries that occurred prior to this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries②">entries</a> can be referenced. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
      <tr>
       <td>int24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>
@@ -2047,7 +2046,7 @@ being requested.</p>
       <td> End (inclusive) of the segment. Must be greater than or equal to start. This value uses the user axis scale: <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
    </table>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="5.2.2.1" id="interpreting-patch-map-format-2"><span class="secno">5.2.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
-   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑤">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">patch map entries</a>.</p>
+   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑤">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
@@ -2057,7 +2056,7 @@ being requested.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
+     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑨">patch map entries</a>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -2107,7 +2106,7 @@ being requested.</p>
     <li data-md>
      <p><var>entry id</var>: the numeric or string id of this entry.</p>
     <li data-md>
-     <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑨">entry</a>.</p>
+     <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①⓪">entry</a>.</p>
     <li data-md>
      <p><var>consumed bytes</var>: the number of bytes used to encode the entry.</p>
     <li data-md>
@@ -2125,16 +2124,16 @@ being requested.</p>
     <li data-md>
      <p>Set the patch format of <var>entry</var> to <var>default patch format</var>.</p>
     <li data-md>
-     <p>Add a single <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a> to <var>entry</var> with all sets initialized to be empty.</p>
+     <p>Add a single <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a> to <var>entry</var> with all sets initialized to be empty.</p>
     <li data-md>
      <p>Read <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⓪">formatFlags</a> from <var>entry bytes</var>.</p>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①①">formatFlags</a> bit 0 is set, then the feature tag and design space lists are present:</p>
      <ul>
       <li data-md>
-       <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> in <var>entry</var>.</p>
+       <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a> in <var>entry</var>.</p>
       <li data-md>
-       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①②">font subset definition</a> in <var>entry</var>. Each
+       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> in <var>entry</var>. Each
 segment defines an interval from <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start">start</a> to <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end">end</a> inclusive for the axis identified
 by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-space-segment-tag">tag</a>. If any segment has a <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start①">start</a> which is greater than <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end①">end</a> then, this encoding is invalid return an error.</p>
      </ul>
@@ -2142,14 +2141,14 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①②">formatFlags</a> bit 1 is set, then the copy indices list is present:</p>
      <ul>
       <li data-md>
-       <p>If the most significant bit of <a data-link-type="dfn" href="#mapping-entry-priorentrymatchmodeandcount" id="ref-for-mapping-entry-priorentrymatchmodeandcount">priorEntryMatchModeAndCount</a> is set then set <var>entry</var>’s match mode to conjunctive,
+       <p>If the most significant bit of <a data-link-type="dfn" href="#mapping-entry-childentrymatchmodeandcount" id="ref-for-mapping-entry-childentrymatchmodeandcount">childEntryMatchModeAndCount</a> is set then set <var>entry</var>’s match mode to conjunctive,
  otherwise to disjunctive.</p>
       <li data-md>
-       <p>Read the prior entry indices list specified by <a data-link-type="dfn" href="#mapping-entry-priorentrymatchmodeandcount" id="ref-for-mapping-entry-priorentrymatchmodeandcount①">priorEntryMatchModeAndCount</a> and <a data-link-type="dfn" href="#mapping-entry-priorentryindices" id="ref-for-mapping-entry-priorentryindices">priorEntryIndices</a> from <var>entry bytes</var>.</p>
+       <p>Read the child entry indices list specified by <a data-link-type="dfn" href="#mapping-entry-childentrymatchmodeandcount" id="ref-for-mapping-entry-childentrymatchmodeandcount①">childEntryMatchModeAndCount</a> and <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices">childEntryIndices</a> from <var>entry bytes</var>.</p>
       <li data-md>
-       <p>The prior entry indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry④">Mapping Entry</a> in <var>prior entry list</var>, 1 the second
- and so on. For each value in <a data-link-type="dfn" href="#mapping-entry-priorentryindices" id="ref-for-mapping-entry-priorentryindices①">priorEntryIndices</a> locate the entry in <var>prior entry list</var> with a matching index.
- Add a reference to that entry into entry. If a <a data-link-type="dfn" href="#mapping-entry-priorentryindices" id="ref-for-mapping-entry-priorentryindices②">priorEntryIndices</a> is greater than or equal to the length
+       <p>The child entry indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry④">Mapping Entry</a> in <var>prior entry list</var>, 1 the second
+ and so on. For each value in <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices①">childEntryIndices</a> locate the entry in <var>prior entry list</var> with a matching index.
+ Add a reference to that entry into entry. If a <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices②">childEntryIndices</a> is greater than or equal to the length
  of <var>prior entry list</var> then, this encoding is invalid return an error.</p>
      </ul>
     <li data-md>
@@ -2177,7 +2176,7 @@ from <var>entry bytes</var>.</p>
        <p>Otherwise the bias is 0.</p>
       <li data-md>
        <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codePoints</a> from <var>entry bytes</var> with bias following <a href="#sparse-bit-set-decoding">§ 5.2.2.3 Sparse Bit Set</a>.
-Add the resulting code point set to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> in <var>entry</var>. If the sparse bit set decoding
+Add the resulting code point set to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①②">font subset definition</a> in <var>entry</var>. If the sparse bit set decoding
 failed then, this encoding is invalid return an error.</p>
      </ul>
     <li data-md>
@@ -2780,11 +2779,11 @@ The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-fon
     <li data-md>
      <p>Must meet all of the requirements in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 6 Font Patch Formats</a>.</p>
     <li data-md>
-     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①④">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑧">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
+     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑧">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
 of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a>.</p>
     <li data-md>
      <p>Must respect patch invalidation criteria. Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑦">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
- for the invalidation mode declared by the associated <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①⓪">patch map entries</a>.</p>
+ for the invalidation mode declared by the associated <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①①">patch map entries</a>.</p>
     <li data-md>
      <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
  should have all of the same <a href="https://docs.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> as the existing font (excluding the incremental IFT/IFTX
@@ -2922,7 +2921,7 @@ The next two subsections discuss maintaining functional equivalent using the dif
    <p>When preparing <a href="#table-keyed">§ 6.2 Table Keyed</a> patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.</p>
-   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑤">font subset definition</a>. The practice of reliably
+   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①④">font subset definition</a>. The practice of reliably
 subsetting a font is well understood and has multiple open-source implementations (a full formal description is
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
@@ -2967,17 +2966,17 @@ sections.</p>
    <p><b><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches</b></p>
    <p>Specifically because they are parameterized by code points and feature tags but can be applied independently of one another, <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches have additional requirements and cannot be directly derived by using a subsetter implementation.  However,
 such an implementation can help clarify what an encoder needs to do to maintain functional equivalence when producing this type
-of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a>. We can define
-the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑦">font subset definition</a> as the full set of glyphs included in the subset, which the
+of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑤">font subset definition</a>. We can define
+the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a> as the full set of glyphs included in the subset, which the
 subsetter has determined is needed to render any combination of the described code points and layout features.</p>
    <p>Using that definition, the <b>glyph closure requirement</b> on the full set <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches is:</p>
    <ul>
     <li data-md>
-     <p>The set of glyphs contained in the patches loaded for a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑧">font subset definition</a> through the patch map tables must be a superset
-of those in the <a data-link-type="dfn" href="#glyph-closure" id="ref-for-glyph-closure">glyph closure</a> of the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑨">font subset definition</a>.</p>
+     <p>The set of glyphs contained in the patches loaded for a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑦">font subset definition</a> through the patch map tables must be a superset
+of those in the <a data-link-type="dfn" href="#glyph-closure" id="ref-for-glyph-closure">glyph closure</a> of the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑧">font subset definition</a>.</p>
    </ul>
    <p>Assuming the subsetter does its job accurately, the glyph closure requirement is a consequence of the requirement for equivalent
-behavior: Suppose there is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition②⓪">font subset definition</a> such that the subsetter includes glyph *i* in its subset, but an encoder that
+behavior: Suppose there is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑨">font subset definition</a> such that the subsetter includes glyph *i* in its subset, but an encoder that
 produces <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches omits glyph *i* from the set of patches that correspond to that definition. If the subsetter is
 right, that glyph must be present to retain equivalent behavior when rendering some combination of the code points and features in 
 the definition, which means that the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑨">incremental font</a> will not behave equivalently when rendering that combination.</p>
@@ -3009,7 +3008,7 @@ when loading the patches for two or more segments.  There are five main strategi
  modifier code point which triggers a glyph substitution when paired with many other code points. Given the large number of alternate
  glyphs it’s desirable to keep them in their own patches which are only loaded when both the modifier code point and appropriate base
  code point(s) are present. This can be achieved by using a <a href="#patch-map-format-2">Format 2 Patch Map</a> and multiple entry matching
- via <a data-link-type="dfn" href="#mapping-entry-priorentryindices" id="ref-for-mapping-entry-priorentryindices③">priorEntryIndices</a>. For the entry one subset definition should contain the modifier code point and a
+ via <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices③">childEntryIndices</a>. For the entry one subset definition should contain the modifier code point and a
  second one has the base code point(s).</p>
     <li data-md>
      <p>Alternatively, the glyph can be included in more than one of the patches that correspond to those segments at the cost of duplicating
@@ -3600,6 +3599,8 @@ content covered by the target subset definition.</p>
      <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 4.3</span>
+   <li><a href="#mapping-entry-childentryindices">childEntryIndices</a><span>, in § 5.2.2</span>
+   <li><a href="#mapping-entry-childentrymatchmodeandcount">childEntryMatchModeAndCount</a><span>, in § 5.2.2</span>
    <li><a href="#mapping-entry-codepoints">codePoints</a><span>, in § 5.2.2</span>
    <li>
     compatibilityId
@@ -3703,8 +3704,6 @@ content covered by the target subset definition.</p>
     </ul>
    <li><a href="#patch-map">patch map</a><span>, in § 3.3</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
-   <li><a href="#mapping-entry-priorentryindices">priorEntryIndices</a><span>, in § 5.2.2</span>
-   <li><a href="#mapping-entry-priorentrymatchmodeandcount">priorEntryMatchModeAndCount</a><span>, in § 5.2.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.2.1.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 5.2.2.2</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.2.2.3</span>
@@ -4000,7 +3999,7 @@ let dfnPanelData = {
 "featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"},{"id":"ref-for-featurerecord-firstnewentryindex\u2460"},{"id":"ref-for-featurerecord-firstnewentryindex\u2461"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
 "font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2464"},{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2467"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2468"},{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2461"},{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
-"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"},{"id":"ref-for-font-subset-definition\u2461"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2463"},{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2467"},{"id":"ref-for-font-subset-definition\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u24ea"},{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"},{"id":"ref-for-font-subset-definition\u2460\u2462"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2463"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"},{"id":"ref-for-font-subset-definition\u2460\u2466"},{"id":"ref-for-font-subset-definition\u2460\u2467"},{"id":"ref-for-font-subset-definition\u2460\u2468"},{"id":"ref-for-font-subset-definition\u2461\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
+"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2461"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"},{"id":"ref-for-font-subset-definition\u2463"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2468"},{"id":"ref-for-font-subset-definition\u2460\u24ea"},{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"},{"id":"ref-for-font-subset-definition\u2460\u2466"},{"id":"ref-for-font-subset-definition\u2460\u2467"},{"id":"ref-for-font-subset-definition\u2460\u2468"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"}],"title":"5.2.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
 "format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.2.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
@@ -4040,6 +4039,8 @@ let dfnPanelData = {
 "mapping-entries-entries": {"dfnID":"mapping-entries-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries-entries"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2460"},{"id":"ref-for-mapping-entries-entries\u2461"}],"title":"5.2.2. Patch Map Table: Format 2"}],"url":"#mapping-entries-entries"},
 "mapping-entry": {"dfnID":"mapping-entry","dfnText":"Mapping Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry"},{"id":"ref-for-mapping-entry\u2460"},{"id":"ref-for-mapping-entry\u2461"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry\u2462"},{"id":"ref-for-mapping-entry\u2463"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry"},
 "mapping-entry-bias": {"dfnID":"mapping-entry-bias","dfnText":"bias","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-bias"},{"id":"ref-for-mapping-entry-bias\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-bias"},
+"mapping-entry-childentryindices": {"dfnID":"mapping-entry-childentryindices","dfnText":"childEntryIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-childentryindices"},{"id":"ref-for-mapping-entry-childentryindices\u2460"},{"id":"ref-for-mapping-entry-childentryindices\u2461"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-childentryindices\u2462"}],"title":"7.1. Encoding Considerations"}],"url":"#mapping-entry-childentryindices"},
+"mapping-entry-childentrymatchmodeandcount": {"dfnID":"mapping-entry-childentrymatchmodeandcount","dfnText":"childEntryMatchModeAndCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-childentrymatchmodeandcount"},{"id":"ref-for-mapping-entry-childentrymatchmodeandcount\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-childentrymatchmodeandcount"},
 "mapping-entry-codepoints": {"dfnID":"mapping-entry-codepoints","dfnText":"codePoints","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-codepoints"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-codepoints"},
 "mapping-entry-designspacecount": {"dfnID":"mapping-entry-designspacecount","dfnText":"designSpaceCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacecount"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacecount"},
 "mapping-entry-designspacesegments": {"dfnID":"mapping-entry-designspacesegments","dfnText":"designSpaceSegments","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacesegments"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacesegments"},
@@ -4049,14 +4050,12 @@ let dfnPanelData = {
 "mapping-entry-featuretags": {"dfnID":"mapping-entry-featuretags","dfnText":"featureTags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featuretags"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featuretags"},
 "mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"5.2.2.2. Remove Entries from Format 2"}],"url":"#mapping-entry-formatflags"},
 "mapping-entry-patchformat": {"dfnID":"mapping-entry-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchformat"},{"id":"ref-for-mapping-entry-patchformat\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchformat"},
-"mapping-entry-priorentryindices": {"dfnID":"mapping-entry-priorentryindices","dfnText":"priorEntryIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-priorentryindices"},{"id":"ref-for-mapping-entry-priorentryindices\u2460"},{"id":"ref-for-mapping-entry-priorentryindices\u2461"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-priorentryindices\u2462"}],"title":"7.1. Encoding Considerations"}],"url":"#mapping-entry-priorentryindices"},
-"mapping-entry-priorentrymatchmodeandcount": {"dfnID":"mapping-entry-priorentrymatchmodeandcount","dfnText":"priorEntryMatchModeAndCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-priorentrymatchmodeandcount"},{"id":"ref-for-mapping-entry-priorentrymatchmodeandcount\u2460"}],"title":"5.2.2.1. Interpreting Format 2"}],"url":"#mapping-entry-priorentrymatchmodeandcount"},
 "no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"7.1. Encoding Considerations"}],"url":"#no-invalidation"},
 "partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2461"},{"id":"ref-for-partial-invalidation\u2462"},{"id":"ref-for-partial-invalidation\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
 "patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
 "patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"},{"id":"ref-for-patch-map\u2461"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-patch-map\u2462"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2463"}],"title":"5.2. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2464"},{"id":"ref-for-patch-map\u2465"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map\u2466"}],"title":"7. Encoding"}],"url":"#patch-map"},
-"patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2461"},{"id":"ref-for-patch-map-entries\u2462"},{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2466"},{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map-entries\u2460\u24ea"}],"title":"7. Encoding"}],"url":"#patch-map-entries"},
+"patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"},{"id":"ref-for-patch-map-entries\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2462"},{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"}],"title":"5.2.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"}],"title":"5.2.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"7. Encoding"}],"url":"#patch-map-entries"},
 "sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.2.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.2.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
 "table-keyed-patch": {"dfnID":"table-keyed-patch","dfnText":"Table keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch"},
 "table-keyed-patch-compatibilityid": {"dfnID":"table-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-compatibilityid"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-compatibilityid"},
@@ -4521,6 +4520,8 @@ let refsData = {
 "#mapping-entries-entries": {"export":true,"for_":["Mapping Entries"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entries","type":"dfn","url":"#mapping-entries-entries"},
 "#mapping-entry": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"mapping entry","type":"dfn","url":"#mapping-entry"},
 "#mapping-entry-bias": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"bias","type":"dfn","url":"#mapping-entry-bias"},
+"#mapping-entry-childentryindices": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"childentryindices","type":"dfn","url":"#mapping-entry-childentryindices"},
+"#mapping-entry-childentrymatchmodeandcount": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"childentrymatchmodeandcount","type":"dfn","url":"#mapping-entry-childentrymatchmodeandcount"},
 "#mapping-entry-codepoints": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"codepoints","type":"dfn","url":"#mapping-entry-codepoints"},
 "#mapping-entry-designspacecount": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"designspacecount","type":"dfn","url":"#mapping-entry-designspacecount"},
 "#mapping-entry-designspacesegments": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"designspacesegments","type":"dfn","url":"#mapping-entry-designspacesegments"},
@@ -4530,8 +4531,6 @@ let refsData = {
 "#mapping-entry-featuretags": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featuretags","type":"dfn","url":"#mapping-entry-featuretags"},
 "#mapping-entry-formatflags": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"formatflags","type":"dfn","url":"#mapping-entry-formatflags"},
 "#mapping-entry-patchformat": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchformat","type":"dfn","url":"#mapping-entry-patchformat"},
-"#mapping-entry-priorentryindices": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"priorentryindices","type":"dfn","url":"#mapping-entry-priorentryindices"},
-"#mapping-entry-priorentrymatchmodeandcount": {"export":true,"for_":["Mapping Entry"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"priorentrymatchmodeandcount","type":"dfn","url":"#mapping-entry-priorentrymatchmodeandcount"},
 "#no-invalidation": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"no invalidation","type":"dfn","url":"#no-invalidation"},
 "#partial-invalidation": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"partial invalidation","type":"dfn","url":"#partial-invalidation"},
 "#patch-application-algorithm": {"export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch application algorithm","type":"dfn","url":"#patch-application-algorithm"},


### PR DESCRIPTION
Instead of producing multiple subset definitions, define the intersection check in terms of whether referenced child entries would intersect. This largely provides the same functionality while overall making the mechanism simpler to reason about. Additionally it provides a path to a more efficient client side implementation, which can now cache the intersection checks on prior entries to quickly compute down stream entry intersection results. The prior approach requires in some cases fully expanding out the subset definition unions for each entry to correctly compute intersection results.

Also adds an appendix B example using child indices to demonstrate how UVS specific patches can be loaded. Fixes #245.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/252.html" title="Last updated on Feb 7, 2025, 9:55 PM UTC (4d8d534)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/252/b592442...4d8d534.html" title="Last updated on Feb 7, 2025, 9:55 PM UTC (4d8d534)">Diff</a>