### PR TITLE
Spec changes to allow entries to optionally include patch preload lists.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -431,7 +431,7 @@ code points, layout features and/or design space. This algorithm incrementally s
 them as needed. As an important optimization to minimize network round trips it permits loads to be started for all patches that will eventually
 be needed. These come in two forms:
 
-*  First, [=patch map|patch mapping entries=] may list more than one URI, where each URI after the first is to be preloaded because it
+*  First, [=patch map|patch mapping entries=] may list more than one URI, where each URI after the first should also be loaded because they
     will be needed in future iterations.
 
 *  Second, [[#font-patch-invalidations]] is used to determine which patches loads can be started for. Any patches which match the target subset
@@ -490,7 +490,7 @@ The algorithm:
 
 9.  Start a load of <var>patch file</var> (if not already previously started) by invoking [$Load patch file$] with the <var>initial font subset URI</var>
     as the initial font URI and the first patch URI in <var>entry</var> as the patch URI. If there are any other URIs in <var>entry</var>, then initiate
-    loads for those using the same procedure. These are preloads and the results may be used during future iterations of this algorithm.
+    loads for those using the same procedure. These may be used during future iterations of this algorithm.
     Additionally the client may optionally start loads using the same procedure for any entries in <var>entry list</var> which will not be
     [[#font-patch-invalidations|invalidated]] by <var>entry</var>. The total number of patches that a client can load and apply during a single execution
     of this algorithm is limited to:
@@ -743,7 +743,7 @@ round trips.
 The following selection criteria minimizes round trips and must be used by the client when selecting a single partial or full invalidation patch in step 8
 of [$Extend an Incremental Font Subset$]:
 
-1.  If one or more candidate entries have previously had their associated patch file preloaded by step 9 of [$Extend an Incremental Font Subset$],
+1.  If one or more candidate entries have previously had their associated patch file loaded by step 9 of [$Extend an Incremental Font Subset$],
     then in the following steps only consider candidate entries whose patch file is already loaded or is currently being loaded. Otherwise consider all
     candidate entries.
 
@@ -1462,9 +1462,9 @@ The algorithm:
     <td>
       List of signed deltas which calculate the IDs of the URIs for this entry. If present, has at least one delta. If the least
       significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
-      cleared is encountered. The entry id for each delta the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if
+      cleared is encountered. The entry id for each delta is the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if
       [=Mapping Entry/formatFlags=] bit 2 is set and [=Format 2 Patch Map/entryIdStringData=] is null (0).
-      If not present and [=Format 2 Patch Map/entryIdStringData=] is null (0), then there is one id for this entry and and the
+      If not present and [=Format 2 Patch Map/entryIdStringData=] is null (0), then there is one id for this entry and the
       delta is assumed to be 0.
     </td>
   </tr>

--- a/Overview.bs
+++ b/Overview.bs
@@ -429,8 +429,14 @@ opt to exclude those unused features from the subset definition.
 The following algorithm is used by a client to extend an [=incremental font|incremental=] [=font subset=] to cover additional
 code points, layout features and/or design space. This algorithm incrementally selects and applies patches to the font one at a time, loading
 them as needed. As an important optimization to minimize network round trips it permits loads to be started for all patches that will eventually
-be needed. [[#font-patch-invalidations]] is used to determine which patches loads can be started for. Any patches which match the target subset definition
-and will not be invalidated by the next patch to be applied according to [[#font-patch-invalidations]] can be expected to be needed in future iterations.
+be needed. These come in two forms:
+
+*  First, [=patch map|patch mapping entries=] may list more than one URI, where each URI after the first is to be preloaded because it
+    will be needed in future iterations.
+
+*  Second, [[#font-patch-invalidations]] is used to determine which patches loads can be started for. Any patches which match the target subset
+    definition and will not be invalidated by the next patch to be applied according to [[#font-patch-invalidations]] can be expected to be
+    needed in future iterations.
 
 <dfn abstract-op>Extend an Incremental Font Subset</dfn>
 
@@ -483,9 +489,11 @@ The algorithm:
         The criteria for selecting the single entry is left up to the implementation to decide.
 
 9.  Start a load of <var>patch file</var> (if not already previously started) by invoking [$Load patch file$] with the <var>initial font subset URI</var>
-    as the initial font URI and the <var>entry</var> patch URI as the patch URI. Additionally the client may optionally start loads using the same
-    procedure for any entries in <var>entry list</var> which will not be [[#font-patch-invalidations|invalidated]] by <var>entry</var>. The total
-    number of patches that a client can load and apply during a single execution of this algorithm is limited to:
+    as the initial font URI and the first patch URI in <var>entry</var> as the patch URI. If there are any other URIs in <var>entry</var>, then initiate
+    loads for those using the same procedure. These are preloads and the results may be used during future iterations of this algorithm.
+    Additionally the client may optionally start loads using the same procedure for any entries in <var>entry list</var> which will not be
+    [[#font-patch-invalidations|invalidated]] by <var>entry</var>. The total number of patches that a client can load and apply during a single execution
+    of this algorithm is limited to:
 
     * At most 100 patches which are [=Partial Invalidation=] or [=Full Invalidation=].
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1450,7 +1450,7 @@ The algorithm:
     <td>
       List of signed deltas which calculate the IDs of the URIs for this entry. If present, has at least one delta. If the least
       significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
-      cleared is encountered. The entry id for each delta the last calculated entry id + 1 + (entryIdDelta / 2). Only present if
+      cleared is encountered. The entry id for each delta the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if
       [=Mapping Entry/formatFlags=] bit 2 is set and [=Format 2 Patch Map/entryIdStringData=] is null (0).
       If not present and [=Format 2 Patch Map/entryIdStringData=] is null (0), then there is one id for this entry and and the
       delta is assumed to be 0.
@@ -1619,7 +1619,7 @@ The algorithm:
 1.  For the all steps whenever data is loaded from <var>entry bytes</var> increment <var>consumed bytes</var> with the
      number of bytes read.
 
-2.  If <var>id string bytes</var> is not present then, set <var>entry id</var> = <var>last entry id</var> + 1. Otherwise set
+2.  If <var>id string bytes</var> is not present then, set <var>entry id</var> = <var>last entry id</var>. Otherwise set
      <var>entry id</var> = <var>last entry id</var>.
 
 3.  Set the patch format of <var>entry</var> to <var>default patch format</var>.
@@ -1639,7 +1639,7 @@ The algorithm:
         by [=Design Space Segment/tag=]. If any segment has a [=Design Space Segment/start=] which is greater than
         [=Design Space Segment/end=] then, this encoding is invalid return an error.
 
-6.  If [=Mapping Entry/formatFlags=] bit 1 is set, then the copy indices list is present:
+7.  If [=Mapping Entry/formatFlags=] bit 1 is set, then the copy indices list is present:
 
     *  If the most significant bit of [=Mapping Entry/childEntryMatchModeAndCount=] is set then set <var>entry</var>'s match mode to conjunctive,
          otherwise to disjunctive.
@@ -1652,20 +1652,42 @@ The algorithm:
          Add a reference to that entry into <var>entry</var>. If a [=Mapping Entry/childEntryIndices=] is greater than or equal to the length
          of <var>prior entry list</var> then, this encoding is invalid return an error.
 
-7.  If [=Mapping Entry/formatFlags=] bit 2 is set, then an id delta or id string length is present:
+8.  If [=Mapping Entry/formatFlags=] bit 2 is set, then id deltas or id string lengths are present:
 
-    *  If <var>id string bytes</var> is not present then, read the id delta specified by [=Mapping Entry/entryIdDelta=]
-        from <var>entry bytes</var> and add the delta to <var>entry id</var>.
+    *  If <var>id string bytes</var> is not present, then:
 
-    *  Otherwise if <var>id string bytes</var> is present then, read [=Mapping Entry/entryIdStringLength=] bytes from
-        <var>id string bytes</var> and set <var>entry id</var> to the result.
+         *  Read the next [=Mapping Entry/entryIdDelta=] value.
 
-8.  If [=Mapping Entry/formatFlags=] bit 3 is set, then a patch format is present. Read the format specified by
+         *  Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
+             If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.
+
+         *  Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]].
+             If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
+
+         *  Add the generated patch URI to <var>entry</var>.
+
+         *  If the least significant bit of the read delta value is set, then repeat step 8.
+
+    *  Otherwise if <var>id string bytes</var> is present, then:
+
+         *  Read the next [=Mapping Entry/entryIdStringLength=] value.
+
+         *  Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
+             Set <var>entry id</var> to the result.
+
+         *  Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]].
+             If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
+
+         *  Add the generated patch URI to <var>entry</var>.
+
+         *  If the most significant bit of the read length value is set, then repeat step 8.
+
+9.  If [=Mapping Entry/formatFlags=] bit 3 is set, then a patch format is present. Read the format specified by
      [=Mapping Entry/patchFormat=] from <var>entry bytes</var> and set the patch format of <var>entry</var> to the read value.
      If [=Mapping Entry/patchFormat=] is not one of the values in [[#font-patch-formats-summary]] then, this encoding is invalid
      return an error.
 
-9.  If one or both of [=Mapping Entry/formatFlags=] bit 4 and bit 5 are set, then a code point list is present:
+10.  If one or both of [=Mapping Entry/formatFlags=] bit 4 and bit 5 are set, then a code point list is present:
 
     *  If [=Mapping Entry/formatFlags=] bit 4 is 0 and bit 5 is 1, then read the 2 byte (uint16) [=Mapping Entry/bias=] value
         from <var>entry bytes</var>.
@@ -1679,14 +1701,9 @@ The algorithm:
         Add the resulting code point set to the first [=font subset definition=] in <var>entry</var>. If the sparse bit set decoding
         failed then, this encoding is invalid return an error.
 
-10. If [=Mapping Entry/formatFlags=] bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.
+11. If [=Mapping Entry/formatFlags=] bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.
 
-11. If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.
-
-12. Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]]. If the template expansion
-     results in an error (see: [[rfc6570#section-3]]) then, return an error. Set the patch uri of <var>entry</var> to the generated URI.
-
-13. Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, [=Mapping Entry/entryIdStringLength=] as
+12. Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, [=Mapping Entry/entryIdStringLength=] as
      <var>consumed id string bytes</var>, and <var>ignored</var>.
 
 <h5 algorithm id="remove-entries-format-2">Remove Entries from Format 2</h5>
@@ -1705,8 +1722,9 @@ The inputs to this algorithm are:
 This algorithm is a modified version of [$Interpret Format 2 Patch Map$], invoke [$Interpret Format 2 Patch Map$] with <var>patch map</var>
 as an input but with the following changes:
 
-*  After step 11 of [$Interpret Format 2 Patch Map Entry$]: compare the URI generated in step 11 to <var>patch URI</var> if they
-    are equal then, set bit 6 of  [=Mapping Entry/formatFlags=] to 1.
+*  During step 8 of [$Interpret Format 2 Patch Map Entry$]: compare the URI generated for only the first delta/length value to
+    <var>patch URI</var> if they are equal then, set bit 6 of  [=Mapping Entry/formatFlags=] to 1. Stop the interpretation process
+    at this point.
 
 *  The return value of [$Interpret Format 2 Patch Map$] is not used.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -743,14 +743,18 @@ round trips.
 The following selection criteria minimizes round trips and must be used by the client when selecting a single partial or full invalidation patch in step 8
 of [$Extend an Incremental Font Subset$]:
 
-1.  For each candidate entry: compute a total subset definition by unioning that entry's subset definition and the subset definition of all child entries
+1.  If one or more candidate entries have previously had their associated patch file preloaded by step 9 of [$Extend an Incremental Font Subset$],
+    then in the following steps only consider candidate entries whose patch file is already loaded or is currently being loaded. Otherwise consider all
+    candidate entries.
+
+2.  For each candidate entry: compute a total subset definition by unioning that entry's subset definition and the subset definition of all child entries
      reachable via the graph of referenced child entries.
 
-2.  For each candidate entry: compute the set intersection between the total subset definition and the target subset definition.
+3.  For each candidate entry: compute the set intersection between the total subset definition and the target subset definition.
    
-3.  Find an entry whose intersection from step 2 is not a strict subset of any other intersection.
+4.  Find an entry whose intersection from step 2 is not a strict subset of any other intersection.
 
-4.  Locate any additional entries that are in the same [=patch map=] and have the same intersection as the entry found in step 3. From the this set of
+5.  Locate any additional entries that are in the same [=patch map=] and have the same intersection as the entry found in step 3. From the this set of
      entries (including the step 3 pick) the final selection is the entry which is listed first in the [=patch map=]. For [[#patch-map-format-1]] this is the
      entry with the lowest entry index. For [[#patch-map-format-2]] this is the entry that appears first in the [=Mapping Entries/entries=] array.
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -340,11 +340,12 @@ changes encoded according to the format is a [=font patch=]. Each [=patch format
 Patch Map {#patch-map-dfn}
 --------------------------
 
-A <dfn dfn>patch map</dfn> is an [[open-type/otff#table-directory|open type table]] which encodes a collection of mappings from
-[=font subset definition|font subset definitions=] to URIs which host [[#font-patch-formats|patches]] that extend the
-[=incremental font=]. A [=patch map=] table encodes a list of <dfn dfn>patch map entries</dfn>, where each entry has a key and value.
-The key of an entry defines the coverage of the entry, which is information on what subset definitions will match it. The value specifies
-information about the patch which should be applied when the entry is matched. [=patch map entries|Patch Map Entry=] summary:
+A <dfn dfn>patch map</dfn> is an [[open-type/otff#table-directory|open type table]] which encodes a collection of
+mappings from [=font subset definition|font subset definitions=] to URIs which host [[#font-patch-formats|patches]] that
+extend the [=incremental font=]. A [=patch map=] table encodes a list of <dfn dfn>patch map entries</dfn>, where each
+entry has a key and value.  The key of an entry defines the coverage of the entry, which is information on what subset
+definitions will match it. The value specifies information about the patches which should be applied when the entry is
+matched. [=patch map entries|Patch Map Entry=] summary:
 
 <table>
   <tr><th>Key</th><th>Value</th></tr>
@@ -357,7 +358,7 @@ information about the patch which should be applied when the entry is matched. [
       
     </td>
     <td>
-      * Patch URI
+      * One or more Patch URIs
       * [[#font-patch-formats|Patch Format]]
       * [[#font-patch-invalidations|compatibility ID]]
       
@@ -1445,20 +1446,27 @@ The algorithm:
 
   <tr>
     <td>int24</td>
-    <td><dfn for="Mapping Entry">entryIdDelta</dfn></td>
+    <td><dfn for="Mapping Entry">entryIdDelta</dfn>[variable]</td>
     <td>
-      Signed delta which is used to calculate the id for this entry. The id for this entry is the entry id of the previous
-      [=Mapping Entry=] + 1 + entryIdDelta. Only present if [=Mapping Entry/formatFlags=] bit 2 is set and
-      [=Format 2 Patch Map/entryIdStringData=] is null (0). If not present delta is assumed to be 0.
+      List of signed deltas which calculate the IDs of the URIs for this entry. If present, has at least one delta. If the least
+      significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
+      cleared is encountered. The entry id for each delta the last calculated entry id + 1 + (entryIdDelta / 2). Only present if
+      [=Mapping Entry/formatFlags=] bit 2 is set and [=Format 2 Patch Map/entryIdStringData=] is null (0).
+      If not present and [=Format 2 Patch Map/entryIdStringData=] is null (0), then there is one id for this entry and and the
+      delta is assumed to be 0.
     </td>
   </tr>
   <tr>
-    <td>uint16</td>
-    <td><dfn for="Mapping Entry">entryIdStringLength</dfn></td>
+    <td>uint24</td>
+    <td><dfn for="Mapping Entry">entryIdStringLength</dfn>[variable]</td>
     <td>
-      The number of bytes that the id string for this entry occupies in the [=Format 2 Patch Map/entryIdStringData=] data block.
-      Only present if [=Mapping Entry/formatFlags=] bit 2 is set and [=Format 2 Patch Map/entryIdStringData=] is not null (0). If not
-      present the length is assumed to be 0.
+      The number of bytes that each id string for this entry occupies in the [=Format 2 Patch Map/entryIdStringData=]
+      data block.  If the most significant bit of a length value is set, then another length value follows. This repeats
+      until a length value with the most significant bit cleared is encountered. The actual length value is stored in
+      the least significant 23 bits of each value. Only present if [=Mapping Entry/formatFlags=] bit 2 is set and
+      [=Format 2 Patch Map/entryIdStringData=] is not null (0). If present has at least one length value. If not present
+      and [=Format 2 Patch Map/entryIdStringData=] is not null (0), then the there is one id string for this entry and
+      its length is zero.
     </td>
   </tr>
 

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="1f572eaaa54a42581b9f4ddfb539dc2cdb90a54a" name="revision">
+  <meta content="3746c44c40887e3d9e2683d9a366fd9e831db3b6" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1110,9 +1110,12 @@ an existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset�
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-format">patch format</dfn> is a specified encoding of changes to be applied relative to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②">font subset</a>. A set of
 changes encoded according to the format is a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Each <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
    <h3 class="heading settled" data-level="3.3" id="patch-map-dfn"><span class="secno">3.3. </span><span class="content">Patch Map</span><a class="self-link" href="#patch-map-dfn"></a></h3>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map">patch map</dfn> is an <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">open type table</a> which encodes a collection of mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which host <a href="#font-patch-formats">patches</a> that extend the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental font</a>. A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map">patch map</a> table encodes a list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map-entries">patch map entries</dfn>, where each entry has a key and value.
-The key of an entry defines the coverage of the entry, which is information on what subset definitions will match it. The value specifies
-information about the patch which should be applied when the entry is matched. <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries">Patch Map Entry</a> summary:</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map">patch map</dfn> is an <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">open type table</a> which encodes a collection of
+mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which host <a href="#font-patch-formats">patches</a> that
+extend the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental font</a>. A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map">patch map</a> table encodes a list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map-entries">patch map entries</dfn>, where each
+entry has a key and value.  The key of an entry defines the coverage of the entry, which is information on what subset
+definitions will match it. The value specifies information about the patches which should be applied when the entry is
+matched. <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries">Patch Map Entry</a> summary:</p>
    <table>
     <tbody>
      <tr>
@@ -1131,7 +1134,7 @@ information about the patch which should be applied when the entry is matched. <
       <td>
        <ul>
         <li data-md>
-         <p>Patch URI</p>
+         <p>One or more Patch URIs</p>
         <li data-md>
          <p><a href="#font-patch-formats">Patch Format</a></p>
         <li data-md>
@@ -2007,14 +2010,20 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
       Only entries that occurred prior to this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries②">entries</a> can be referenced. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
      <tr>
       <td>int24
-      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>
-      <td> Signed delta which is used to calculate the id for this entry. The id for this entry is the entry id of the previous <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a> + 1 + entryIdDelta. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0). If not present delta is assumed to be 0. 
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>[variable]
+      <td> List of signed deltas which calculate the IDs of the URIs for this entry. If present, has at least one delta. If the least
+      significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
+      cleared is encountered. The entry id for each delta the last calculated entry id + 1 + (entryIdDelta / 2). Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0).
+      If not present and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata①">entryIdStringData</a> is null (0), then there is one id for this entry and and the
+      delta is assumed to be 0. 
      <tr>
-      <td>uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryidstringlength">entryIdStringLength</dfn>
-      <td> The number of bytes that the id string for this entry occupies in the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata①">entryIdStringData</a> data block.
-      Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑦">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata②">entryIdStringData</a> is not null (0). If not
-      present the length is assumed to be 0. 
+      <td>uint24
+      <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryidstringlength">entryIdStringLength</dfn>[variable]
+      <td> The number of bytes that each id string for this entry occupies in the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata②">entryIdStringData</a> data block.  If the most significant bit of a length value is set, then another length value follows. This repeats
+      until a length value with the most significant bit cleared is encountered. The actual length value is stored in
+      the least significant 23 bits of each value. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑦">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a> is not null (0). If present has at least one length value. If not present
+      and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a> is not null (0), then the there is one id string for this entry and
+      its length is zero. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchformat">patchFormat</dfn>
@@ -2077,7 +2086,7 @@ being requested.</p>
     <li data-md>
      <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 5.3.2 Patch Map Table: Format 2</a> (requirements are marked with a "must"). If it is not return an error.</p>
     <li data-md>
-     <p>If the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a> offset is 0 then initialize <var>last entry id</var> to 0. Otherwise initialize
+     <p>If the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑤">entryIdStringData</a> offset is 0 then initialize <var>last entry id</var> to 0. Otherwise initialize
  it to an empty byte string. Set <var>current byte</var> to 0, and <var>current id string byte</var> to 0.</p>
     <li data-md>
      <p>Initialize <var>entry list</var> and <var>prior entry list</var> to empty lists.</p>
@@ -2087,8 +2096,8 @@ being requested.</p>
       <li data-md>
        <p>pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
- the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a>[<var>current id string byte</var>]
- to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑤">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
+ the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑥">entryIdStringData</a>[<var>current id string byte</var>]
+ to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
@@ -2109,7 +2118,7 @@ being requested.</p>
     <li data-md>
      <p><var>prior entry list</var>: a list of entries prior to this one.</p>
     <li data-md>
-     <p><var>entry bytes</var>: a byte array that contains an encoded <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry③">Mapping Entry</a>.</p>
+     <p><var>entry bytes</var>: a byte array that contains an encoded <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry②">Mapping Entry</a>.</p>
     <li data-md>
      <p><var>id string bytes</var> (optional): a byte array the contains entry ID strings.</p>
     <li data-md>
@@ -2164,7 +2173,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
       <li data-md>
        <p>Read the child entry indices list specified by <a data-link-type="dfn" href="#mapping-entry-childentrymatchmodeandcount" id="ref-for-mapping-entry-childentrymatchmodeandcount①">childEntryMatchModeAndCount</a> and <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices">childEntryIndices</a> from <var>entry bytes</var>.</p>
       <li data-md>
-       <p>The child entry indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry④">Mapping Entry</a> in <var>prior entry list</var>, 1 the second
+       <p>The child entry indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry③">Mapping Entry</a> in <var>prior entry list</var>, 1 the second
  and so on. For each value in <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices①">childEntryIndices</a> locate the entry in <var>prior entry list</var> with a matching index.
  Add a reference to that entry into <var>entry</var>. If a <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices②">childEntryIndices</a> is greater than or equal to the length
  of <var>prior entry list</var> then, this encoding is invalid return an error.</p>
@@ -4170,7 +4179,7 @@ let dfnPanelData = {
 "format-2-patch-map-defaultpatchformat": {"dfnID":"format-2-patch-map-defaultpatchformat","dfnText":"defaultPatchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-defaultpatchformat"},
 "format-2-patch-map-entries": {"dfnID":"format-2-patch-map-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entries"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entries"},
 "format-2-patch-map-entrycount": {"dfnID":"format-2-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entrycount"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entrycount\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entrycount"},
-"format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
+"format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2465"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2466"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
 "format-2-patch-map-format": {"dfnID":"format-2-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-format"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-format"},
 "format-2-patch-map-uritemplate": {"dfnID":"format-2-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-uritemplate"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-uritemplate"},
 "full-invalidation": {"dfnID":"full-invalidation","dfnText":"Full Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-full-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-full-invalidation\u2460"}],"title":"6.1. Formats Summary"}],"url":"#full-invalidation"},
@@ -4192,7 +4201,7 @@ let dfnPanelData = {
 "incremental-font": {"dfnID":"incremental-font","dfnText":"incremental font","external":false,"refSections":[{"refs":[{"id":"ref-for-incremental-font"}],"title":"1.2. Overview"},{"refs":[{"id":"ref-for-incremental-font\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-incremental-font\u2461"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-incremental-font\u2462"},{"id":"ref-for-incremental-font\u2463"},{"id":"ref-for-incremental-font\u2464"},{"id":"ref-for-incremental-font\u2465"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-incremental-font\u2466"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-incremental-font\u2467"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-incremental-font\u2468"},{"id":"ref-for-incremental-font\u2460\u24ea"},{"id":"ref-for-incremental-font\u2460\u2460"},{"id":"ref-for-incremental-font\u2460\u2461"},{"id":"ref-for-incremental-font\u2460\u2462"},{"id":"ref-for-incremental-font\u2460\u2463"},{"id":"ref-for-incremental-font\u2460\u2464"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-incremental-font\u2460\u2465"},{"id":"ref-for-incremental-font\u2460\u2466"},{"id":"ref-for-incremental-font\u2460\u2467"},{"id":"ref-for-incremental-font\u2460\u2468"},{"id":"ref-for-incremental-font\u2461\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#incremental-font"},
 "mapping-entries": {"dfnID":"mapping-entries","dfnText":"Mapping Entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#mapping-entries"},
 "mapping-entries-entries": {"dfnID":"mapping-entries-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries-entries"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2460"},{"id":"ref-for-mapping-entries-entries\u2461"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#mapping-entries-entries"},
-"mapping-entry": {"dfnID":"mapping-entry","dfnText":"Mapping Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry"},{"id":"ref-for-mapping-entry\u2460"},{"id":"ref-for-mapping-entry\u2461"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry\u2462"},{"id":"ref-for-mapping-entry\u2463"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry"},
+"mapping-entry": {"dfnID":"mapping-entry","dfnText":"Mapping Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry"},{"id":"ref-for-mapping-entry\u2460"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry\u2461"},{"id":"ref-for-mapping-entry\u2462"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry"},
 "mapping-entry-bias": {"dfnID":"mapping-entry-bias","dfnText":"bias","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-bias"},{"id":"ref-for-mapping-entry-bias\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-bias"},
 "mapping-entry-childentryindices": {"dfnID":"mapping-entry-childentryindices","dfnText":"childEntryIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-childentryindices"},{"id":"ref-for-mapping-entry-childentryindices\u2460"},{"id":"ref-for-mapping-entry-childentryindices\u2461"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-childentryindices\u2462"}],"title":"7.1. Encoding Considerations"}],"url":"#mapping-entry-childentryindices"},
 "mapping-entry-childentrymatchmodeandcount": {"dfnID":"mapping-entry-childentrymatchmodeandcount","dfnText":"childEntryMatchModeAndCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-childentrymatchmodeandcount"},{"id":"ref-for-mapping-entry-childentrymatchmodeandcount\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-childentrymatchmodeandcount"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="c4e092ce1fa4fec5671e36b7aefad9f86f20868f" name="revision">
+  <meta content="5c88ae44d439b835868cfddf951503fe2cb0f0ed" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1457,6 +1457,10 @@ round trips.</p>
 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①">Extend an Incremental Font Subset</a>:</p>
    <ol>
     <li data-md>
+     <p>If one or more candidate entries have previously had their associated patch file preloaded by step 9 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset②">Extend an Incremental Font Subset</a>,
+then in the following steps only consider candidate entries whose patch file is already loaded or is currently being loaded. Otherwise consider all
+candidate entries.</p>
+    <li data-md>
      <p>For each candidate entry: compute a total subset definition by unioning that entry’s subset definition and the subset definition of all child entries
  reachable via the graph of referenced child entries.</p>
     <li data-md>
@@ -1473,7 +1477,7 @@ set intersection, then the size of feature tag set intersection, and finally the
 guaranteed to not be a strict subset of any other entries, since any strict super sets would have to be at least one item larger. This approach also has
 the added benefit that it selects the patch which will add the most data which the client is currently requesting.</p>
    <h3 class="heading settled" data-level="4.5" id="target-subset-definitions"><span class="secno">4.5. </span><span class="content">Target Subset Definition</span><a class="self-link" href="#target-subset-definitions"></a></h3>
-   <p>The <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset②">Extend an Incremental Font Subset</a> algorithm takes as an input a target subset definition based on some content that the client
+   <p>The <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset③">Extend an Incremental Font Subset</a> algorithm takes as an input a target subset definition based on some content that the client
 wants to render. The client may choose to form one single subset definition for the content as a whole and run the extension algorithm
 once. Alternatively, the client may instead break the content up into smaller spans, form a subset definition for each span, and run
 the extension algorithm on each of the smaller subset definitions. Either approach will ultimately produce a font which equivalently
@@ -1503,7 +1507,7 @@ shaping.</p>
        <p>First, if for any code point in the shaping unit there is not a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> entry for it, or the entry maps to glyph
 0 then the incremental font does not fully support rendering the shaping unit.</p>
       <li data-md>
-       <p>Second, compute the corresponding <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definition</a> and execute the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset③">Extend an Incremental Font Subset</a> algorithm,
+       <p>Second, compute the corresponding <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑤">font subset definition</a> and execute the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset④">Extend an Incremental Font Subset</a> algorithm,
 stopping at step 6. If the entry list is not empty then the incremental font does not fully support rendering the shaping unit.</p>
      </ul>
     <li data-md>
@@ -1558,12 +1562,12 @@ incremental font:</p>
    <p>Any text from the shaping unit which is not covered by one of the returned spans is not supported by the incremental font and should
 be rendered with a fallback font. Each span should be shaped in isolation (ie. each span becomes a new shaping unit).
 Because this method splits a shaping unit up, not all features of the original font, such as multi code point substitutions, may be
-present. If the client is correctly following the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset④">Extend an Incremental Font Subset</a> algorithm with a subset definition formed
+present. If the client is correctly following the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑤">Extend an Incremental Font Subset</a> algorithm with a subset definition formed
 according to <a href="#target-subset-definitions">§ 4.5 Target Subset Definition</a> then the missing data will be loaded and this case will only occur temporarily while the
 relevant patch is loading. Once the missing patch arrives and has been applied the rendering of the affected
 code points may change as a result of the substitution.</p>
    <p class="note" role="note"><span class="marker">Note:</span> The "supported_spans(...)" check above should not be used to drive incremental font extension. Target subset definitions for full
-executions of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑤">Extend an Incremental Font Subset</a> should follow the guidelines in <a href="#target-subset-definitions">§ 4.5 Target Subset Definition</a>.</p>
+executions of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑥">Extend an Incremental Font Subset</a> should follow the guidelines in <a href="#target-subset-definitions">§ 4.5 Target Subset Definition</a>.</p>
    <h3 class="heading settled algorithm" data-algorithm="Fully Expanding a Font" data-level="4.7" id="fully-expanding-a-font"><span class="secno">4.7. </span><span class="content">Fully Expanding a Font</span><a class="self-link" href="#fully-expanding-a-font"></a></h3>
    <p>This sections defines an algorithm that can be used to transform an incremental font into a fully expanded non-incremental font. This
 process loads all available data provided by the incremental font and produces a single static font file that contains no further
@@ -1582,7 +1586,7 @@ patches to be applied.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑥">Extend an Incremental Font Subset</a> with <var>font subset</var>. The input target subset definition is a special one which
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑦">Extend an Incremental Font Subset</a> with <var>font subset</var>. The input target subset definition is a special one which
 is considered to intersect all entries in the <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection②">Check entry intersection</a> step. Return the resulting font subset as
 the <var>expanded font</var>.</p>
    </ol>
@@ -1648,7 +1652,7 @@ not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-f
      <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
 is typically less compact than format 1.</p>
    </ul>
-   <p>Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑦">Extend an Incremental Font Subset</a> algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
+   <p>Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑧">Extend an Incremental Font Subset</a> algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
 encoded bytes are the source of truth at all times for the patch map. Patch application during subset extension will alter the encoded
 bytes of the patch map and as a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets
 the encoded bytes at the start of every iteration to pick up any changes made in the previous iteration.</p>
@@ -2842,8 +2846,8 @@ The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-fon
     <li data-md>
      <p>Must meet all of the requirements in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 6 Font Patch Formats</a>.</p>
     <li data-md>
-     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑧">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
-of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a>.</p>
+     <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
+of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①⓪">Extend an Incremental Font Subset</a>.</p>
     <li data-md>
      <p>Must respect patch invalidation criteria. Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑧">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
  for the invalidation mode declared by the associated <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①①">patch map entries</a>.</p>
@@ -2854,7 +2858,7 @@ of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#ab
  expanded may not always be an exact binary match with the existing font.</p>
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font throughout the augmentation process, that is:
- given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①⓪">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①④">incremental font</a> and the minimal subset definition covering that content should
+ given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①①">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①④">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
    </ol>
    <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑤">incremental font</a> and a client is implemented according to the
@@ -4169,7 +4173,7 @@ let dfnPanelData = {
 "abstract-opdef-apply-table-keyed-patch": {"dfnID":"abstract-opdef-apply-table-keyed-patch","dfnText":"Apply table keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-table-keyed-patch"},
 "abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2461"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2462"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2463"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2464"}],"title":"Example 1: Table and Glyph Keyed Patches"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2465"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2466"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2467"}],"title":"Example 2: Glyph Keyed Patches with Child Entries"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
-"abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"}],"title":"4.5. Target Subset Definition"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2464"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2465"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2466"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2467"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2468"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u24ea"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
+"abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"}],"title":"4.5. Target Subset Definition"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2464"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2465"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2466"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2467"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2468"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u24ea"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u2460"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "abstract-opdef-fully-expand-a-font-subset": {"dfnID":"abstract-opdef-fully-expand-a-font-subset","dfnText":"Fully Expand a Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset"}],"title":"2.1. Offline Usage"},{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2460"},{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2461"}],"title":"7. Encoding"}],"url":"#abstract-opdef-fully-expand-a-font-subset"},
 "abstract-opdef-handle-errors": {"dfnID":"abstract-opdef-handle-errors","dfnText":"Handle errors","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-handle-errors"},{"id":"ref-for-abstract-opdef-handle-errors\u2460"},{"id":"ref-for-abstract-opdef-handle-errors\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-handle-errors"},
 "abstract-opdef-interpret-format-1-patch-map": {"dfnID":"abstract-opdef-interpret-format-1-patch-map","dfnText":"Interpret Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-1-patch-map"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-interpret-format-1-patch-map"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="0c58d154b3555bbcbd02a447d5f38be5be50fea1" name="revision">
+  <meta content="c4e092ce1fa4fec5671e36b7aefad9f86f20868f" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1190,8 +1190,16 @@ opt to exclude those unused features from the subset definition.</p>
    <p>The following algorithm is used by a client to extend an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font③">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑦">font subset</a> to cover additional
 code points, layout features and/or design space. This algorithm incrementally selects and applies patches to the font one at a time, loading
 them as needed. As an important optimization to minimize network round trips it permits loads to be started for all patches that will eventually
-be needed. <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> is used to determine which patches loads can be started for. Any patches which match the target subset definition
-and will not be invalidated by the next patch to be applied according to <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> can be expected to be needed in future iterations.</p>
+be needed. These come in two forms:</p>
+   <ul>
+    <li data-md>
+     <p>First, <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①">patch mapping entries</a> may list more than one URI, where each URI after the first is to be preloaded because it
+will be needed in future iterations.</p>
+    <li data-md>
+     <p>Second, <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> is used to determine which patches loads can be started for. Any patches which match the target subset
+definition and will not be invalidated by the next patch to be applied according to <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> can be expected to be
+needed in future iterations.</p>
+   </ul>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
@@ -1242,9 +1250,10 @@ Follow the criteria in <a href="#invalidating-patch-selection">§ 4.4 Selectin
 The criteria for selecting the single entry is left up to the implementation to decide.</p>
      </ul>
     <li data-md>
-     <p>Start a load of <var>patch file</var> (if not already previously started) by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>initial font subset URI</var> as the initial font URI and the <var>entry</var> patch URI as the patch URI. Additionally the client may optionally start loads using the same
-procedure for any entries in <var>entry list</var> which will not be <a href="#font-patch-invalidations">invalidated</a> by <var>entry</var>. The total
-number of patches that a client can load and apply during a single execution of this algorithm is limited to:</p>
+     <p>Start a load of <var>patch file</var> (if not already previously started) by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>initial font subset URI</var> as the initial font URI and the first patch URI in <var>entry</var> as the patch URI. If there are any other URIs in <var>entry</var>, then initiate
+loads for those using the same procedure. These are preloads and the results may be used during future iterations of this algorithm.
+Additionally the client may optionally start loads using the same procedure for any entries in <var>entry list</var> which will not be <a href="#font-patch-invalidations">invalidated</a> by <var>entry</var>. The total number of patches that a client can load and apply during a single execution
+of this algorithm is limited to:</p>
      <ul>
       <li data-md>
        <p>At most 100 patches which are <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation">Partial Invalidation</a> or <a data-link-type="dfn" href="#full-invalidation" id="ref-for-full-invalidation">Full Invalidation</a>.</p>
@@ -1455,8 +1464,8 @@ of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-f
     <li data-md>
      <p>Find an entry whose intersection from step 2 is not a strict subset of any other intersection.</p>
     <li data-md>
-     <p>Locate any additional entries that are in the same <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①">patch map</a> and have the same intersection as the entry found in step 3. From the this set of
- entries (including the step 3 pick) the final selection is the entry which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map②">patch map</a>. For <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a> this is the
+     <p>Locate any additional entries that are in the same <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map②">patch map</a> and have the same intersection as the entry found in step 3. From the this set of
+ entries (including the step 3 pick) the final selection is the entry which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map③">patch map</a>. For <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a> this is the
  entry with the lowest entry index. For <a href="#patch-map-format-2">§ 5.3.2 Patch Map Table: Format 2</a> this is the entry that appears first in the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array.</p>
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> a fast and efficient way to find an entry which satisfies the criteria for step 3 is to sort the entries (descending) by the size of the code point
@@ -1583,7 +1592,7 @@ to the procedures in this section. So if an incremental font needs to be stored 
 store only the font binary produced by the most recent application of the extension algorithm. It is not necessary to retain the initial
 font or any versions produced by prior extensions.</p>
    <h2 class="heading settled" data-level="5" id="font-format-extensions"><span class="secno">5. </span><span class="content">Extensions to the Font Format</span><a class="self-link" href="#font-format-extensions"></a></h2>
-   <p>An <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but includes two new <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map③">patch maps</a>. All incremental fonts must contain the 'IFT ' table. The 'IFTX' table is optional. When both tables are
+   <p>An <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but includes two new <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map④">patch maps</a>. All incremental fonts must contain the 'IFT ' table. The 'IFTX' table is optional. When both tables are
 present, the mapping of the font as a whole is the union of the mappings of the two tables. The two new tables are used only in this
 specification and are not being added to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">Open-Type</a> specification.</p>
    <p class="note" role="note"><span class="marker">Note:</span> allowing the mapping to be split between two distinct tables allows an incremental font to more easily make use of multiple
@@ -1630,7 +1639,7 @@ non-subroutinized font more effectively than its subroutinized equivalent (at th
 uncompressed file).  Therefore, it is recommended that subroutinzation either be avoided, used moderately, or customized
 to the specific needs of IFT.</p>
    <h3 class="heading settled" data-level="5.3" id="patch-map-table"><span class="secno">5.3. </span><span class="content">Patch Map Table</span><a class="self-link" href="#patch-map-table"></a></h3>
-   <p>A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map④">patch map</a> is encoded in one of two formats:</p>
+   <p>A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑤">patch map</a> is encoded in one of two formats:</p>
    <ul>
     <li data-md>
      <p>Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URIs. It does
@@ -2069,12 +2078,12 @@ being requested.</p>
       <td> End (inclusive) of the segment. Must be greater than or equal to start. This value uses the user axis scale: <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
    </table>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="5.3.2.1" id="interpreting-patch-map-format-2"><span class="secno">5.3.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
-   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑤">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
+   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑥">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map">Format 2 Patch Map</a> encoded <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑥">patch map</a>.</p>
+     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map">Format 2 Patch Map</a> encoded <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑦">patch map</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -2836,7 +2845,7 @@ The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-fon
      <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑧">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
 of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a>.</p>
     <li data-md>
-     <p>Must respect patch invalidation criteria. Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑦">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
+     <p>Must respect patch invalidation criteria. Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑧">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
  for the invalidation mode declared by the associated <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①①">patch map entries</a>.</p>
     <li data-md>
      <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
@@ -4241,7 +4250,7 @@ let dfnPanelData = {
 "partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2461"},{"id":"ref-for-partial-invalidation\u2462"},{"id":"ref-for-partial-invalidation\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
 "patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
-"patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"},{"id":"ref-for-patch-map\u2461"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-patch-map\u2462"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2463"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2464"},{"id":"ref-for-patch-map\u2465"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map\u2466"}],"title":"7. Encoding"}],"url":"#patch-map"},
+"patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map\u2461"},{"id":"ref-for-patch-map\u2462"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-patch-map\u2463"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2464"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2465"},{"id":"ref-for-patch-map\u2466"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map\u2467"}],"title":"7. Encoding"}],"url":"#patch-map"},
 "patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"},{"id":"ref-for-patch-map-entries\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2462"},{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"7. Encoding"}],"url":"#patch-map-entries"},
 "sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
 "table-keyed-patch": {"dfnID":"table-keyed-patch","dfnText":"Table keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="5c88ae44d439b835868cfddf951503fe2cb0f0ed" name="revision">
+  <meta content="8108f4b43a3fa6f7c3d6fd95a598a294822a4055" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1193,7 +1193,7 @@ them as needed. As an important optimization to minimize network round trips it 
 be needed. These come in two forms:</p>
    <ul>
     <li data-md>
-     <p>First, <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①">patch mapping entries</a> may list more than one URI, where each URI after the first is to be preloaded because it
+     <p>First, <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①">patch mapping entries</a> may list more than one URI, where each URI after the first should also be loaded because they
 will be needed in future iterations.</p>
     <li data-md>
      <p>Second, <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> is used to determine which patches loads can be started for. Any patches which match the target subset
@@ -1251,7 +1251,7 @@ The criteria for selecting the single entry is left up to the implementation to 
      </ul>
     <li data-md>
      <p>Start a load of <var>patch file</var> (if not already previously started) by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>initial font subset URI</var> as the initial font URI and the first patch URI in <var>entry</var> as the patch URI. If there are any other URIs in <var>entry</var>, then initiate
-loads for those using the same procedure. These are preloads and the results may be used during future iterations of this algorithm.
+loads for those using the same procedure. These may be used during future iterations of this algorithm.
 Additionally the client may optionally start loads using the same procedure for any entries in <var>entry list</var> which will not be <a href="#font-patch-invalidations">invalidated</a> by <var>entry</var>. The total number of patches that a client can load and apply during a single execution
 of this algorithm is limited to:</p>
      <ul>
@@ -1457,7 +1457,7 @@ round trips.</p>
 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①">Extend an Incremental Font Subset</a>:</p>
    <ol>
     <li data-md>
-     <p>If one or more candidate entries have previously had their associated patch file preloaded by step 9 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset②">Extend an Incremental Font Subset</a>,
+     <p>If one or more candidate entries have previously had their associated patch file loaded by step 9 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset②">Extend an Incremental Font Subset</a>,
 then in the following steps only consider candidate entries whose patch file is already loaded or is currently being loaded. Otherwise consider all
 candidate entries.</p>
     <li data-md>
@@ -2026,8 +2026,8 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>[variable]
       <td> List of signed deltas which calculate the IDs of the URIs for this entry. If present, has at least one delta. If the least
       significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
-      cleared is encountered. The entry id for each delta the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0).
-      If not present and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata①">entryIdStringData</a> is null (0), then there is one id for this entry and and the
+      cleared is encountered. The entry id for each delta is the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0).
+      If not present and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata①">entryIdStringData</a> is null (0), then there is one id for this entry and the
       delta is assumed to be 0. 
      <tr>
       <td>uint24

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="3746c44c40887e3d9e2683d9a366fd9e831db3b6" name="revision">
+  <meta content="0c58d154b3555bbcbd02a447d5f38be5be50fea1" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2013,7 +2013,7 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>[variable]
       <td> List of signed deltas which calculate the IDs of the URIs for this entry. If present, has at least one delta. If the least
       significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
-      cleared is encountered. The entry id for each delta the last calculated entry id + 1 + (entryIdDelta / 2). Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0).
+      cleared is encountered. The entry id for each delta the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0).
       If not present and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata①">entryIdStringData</a> is null (0), then there is one id for this entry and and the
       delta is assumed to be 0. 
      <tr>
@@ -2147,7 +2147,7 @@ being requested.</p>
      <p>For the all steps whenever data is loaded from <var>entry bytes</var> increment <var>consumed bytes</var> with the
  number of bytes read.</p>
     <li data-md>
-     <p>If <var>id string bytes</var> is not present then, set <var>entry id</var> = <var>last entry id</var> + 1. Otherwise set <var>entry id</var> = <var>last entry id</var>.</p>
+     <p>If <var>id string bytes</var> is not present then, set <var>entry id</var> = <var>last entry id</var>. Otherwise set <var>entry id</var> = <var>last entry id</var>.</p>
     <li data-md>
      <p>Set the patch format of <var>entry</var> to <var>default patch format</var>.</p>
     <li data-md>
@@ -2179,12 +2179,40 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
  of <var>prior entry list</var> then, this encoding is invalid return an error.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①③">formatFlags</a> bit 2 is set, then an id delta or id string length is present:</p>
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①③">formatFlags</a> bit 2 is set, then id deltas or id string lengths are present:</p>
      <ul>
       <li data-md>
-       <p>If <var>id string bytes</var> is not present then, read the id delta specified by <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta①">entryIdDelta</a> from <var>entry bytes</var> and add the delta to <var>entry id</var>.</p>
+       <p>If <var>id string bytes</var> is not present, then:</p>
+       <ul>
+        <li data-md>
+         <p>Read the next <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta①">entryIdDelta</a> value.</p>
+        <li data-md>
+         <p>Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
+ If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
+        <li data-md>
+         <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
+ If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
+        <li data-md>
+         <p>Add the generated patch URI to <var>entry</var>.</p>
+        <li data-md>
+         <p>If the least significant bit of the read delta value is set, then repeat step 8.</p>
+       </ul>
       <li data-md>
-       <p>Otherwise if <var>id string bytes</var> is present then, read <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength">entryIdStringLength</a> bytes from <var>id string bytes</var> and set <var>entry id</var> to the result.</p>
+       <p>Otherwise if <var>id string bytes</var> is present, then:</p>
+       <ul>
+        <li data-md>
+         <p>Read the next <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength">entryIdStringLength</a> value.</p>
+        <li data-md>
+         <p>Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
+ Set <var>entry id</var> to the result.</p>
+        <li data-md>
+         <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
+ If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
+        <li data-md>
+         <p>Add the generated patch URI to <var>entry</var>.</p>
+        <li data-md>
+         <p>If the most significant bit of the read length value is set, then repeat step 8.</p>
+       </ul>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①④">formatFlags</a> bit 3 is set, then a patch format is present. Read the format specified by <a data-link-type="dfn" href="#mapping-entry-patchformat" id="ref-for-mapping-entry-patchformat">patchFormat</a> from <var>entry bytes</var> and set the patch format of <var>entry</var> to the read value.
@@ -2209,11 +2237,6 @@ failed then, this encoding is invalid return an error.</p>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑧">formatFlags</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
     <li data-md>
-     <p>If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
-    <li data-md>
-     <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>. If the template expansion
- results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error. Set the patch uri of <var>entry</var> to the generated URI.</p>
-    <li data-md>
      <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, <a data-link-type="dfn" href="#mapping-entry-entryidstringlength" id="ref-for-mapping-entry-entryidstringlength①">entryIdStringLength</a> as <var>consumed id string bytes</var>, and <var>ignored</var>.</p>
    </ol>
    <h5 class="heading settled algorithm" data-algorithm="Remove Entries from Format 2" data-level="5.3.2.2" id="remove-entries-format-2"><span class="secno">5.3.2.2. </span><span class="content">Remove Entries from Format 2</span><a class="self-link" href="#remove-entries-format-2"></a></h5>
@@ -2230,8 +2253,8 @@ change the number of bytes.</p>
    <p>This algorithm is a modified version of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map①">Interpret Format 2 Patch Map</a>, invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map②">Interpret Format 2 Patch Map</a> with <var>patch map</var> as an input but with the following changes:</p>
    <ul>
     <li data-md>
-     <p>After step 11 of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry②">Interpret Format 2 Patch Map Entry</a>: compare the URI generated in step 11 to <var>patch URI</var> if they
-are equal then, set bit 6 of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑨">formatFlags</a> to 1.</p>
+     <p>During step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry②">Interpret Format 2 Patch Map Entry</a>: compare the URI generated for only the first delta/length value to <var>patch URI</var> if they are equal then, set bit 6 of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑨">formatFlags</a> to 1. Stop the interpretation process
+at this point.</p>
     <li data-md>
      <p>The return value of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map③">Interpret Format 2 Patch Map</a> is not used.</p>
    </ul>


### PR DESCRIPTION
Context: https://lists.w3.org/Archives/Public/public-webfonts-wg/2025Feb/0002.html

This makes so updates to the spec which allows mapping entries to list more than one URL, where all URLs after the first one are treated as preloads. This will allow table keyed patch graphs to utilize less patches by preloading additional jumps in the graph instead of requiring them to be placed into unique patches.

Three main areas are modified:
- Format 2: one bit from the id delta and length fields is reserved to indicate an additional value follows. This allows for encoding more than one value without increasing the cost of encoding entries with only one value.
- Extension algorithm: is updated to preload all URLs listed in the selected entry.
- Invalidating Selection Algorithm: prioritizes any entries which are already loaded, since from the perspective of number of round trips these are free to select and apply.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/262.html" title="Last updated on Mar 20, 2025, 6:50 PM UTC (4190896)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/262/3746c44...4190896.html" title="Last updated on Mar 20, 2025, 6:50 PM UTC (4190896)">Diff</a>