### PR TITLE
Switch to WhatWG URL and Limit URL Templates to level 1

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1043,7 +1043,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td>uint8</td>
     <td><dfn for="Format 1 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
     <td>
-      A [[!UTF-8]] encoded string. Contains a [[#url-templates]] which is used to produce URL strings associated with each entry.
+      A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URL strings associated with each entry.
       Must be a valid [[!UTF-8]] sequence.
     </td>
   </tr>
@@ -1214,7 +1214,7 @@ The algorithm:
         [[open-type/cmap|cmap]] table of <var>font subset</var>. Ignore any glyph indices that are not mapped by [[open-type/cmap|cmap]].
         Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.
 
-    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#url-templates]]. If
+    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#uri-templates]]. If
         the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
@@ -1241,7 +1241,7 @@ The algorithm:
     *  If [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] is greater than
         [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
 
-    *  Convert <var>mapped entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#url-templates]].
+    *  Convert <var>mapped entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#uri-templates]].
         If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the bit for <var>mapped entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this entry.
@@ -1293,7 +1293,7 @@ The algorithm:
     *  If the bit for <var>entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this
         <var>entry index</var>.
 
-    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#url-templates]].
+    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#uri-templates]].
         If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in
@@ -1362,7 +1362,7 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Format 2 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
     <td>
-      A [[!UTF-8]] encoded string. Contains a [[#url-templates]] which is used to produce URL strings associated with each entry.
+      A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URL strings associated with each entry.
       Must be a valid [[!UTF-8]] sequence.
     </td>
   </tr>
@@ -1604,7 +1604,7 @@ The inputs to this algorithm are:
 
 * <var>default patch format</var>: the default patch format if one isn't specified.
 
-* <var>url template</var>: the URL template used to locate patches.
+* <var>uri template</var>: the URI template used to locate patches.
 
 The algorithm outputs:
 
@@ -1665,7 +1665,7 @@ The algorithm:
          *  Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
              If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.
 
-         *  Convert <var>entry id</var> into a URL string by applying <var>url template</var> following [[#url-templates]].
+         *  Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following [[#uri-templates]].
              If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
@@ -1679,7 +1679,7 @@ The algorithm:
          *  Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
              Set <var>entry id</var> to the result.
 
-         *  Convert <var>entry id</var> into a URL string by applying <var>url template</var> following [[#url-templates]].
+         *  Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following [[#uri-templates]].
              If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
@@ -1902,12 +1902,12 @@ to give the smallest encodings for most unicode code point sets typically encoun
   ```
 </div>
 
-### URL Templates ### {#url-templates}
+### URI Templates ### {#uri-templates}
 
-URL templates [[!rfc6570]] are used to convert numeric or string IDs into URL strings where patch files are located.
+URI templates [[!rfc6570]] are used to convert numeric or string IDs into URL strings where patch files are located.
 A string ID is a sequence of bytes. The output of template expansion is a [[!UTF-8]] encoded string.
 
-To limit the complexity of the template expansion implementation, URL templates in IFT are restricted to only
+To limit the complexity of the template expansion implementation, URI templates in IFT are restricted to only
 [[rfc6570#section-1.2|Level 1]] substitution expressions. If during expansion unsupported operators (level 2 and above)
 or an expression which doesn't match template grammar is encountered ([[rfc6570#section-3]]), then template expansion must
 result in an error. Additionally, for consistency when producing percent encodings as part of template expansion
@@ -2735,7 +2735,7 @@ additional tables needed to decode the mapping tables as early as possible in th
 
 <b>Choosing the input ID encoding</b>
 
-The specification supports two encodings for embedding patch IDs in the URL template. The first is [[rfc4648#section-7|base32hex]],
+The specification supports two encodings for embedding patch IDs in the URI template. The first is [[rfc4648#section-7|base32hex]],
 which is a good match for pre-generated patches that will typically be stored in a filesystem. Base32hex encoding only uses the
 letters 0-9 and A-V, which are safe letters for a file name in every commonly used filesystem, with no risk of collisions due to
 case-insensitivity. Because the string is embedded without padding this format cannot be reliably decoded, so it may be a poor

--- a/Overview.bs
+++ b/Overview.bs
@@ -1908,10 +1908,10 @@ URI templates [[!rfc6570]] are used to convert numeric or string IDs into URL st
 A string ID is a sequence of bytes. The output of template expansion is a [[!UTF-8]] encoded string.
 
 To limit the complexity of the template expansion implementation, URI templates in IFT are restricted to only
-[[rfc6570#section-1.2|Level 1]] substitution expressions. If during expansion unsupported operators (level 2 and above)
-or an expression which doesn't match template grammar is encountered ([[rfc6570#section-3]]), then template expansion must
-result in an error. Additionally, for consistency when producing percent encodings as part of template expansion
-([[rfc6570#section-3.1]]) IFT implementations must only use uppercase letters.
+[[rfc6570#section-1.2|Level 1]] substitution expressions. If a URI template contains expression(s) which do not match the level
+1 grammar ([[rfc6570#section-2.2]]), then template expansion must result in an error. Additionally, for consistency when
+producing percent encodings as part of template expansion ([[rfc6570#section-3.1]]) IFT implementations must only use uppercase
+letters.
 
 Several variables are defined which are used to produce the expansion of the template:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -278,7 +278,6 @@ variety of ways fonts are used on web pages. Authors have control over which fon
 this technology with, and which they do not.
 
 Note: the IFT tech keyword can be used in conjunction with other font tech specifiers to perform
-
 font feature selection. For example a <code>@font-face</code> could include two URLs one with
 <code>tech(incremental, color-COLRv1)</code> and the other with
 <code>tech(incremental, color-COLRv0)</code>.
@@ -1905,11 +1904,16 @@ to give the smallest encodings for most unicode code point sets typically encoun
 
 ### URL Templates ### {#url-templates}
 
-<!-- TODO(garretrieger): restrict this to only level 1 and update the examples as needed -->
-
 URL templates [[!rfc6570]] are used to convert numeric or string IDs into URL strings where patch files are located.
-A string ID is a sequence of bytes. The output of template expansion is a [[!UTF-8]] encoded string. Several variables
-are defined which are used to produce the expansion of the template:
+A string ID is a sequence of bytes. The output of template expansion is a [[!UTF-8]] encoded string.
+
+To limit the complexity of the template expansion implementation, URL templates in IFT are restricted to only
+[[rfc6570#section-1.2|Level 1]] substitution expressions. If during expansion unsupported operators (level 2 and above)
+or an expression which doesn't match template grammar is encountered ([[rfc6570#section-3]]), then template expansion must
+result in an error. Additionally, for consistency when producing percent encodings as part of template expansion
+([[rfc6570#section-3.1]]) IFT implementations must only use uppercase letters.
+
+Several variables are defined which are used to produce the expansion of the template:
 
 <table>
   <tr><th>Variable</th><th>Value</th></tr>
@@ -1965,6 +1969,10 @@ are defined which are used to produce the expansion of the template:
   </tr>
 </table>
 
+Note: since there is a small fixed set of variables and only level one expression are supported for expansion, implementations
+may want to consider a custom optimized template expansion implementation instead of relying on a general purpose implementation
+of [[!rfc6570]].
+
 <div class="example">
 
 Some example inputs and the corresponding expansions:
@@ -1984,64 +1992,58 @@ Some example inputs and the corresponding expansions:
     <td>//foo.bar/00</td>
   </tr>
   <tr>
-    <td>//foo.bar{/d1,d2,id}</td>
+    <td>//foo.bar/{d1}/{d2}/{id}</td>
     <td>478</td>
     <td>Integer</td>
     <td>//foo.bar/0/F/07F0</td>
   </tr>
   <tr>
-    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>//foo.bar/{d1}/{d2}/{d3}/{id}</td>
     <td>123</td>
     <td>Integer</td>
     <td>//foo.bar/C/F/_/FC</td>
   </tr>
   <tr>
-    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>//foo.bar/{d1}/{d2}/{d3}/{id}</td>
     <td>baz</td>
     <td>String</td>
     <td>//foo.bar/K/N/G/C9GNK</td>
   </tr>
   <tr>
-    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>//foo.bar/{d1}/{d2}/{d3}/{id}</td>
     <td>z</td>
     <td>String</td>
     <td>//foo.bar/8/F/_/F8</td>
   </tr>
   <tr>
-    <td>//foo.bar{/d1,d2,d3,id}</td>
+    <td>//foo.bar/{d1}/{d2}/{d3}/{id}</td>
     <td>àbc</td>
     <td>String</td>
     <td>//foo.bar/O/O/4/OEG64OO</td>
   </tr>
   <tr>
-    <td>//foo.bar{/id64}</td>
+    <td>//foo.bar/{id64}</td>
     <td>14,000,000</td>
     <td>Integer</td>
     <td>//foo.bar/1Z-A</td>
   </tr>
   <tr>
-    <td>//foo.bar{/id64}</td>
+    <td>//foo.bar/{id64}</td>
     <td>0</td>
     <td>Integer</td>
     <td>//foo.bar/AA%3D%3D</td>
   </tr>
   <tr>
-    <td>//foo.bar{/id64}</td>
+    <td>//foo.bar/{id64}</td>
     <td>17,000,000</td>
     <td>Integer</td>
     <td>//foo.bar/AQNmQA%3D%3D</td>
   </tr>
   <tr>
-    <td>//foo.bar{/id64}</td>
+    <td>//foo.bar/{id64}</td>
     <td>àbc</td>
     <td>String</td>
     <td>//foo.bar/w6BiYw%3D%3D</td>
-  </tr>
-  <tr>
-    <td>//foo.bar/{+id64}</td>
-    <td>àbcd</td>
-    <td>String</td>
-    <td>//foo.bar/w6BiY2Q=</td>
   </tr>
 </table>
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -1909,9 +1909,9 @@ A string ID is a sequence of bytes. The output of template expansion is a [[!UTF
 
 To limit the complexity of the template expansion implementation, URI templates in IFT are restricted to only
 [[rfc6570#section-1.2|Level 1]] substitution expressions. If a URI template contains expression(s) which do not match the level
-1 grammar ([[rfc6570#section-2.2]]), then template expansion must result in an error. Additionally, for consistency when
-producing percent encodings as part of template expansion ([[rfc6570#section-3.1]]) IFT implementations must only use uppercase
-letters.
+1 grammar ([[rfc6570#section-2.2]]) or have variable names other than those defined below, then template expansion must result
+in an error. Additionally, for consistency when producing percent encodings as part of template expansion
+([[rfc6570#section-3.1]]) IFT implementations must only use uppercase letters.
 
 Several variables are defined which are used to produce the expansion of the template:
 

--- a/Overview.bs
+++ b/Overview.bs
@@ -66,15 +66,6 @@ spec:fetch; type:dfn; for:/; text:response
     "date": "May 2024"
   },
 
-  "fetch": {
-    "href": "https://fetch.spec.whatwg.org/",
-    "authors": [],
-    "status": "Living Standard",
-    "publisher": "What WG",
-    "title": "Fetch Standard",
-    "date": "17 June 2024"
-  },
-
   "enabling-typography": {
     "href": "https://www.tiro.com/articles/enabling-typography",
     "authors": ["John Hudson"],
@@ -287,7 +278,8 @@ variety of ways fonts are used on web pages. Authors have control over which fon
 this technology with, and which they do not.
 
 Note: the IFT tech keyword can be used in conjunction with other font tech specifiers to perform
-font feature selection. For example a <code>@font-face</code> could include two URIs one with
+
+font feature selection. For example a <code>@font-face</code> could include two URLs one with
 <code>tech(incremental, color-COLRv1)</code> and the other with
 <code>tech(incremental, color-COLRv0)</code>.
 
@@ -341,7 +333,7 @@ Patch Map {#patch-map-dfn}
 --------------------------
 
 A <dfn dfn>patch map</dfn> is an [[open-type/otff#table-directory|open type table]] which encodes a collection of
-mappings from [=font subset definition|font subset definitions=] to URIs which host [[#font-patch-formats|patches]] that
+mappings from [=font subset definition|font subset definitions=] to URLs which host [[#font-patch-formats|patches]] that
 extend the [=incremental font=]. A [=patch map=] table encodes a list of <dfn dfn>patch map entries</dfn>, where each
 entry has a key and value.  The key of an entry defines the coverage of the entry, which is information on what subset
 definitions will match it. The value specifies information about the patches which should be applied when the entry is
@@ -358,7 +350,7 @@ matched. [=patch map entries|Patch Map Entry=] summary:
       
     </td>
     <td>
-      * One or more Patch URIs
+      * One or more Patch  [[whatwg-url|URL]] strings
       * [[#font-patch-formats|Patch Format]]
       * [[#font-patch-invalidations|compatibility ID]]
       
@@ -444,7 +436,7 @@ The inputs to this algorithm are:
 
 *  <var>font subset</var>: an [=incremental font|incremental=] [=font subset=].
 
-*  <var>initial font subset URI</var>: an [[rfc3986#section-4.3|absolute URI]] which identifies the location of the initial incremental
+*  <var>initial font URL</var>: a [[whatwg-url#concept-url|URL]] which identifies the location of the initial incremental
     font that <var>font subset</var> was derived from.
 
 *  <var>target subset definition</var>: the [=font subset definition=] that the client wants to extend <var>font subset</var> to cover.
@@ -470,7 +462,7 @@ The algorithm:
     
 5.  For each <var>entry</var> in <var>entry list</var> invoke [$Check entry intersection$] with <var>entry</var> and
     <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var> from <var>entry list</var>. Additionally remove
-    any entries in <var>entry list</var> which have a patch URI which was loaded and applied previously during the execution of this algorithm.
+    any entries in <var>entry list</var> which have a patch URL string which was loaded and applied previously during the execution of this algorithm.
 
 6.  If <var>entry list</var> is empty, then the extension operation is finished, return <var>extended font subset</var>.
 
@@ -488,9 +480,9 @@ The algorithm:
     *  Otherwise select exactly one of the entries in <var>no invalidation entry list</var>.
         The criteria for selecting the single entry is left up to the implementation to decide.
 
-9.  Start a load of <var>patch file</var> (if not already previously started) by invoking [$Load patch file$] with the <var>initial font subset URI</var>
-    as the initial font URI and the first patch URI in <var>entry</var> as the patch URI. If there are any other URIs in <var>entry</var>, then initiate
-    loads for those using the same procedure. These may be used during future iterations of this algorithm.
+9.  Start a load of <var>patch file</var> (if not already previously started) by invoking [$Load patch file$] with the <var>initial font URL</var>
+    as the initial font URL and the first patch URL string in <var>entry</var> as the patch URL string. If there are any other URL strings in
+    <var>entry</var>, then initiate loads for those using the same procedure. These may be used during future iterations of this algorithm.
     Additionally the client may optionally start loads using the same procedure for any entries in <var>entry list</var> which will not be
     [[#font-patch-invalidations|invalidated]] by <var>entry</var>. The total number of patches that a client can load and apply during a single execution
     of this algorithm is limited to:
@@ -503,7 +495,7 @@ The algorithm:
     [$Handle errors$].
 
 10.  Once the load for <var>patch file</var> is finished, apply it using the appropriate application algorithm (matching the patches format in
-     <var>entry</var>) from [[#font-patch-formats]] to apply the <var>patch file</var> using the patch URI and the compatibility id from
+     <var>entry</var>) from [[#font-patch-formats]] to apply the <var>patch file</var> using the patch URL string and the compatibility id from
      <var>entry</var> to <var>extended font subset</var>.
 
 11. Go to step 2.
@@ -700,23 +692,24 @@ when a set (ie. code points, feature tags, design space, child entries) is not s
 
 The inputs to this algorithm are:
 
-*   <var>Patch URI</var>: A [[rfc3986#section-4.1|URI Reference]] identifying the patch file to load. As a URI reference this may be a
-     relative path.
+*   <var>patch URL string</var>: A [[whatwg-url|URL]] string ([[!UTF-8]] encoded) identifying the patch file to load. It  may be a
+     [[whatwg-url#relative-url-string|relative]] URL.
 
-*   <var>Initial Font URI</var>: An [[rfc3986#section-4.3|absolute URI]] which identifies the initial incremental font that the
-     patch URI was derived from.
+*  <var>initial font URL</var>: a [[whatwg-url#concept-url|URL]] which identifies the location of the initial incremental
+    font that <var>font subset</var> was derived from.
 
 The algorithm outputs:
 
-*   <var>patch file</var>: the content (bytes) identified by <var>Patch URI</var>.
+*   <var>patch file</var>: the content (bytes) identified by <var>patch URL string</var>.
 
 The algorithm:
 
-1.  Perform [[rfc3986#section-5|reference resolution]] on <var>Patch URI</var> using <var>Initial Font URI</var> as the base URI to
-     produce the <var>target URI</var>.
+1.  Parse <var>patch URL string</var> into a [[whatwg-url#concept-url|URL Record]] using [[whatwg-url#url-parsing]].
+     <var>initial font URL</var> is the [[whatwg-url#concept-base-url|base URL]] and encoding is UTF-8. Store the result
+     in <var>target URL</var>.
 
-2.  Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers,
-     [[fetch]] should be used. When using [[fetch]] a request for patches should use the same CORS settings as the initial request for
+2.  Retrieve the contents of <var>target URL</var> using the fetching capabilities of the implementing user agent. For web browsers,
+     [[FETCH]] should be used. When using [[FETCH]] a request for patches should use the same CORS settings as the initial request for
      the IFT font. This means that for a font loaded via CSS the patch request would follow: [[css-fonts-4#font-fetching-requirements]].
 
 3.  Return the retrieved contents as <var>patch file</var>, or an error if the fetch resulted in an error.
@@ -964,7 +957,7 @@ Patch Map Table {#patch-map-table}
 
 A [=patch map=] is encoded in one of two formats:
 
-*  Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URIs. It does
+*  Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URL strings. It does
     not support [=font subset definitions=] with design space or entries with overlapping subset definitions.
 
 *  Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
@@ -1042,16 +1035,16 @@ the encoded bytes at the start of every iteration to pick up any changes made in
   </tr>
   <tr>
     <td>uint16</td>
-    <td>uriTemplateLength</td>
+    <td>urlTemplateLength</td>
     <td>
-      Length of the uriTemplate string.
+      Length of the urlTemplate string.
     </td>
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
+    <td><dfn for="Format 1 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
     <td>
-      A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URIs associated with each entry.
+      A [[!UTF-8]] encoded string. Contains a [[#url-templates]] which is used to produce URL strings associated with each entry.
       Must be a valid [[!UTF-8]] sequence.
     </td>
   </tr>
@@ -1059,7 +1052,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td>uint8</td>
     <td><dfn for="Format 1 Patch Map">patchFormat</dfn></td>
     <td>
-      Specifies the format of the patches linked to by uriTemplate.
+      Specifies the format of the patches linked to by urlTemplate.
       Must be set to one of the format numbers from  the [[#font-patch-formats-summary]] table.
     </td>
   </tr>
@@ -1222,13 +1215,13 @@ The algorithm:
         [[open-type/cmap|cmap]] table of <var>font subset</var>. Ignore any glyph indices that are not mapped by [[open-type/cmap|cmap]].
         Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.
 
-    *  Convert <var>entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]]. If
+    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#url-templates]]. If
         the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
 
     *  Add an [=patch map entries|entry=] to <var>entry list</var> with a subset definition which contains only the Unicode code point
-        set and maps to the generated URI, the patch format specified by [=Format 1 Patch Map/patchFormat=], and
+        set and maps to the generated URL string, the patch format specified by [=Format 1 Patch Map/patchFormat=], and
         [=Format 1 Patch Map/compatibilityId=].
 
 3.  If [=Format 1 Patch Map/featureMapOffset=] is not null then, for each [=FeatureRecord=] and associated [=EntryMapRecord=] in
@@ -1249,7 +1242,7 @@ The algorithm:
     *  If [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] is greater than
         [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
 
-    *  Convert <var>mapped entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
+    *  Convert <var>mapped entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#url-templates]].
         If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the bit for <var>mapped entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this entry.
@@ -1267,9 +1260,9 @@ The algorithm:
 
     *  If the constructed set of Unicode code points is empty then, this [=EntryMapRecord=] is invalid skip it.
 
-    *  Add an [=patch map entries|entry=] to <var>entry list</var> which  maps to the generated URI, the patch format
+    *  Add an [=patch map entries|entry=] to <var>entry list</var> which  maps to the generated URL string, the patch format
         specified by [=Format 1 Patch Map/patchFormat=], and [=Format 1 Patch Map/compatibilityId=]; or if there is an existing
-        [=patch map entries|entry=] in <var>entry list</var> which has the same patch URI as the generated URI then
+        [=patch map entries|entry=] in <var>entry list</var> which has the same patch URL string as the generated URL string then
         instead modify the existing entry. Add the constructed set of Unicode code points and [=FeatureRecord/featureTag=] to the new or
         existing entry's subset definition.
 
@@ -1289,7 +1282,7 @@ The inputs to this algorithm are:
 
 * <var>patch map</var>: a [=Format 1 Patch Map=] encoded patch map. May be modified by this procedure.
 
-* <var>patch URI</var>: URI for a patch which identifies the entries to be removed.
+* <var>patch URL string</var>: URL string for a patch which identifies the entries to be removed.
 
 The algorithm:
 
@@ -1301,10 +1294,10 @@ The algorithm:
     *  If the bit for <var>entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this
         <var>entry index</var>.
 
-    *  Convert <var>entry index</var> into a URI by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
+    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#url-templates]].
         If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
-    *  If the generated URI is equal to <var>patch URI</var> then set the bit for <var>entry index</var> in
+    *  If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in
         [=Format 1 Patch Map/appliedEntriesBitMap=] to 1.
 
 ### Patch Map Table: Format 2 ### {#patch-map-format-2}
@@ -1337,7 +1330,7 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Format 2 Patch Map">defaultPatchFormat</dfn></td>
     <td>
-      Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
+      Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
       Must be set to one of the format numbers from the [[#font-patch-formats-summary]] table.
     </td>
   </tr>
@@ -1361,16 +1354,16 @@ The algorithm:
   </tr>
   <tr>
     <td>uint16</td>
-    <td>uriTemplateLength</td>
+    <td>urlTemplateLength</td>
     <td>
-      Length of the uriTemplate string.
+      Length of the urlTemplate string.
     </td>
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 2 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
+    <td><dfn for="Format 2 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
     <td>
-      A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URIs associated with each entry.
+      A [[!UTF-8]] encoded string. Contains a [[#url-templates]] which is used to produce URL strings associated with each entry.
       Must be a valid [[!UTF-8]] sequence.
     </td>
   </tr>
@@ -1583,7 +1576,7 @@ The algorithm:
          to the end of <var>patch map</var> if [=Format 2 Patch Map/entryIdStringData=] is non zero,
          <var>last entry id</var>,
          [=Format 2 Patch Map/defaultPatchFormat=], and
-         [=Format 2 Patch Map/uriTemplate=].
+         [=Format 2 Patch Map/urlTemplate=].
 
      *  Set <var>last entry id</var> to the returned entry id.
 
@@ -1612,7 +1605,7 @@ The inputs to this algorithm are:
 
 * <var>default patch format</var>: the default patch format if one isn't specified.
 
-* <var>uri template</var>: the URI template used to locate patches.
+* <var>url template</var>: the URL template used to locate patches.
 
 The algorithm outputs:
 
@@ -1673,10 +1666,10 @@ The algorithm:
          *  Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
              If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.
 
-         *  Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]].
+         *  Convert <var>entry id</var> into a URL string by applying <var>url template</var> following [[#url-templates]].
              If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
-         *  Add the generated patch URI to <var>entry</var>.
+         *  Add the generated patch URL string to <var>entry</var>.
 
          *  If the least significant bit of the read delta value is set, then repeat step 8.
 
@@ -1687,10 +1680,10 @@ The algorithm:
          *  Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
              Set <var>entry id</var> to the result.
 
-         *  Convert <var>entry id</var> into a URI by applying <var>uri template</var> following [[#uri-templates]].
+         *  Convert <var>entry id</var> into a URL string by applying <var>url template</var> following [[#url-templates]].
              If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
-         *  Add the generated patch URI to <var>entry</var>.
+         *  Add the generated patch URL string to <var>entry</var>.
 
          *  If the most significant bit of the read length value is set, then repeat step 8.
 
@@ -1729,13 +1722,13 @@ The inputs to this algorithm are:
 
 * <var>patch map</var>: a [=Format 2 Patch Map=] encoded patch map. May be modified by this procedure.
 
-* <var>patch URI</var>: URI for a patch which identifies the entries to be removed.
+* <var>patch URL string</var>: URL string for a patch which identifies the entries to be removed.
 
 This algorithm is a modified version of [$Interpret Format 2 Patch Map$], invoke [$Interpret Format 2 Patch Map$] with <var>patch map</var>
 as an input but with the following changes:
 
-*  During step 8 of [$Interpret Format 2 Patch Map Entry$]: compare the URI generated for only the first delta/length value to
-    <var>patch URI</var> if they are equal then, set bit 6 of  [=Mapping Entry/formatFlags=] to 1. Stop the interpretation process
+*  During step 8 of [$Interpret Format 2 Patch Map Entry$]: compare the URL string generated for only the first delta/length value to
+    <var>patch URL string</var> if they are equal then, set bit 6 of  [=Mapping Entry/formatFlags=] to 1. Stop the interpretation process
     at this point.
 
 *  The return value of [$Interpret Format 2 Patch Map$] is not used.
@@ -1910,10 +1903,13 @@ to give the smallest encodings for most unicode code point sets typically encoun
   ```
 </div>
 
-### URI Templates ### {#uri-templates}
+### URL Templates ### {#url-templates}
 
-URI templates [[!rfc6570]] are used to convert numeric or string IDs into URIs where patch files are located.
-A string ID is a sequence of bytes. Several variables are defined which are used to produce the expansion of the template:
+<!-- TODO(garretrieger): restrict this to only level 1 and update the examples as needed -->
+
+URL templates [[!rfc6570]] are used to convert numeric or string IDs into URL strings where patch files are located.
+A string ID is a sequence of bytes. The output of template expansion is a [[!UTF-8]] encoded string. Several variables
+are defined which are used to produce the expansion of the template:
 
 <table>
   <tr><th>Variable</th><th>Value</th></tr>
@@ -2349,7 +2345,7 @@ The inputs to this algorithm are:
 
 * <var>patch</var>: a [=glyph keyed patch=] to be applied to <var>base font subset</var>.
 
-* <var>patch uri</var>: the URI where the patch data is located.
+* <var>patch URL string</var>: the URL string where the patch data is located.
 
 * <var>compatibility id</var>: The compatibility ID from the 'IFT ' or 'IFTX' table of <var>base font subset</var> which listed this patch.
 
@@ -2402,9 +2398,9 @@ The algorithm:
     *  Insert the synthesized table into <var>extended font subset</var>.
 
 5. Locate the [[#patch-map-table]] which has the same [=Glyph keyed patch/compatibilityId=] as <var>compatibility id</var>. If it is a
-    format 1 patch map then, invoke [$Remove Entries from Format 1 Patch Map$] with the patch map table and <var>patch uri</var> as an
+    format 1 patch map then, invoke [$Remove Entries from Format 1 Patch Map$] with the patch map table and <var>patch URL string</var> as an
     input. Otherwise if it is a format 2 patch map then, invoke [$Remove Entries from Format 2 Patch Map$] with the patch map table and
-    <var>patch uri</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.
+    <var>patch URL string</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.
 
 6. For each [[open-type/otff#table-directory|table]] in <var>base font subset</var> which has a tag that was not found in any of
     the entries processed in step 4 or 5, add a copy of that table to <var>extended font subset</var>.
@@ -2802,10 +2798,10 @@ One security concern is that IFT fonts could potentially generate a large number
 problems on the client or the service hosting the patches. The IFT specification contains a couple of mitigations to limit excessive
 number of requests:
 
-1.  [[#extending-font-subset]]: disallows re-requesting the same URI multiple times and has limits on the total number of requests
+1.  [[#extending-font-subset]]: disallows re-requesting the same URL multiple times and has limits on the total number of requests
      that can be issued during the extension process.
 
-2.  [$Load patch file$]: specifies the use of [[fetch]] in implementing web browsers and matches the CORS settings for the initial
+2.  [$Load patch file$]: specifies the use of [[FETCH]] in implementing web browsers and matches the CORS settings for the initial
      font load. As a result cross-origin requests for patch files are disallowed unless the hosting service opts in via the appropriate
      access control headers.
 
@@ -2866,7 +2862,7 @@ they are defaulted to an empty set.
 
 <table>
   <tr><th>Table = "IFT "</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0001</th></tr>
-  <tr><th>Subset Definition</th><th>URI</th><th>Format Number</th>
+  <tr><th>Subset Definition</th><th>URL</th><th>Format Number</th>
   <tr>
     <td>
       ```
@@ -2930,7 +2926,7 @@ they are defaulted to an empty set.
 <br/>
 <table>
   <tr><th>Table = "IFTX"</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0002</th></tr>
-  <tr><th>Subset Definition</th><th>URI</th><th>Format Number</th>
+  <tr><th>Subset Definition</th><th>URL</th><th>Format Number</th>
   <tr>
     <td>
       ```
@@ -2992,7 +2988,7 @@ they are defaulted to an empty set.
 
 Note: this example execution is described as it would be implemented in an optimized client which aims to reduce the number of round trips needing to be
       made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but 
-      loads some URIs (the glyph keyed URIs) earlier than specified in the extension algorithm. This is allowed because these patches
+      loads some URLs (the glyph keyed URLs) earlier than specified in the extension algorithm. This is allowed because these patches
       will not be invalidated by the preceding table keyed patch.
 
 Inputs:
@@ -3030,7 +3026,7 @@ Iteration 1:
 
     <table>
       <tr><th>Table = "IFT "</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0006</th></tr>
-      <tr><th>Subset Definition</th><th>URI</th><th>Format Number</th>
+      <tr><th>Subset Definition</th><th>URL</th><th>Format Number</th>
       <tr>
         <td>
           ```
@@ -3047,7 +3043,7 @@ Iteration 1:
     Note the following changes:
     *  All entries that have data for 'a', ... 'z', and 'A', ..., 'Z' have been removed. Leaving just one entry for the remaining '0', ..., '9' code points.
     *  The font binary has changed and thus the previously listed table keyed patches are no longer valid. As a result the compatibility ID has changed and
-        the URI for the remaining '0', ..., '9' entry has changed. The patch at the new URI, //foo.bar/08.tk, is compatible with the updated font.
+        the URL for the remaining '0', ..., '9' entry has changed. The patch at the new URL, //foo.bar/08.tk, is compatible with the updated font.
 
 Iteration 2:
 
@@ -3063,7 +3059,7 @@ Iteration 2:
 
 *  Step 10 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'm'
     to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/01.gk. The compatibility ID
-    and URIs for other entries are unchanged.
+    and URLs for other entries are unchanged.
 
 Iteration 3:
 
@@ -3077,7 +3073,7 @@ Iteration 3:
 
 *  Step 10 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'N' through 'Z'
     to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/04.gk. The compatibility ID
-    and URIs for other entries are unchanged.
+    and URLs for other entries are unchanged.
 
 
 Iteration 4:
@@ -3099,7 +3095,7 @@ a subset definition they are defaulted to an empty set.
 
 <table>
   <tr><th>Table = "IFT "</th><th colspan="2">Compatibility ID = 0x0000_0000_0000_0001</th></tr>
-  <tr><th>Subset Definition</th><th>URI</th><th>Format Number</th><th>Ignored?</th><th>Notes</th>
+  <tr><th>Subset Definition</th><th>URL</th><th>Format Number</th><th>Ignored?</th><th>Notes</th>
   <tr>
     <td>
       ```

--- a/Overview.bs
+++ b/Overview.bs
@@ -422,8 +422,8 @@ code points, layout features and/or design space. This algorithm incrementally s
 them as needed. As an important optimization to minimize network round trips it permits loads to be started for all patches that will eventually
 be needed. These come in two forms:
 
-*  First, [=patch map|patch mapping entries=] may list more than one URI, where each URI after the first should also be loaded because they
-    will be needed in future iterations.
+*  First, [=patch map|patch mapping entries=] may list more than one URL string, where each URL string after the first should also be loaded
+    because they will be needed in future iterations.
 
 *  Second, [[#font-patch-invalidations]] is used to determine which patches loads can be started for. Any patches which match the target subset
     definition and will not be invalidated by the next patch to be applied according to [[#font-patch-invalidations]] can be expected to be
@@ -1034,14 +1034,14 @@ the encoded bytes at the start of every iteration to pick up any changes made in
   </tr>
   <tr>
     <td>uint16</td>
-    <td>urlTemplateLength</td>
+    <td>uriTemplateLength</td>
     <td>
-      Length of the urlTemplate string.
+      Length of the uriTemplate string.
     </td>
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
+    <td><dfn for="Format 1 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
     <td>
       A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URL strings associated with each entry.
       Must be a valid [[!UTF-8]] sequence.
@@ -1051,7 +1051,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td>uint8</td>
     <td><dfn for="Format 1 Patch Map">patchFormat</dfn></td>
     <td>
-      Specifies the format of the patches linked to by urlTemplate.
+      Specifies the format of the patches linked to by uriTemplate.
       Must be set to one of the format numbers from  the [[#font-patch-formats-summary]] table.
     </td>
   </tr>
@@ -1214,7 +1214,7 @@ The algorithm:
         [[open-type/cmap|cmap]] table of <var>font subset</var>. Ignore any glyph indices that are not mapped by [[open-type/cmap|cmap]].
         Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.
 
-    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#uri-templates]]. If
+    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]]. If
         the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
@@ -1241,7 +1241,7 @@ The algorithm:
     *  If [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] is greater than
         [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
 
-    *  Convert <var>mapped entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#uri-templates]].
+    *  Convert <var>mapped entry index</var> into a URL string by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
         If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the bit for <var>mapped entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this entry.
@@ -1293,7 +1293,7 @@ The algorithm:
     *  If the bit for <var>entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this
         <var>entry index</var>.
 
-    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/urlTemplate=] following [[#uri-templates]].
+    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
         If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
 
     *  If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in
@@ -1329,7 +1329,7 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Format 2 Patch Map">defaultPatchFormat</dfn></td>
     <td>
-      Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
+      Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
       Must be set to one of the format numbers from the [[#font-patch-formats-summary]] table.
     </td>
   </tr>
@@ -1353,14 +1353,14 @@ The algorithm:
   </tr>
   <tr>
     <td>uint16</td>
-    <td>urlTemplateLength</td>
+    <td>uriTemplateLength</td>
     <td>
-      Length of the urlTemplate string.
+      Length of the uriTemplate string.
     </td>
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 2 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
+    <td><dfn for="Format 2 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
     <td>
       A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URL strings associated with each entry.
       Must be a valid [[!UTF-8]] sequence.
@@ -1452,7 +1452,7 @@ The algorithm:
     <td>int24</td>
     <td><dfn for="Mapping Entry">entryIdDelta</dfn>[variable]</td>
     <td>
-      List of signed deltas which calculate the IDs of the URIs for this entry. If present, has at least one delta. If the least
+      List of signed deltas which calculate the IDs of the URL strings for this entry. If present, has at least one delta. If the least
       significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
       cleared is encountered. The entry id for each delta is the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if
       [=Mapping Entry/formatFlags=] bit 2 is set and [=Format 2 Patch Map/entryIdStringData=] is null (0).
@@ -1575,7 +1575,7 @@ The algorithm:
          to the end of <var>patch map</var> if [=Format 2 Patch Map/entryIdStringData=] is non zero,
          <var>last entry id</var>,
          [=Format 2 Patch Map/defaultPatchFormat=], and
-         [=Format 2 Patch Map/urlTemplate=].
+         [=Format 2 Patch Map/uriTemplate=].
 
      *  Set <var>last entry id</var> to the returned entry id.
 

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="9bfc55dc2c35b2244f08838241b4a2d0d7c49c0a" name="revision">
+  <meta content="449ee2b392835f2256cc8febefea2ea936584add" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1193,8 +1193,8 @@ them as needed. As an important optimization to minimize network round trips it 
 be needed. These come in two forms:</p>
    <ul>
     <li data-md>
-     <p>First, <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①">patch mapping entries</a> may list more than one URI, where each URI after the first should also be loaded because they
-will be needed in future iterations.</p>
+     <p>First, <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①">patch mapping entries</a> may list more than one URL string, where each URL string after the first should also be loaded
+because they will be needed in future iterations.</p>
     <li data-md>
      <p>Second, <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> is used to determine which patches loads can be started for. Any patches which match the target subset
 definition and will not be invalidated by the next patch to be applied according to <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> can be expected to be
@@ -1706,17 +1706,17 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       the most significant bit. Bit 8 is the least significant bit of appliedEntriesBitMap[1] and so on. 
      <tr>
       <td>uint16
-      <td>urlTemplateLength
-      <td> Length of the urlTemplate string. 
+      <td>uriTemplateLength
+      <td> Length of the uriTemplate string. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
       <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.3.3 URI Templates</a> which is used to produce URL strings associated with each entry.
       Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchformat">patchFormat</dfn>
-      <td> Specifies the format of the patches linked to by urlTemplate.
+      <td> Specifies the format of the patches linked to by uriTemplate.
       Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
    </table>
    <p class="note" role="note"><span class="marker">Note:</span> <a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> is designed to be compatible with the
@@ -1842,7 +1842,7 @@ index and do not build an entry for it.</p>
        <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
 Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>. If
+       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate">uriTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>. If
 the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
@@ -1863,7 +1863,7 @@ skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigne
       <li data-md>
        <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
       <li data-md>
-       <p>Convert <var>mapped entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
+       <p>Convert <var>mapped entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
 If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this entry.</p>
@@ -1911,7 +1911,7 @@ change the number of bytes.</p>
       <li data-md>
        <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
+       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate②">uriTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
 If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
@@ -1941,7 +1941,7 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchformat">defaultPatchFormat</dfn>
-      <td> Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
+      <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
       Must be set to one of the format numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
      <tr>
       <td>uint24
@@ -1958,11 +1958,11 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
       May be null (0). Offset is from the start of this table. 
      <tr>
       <td>uint16
-      <td>urlTemplateLength
-      <td> Length of the urlTemplate string. 
+      <td>uriTemplateLength
+      <td> Length of the uriTemplate string. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
       <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.3.3 URI Templates</a> which is used to produce URL strings associated with each entry.
       Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
    </table>
@@ -2022,7 +2022,7 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
      <tr>
       <td>int24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>[variable]
-      <td> List of signed deltas which calculate the IDs of the URIs for this entry. If present, has at least one delta. If the least
+      <td> List of signed deltas which calculate the IDs of the URL strings for this entry. If present, has at least one delta. If the least
       significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
       cleared is encountered. The entry id for each delta is the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0).
       If not present and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata①">entryIdStringData</a> is null (0), then there is one id for this entry and the
@@ -2108,7 +2108,7 @@ being requested.</p>
        <p>pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
  the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑥">entryIdStringData</a>[<var>current id string byte</var>]
- to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-urltemplate" id="ref-for-format-2-patch-map-urltemplate">urlTemplate</a>.</p>
+ to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
@@ -3919,10 +3919,10 @@ content covered by the target subset definition.</p>
      <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
    <li>
-    urlTemplate
+    uriTemplate
     <ul>
-     <li><a href="#format-1-patch-map-urltemplate">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#format-2-patch-map-urltemplate">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
+     <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
+     <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -4210,7 +4210,7 @@ let dfnPanelData = {
 "format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.3.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
 "format-1-patch-map-maxglyphmapentryindex": {"dfnID":"format-1-patch-map-maxglyphmapentryindex","dfnText":"maxGlyphMapEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2461"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxglyphmapentryindex"},
 "format-1-patch-map-patchformat": {"dfnID":"format-1-patch-map-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchformat"},{"id":"ref-for-format-1-patch-map-patchformat\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchformat"},
-"format-1-patch-map-urltemplate": {"dfnID":"format-1-patch-map-urltemplate","dfnText":"urlTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-urltemplate"},{"id":"ref-for-format-1-patch-map-urltemplate\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-urltemplate\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-urltemplate"},
+"format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
 "format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.3.2.2. Remove Entries from Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2461"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#format-2-patch-map"},
 "format-2-patch-map-compatibilityid": {"dfnID":"format-2-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-compatibilityid"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-compatibilityid"},
 "format-2-patch-map-defaultpatchformat": {"dfnID":"format-2-patch-map-defaultpatchformat","dfnText":"defaultPatchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-defaultpatchformat"},
@@ -4218,7 +4218,7 @@ let dfnPanelData = {
 "format-2-patch-map-entrycount": {"dfnID":"format-2-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entrycount"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entrycount\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entrycount"},
 "format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2465"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2466"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
 "format-2-patch-map-format": {"dfnID":"format-2-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-format"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-format"},
-"format-2-patch-map-urltemplate": {"dfnID":"format-2-patch-map-urltemplate","dfnText":"urlTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-urltemplate"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-urltemplate"},
+"format-2-patch-map-uritemplate": {"dfnID":"format-2-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-uritemplate"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-uritemplate"},
 "full-invalidation": {"dfnID":"full-invalidation","dfnText":"Full Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-full-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-full-invalidation\u2460"}],"title":"6.1. Formats Summary"}],"url":"#full-invalidation"},
 "glyph-closure": {"dfnID":"glyph-closure","dfnText":"glyph closure","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-closure"}],"title":"7.1. Encoding Considerations"}],"url":"#glyph-closure"},
 "glyph-keyed-patch": {"dfnID":"glyph-keyed-patch","dfnText":"Glyph keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch"},
@@ -4691,7 +4691,7 @@ let refsData = {
 "#format-1-patch-map-maxentryindex": {"displayText":"maxentryindex","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxentryindex","type":"dfn","url":"#format-1-patch-map-maxentryindex"},
 "#format-1-patch-map-maxglyphmapentryindex": {"displayText":"maxglyphmapentryindex","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxglyphmapentryindex","type":"dfn","url":"#format-1-patch-map-maxglyphmapentryindex"},
 "#format-1-patch-map-patchformat": {"displayText":"patchformat","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchformat","type":"dfn","url":"#format-1-patch-map-patchformat"},
-"#format-1-patch-map-urltemplate": {"displayText":"urltemplate","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"urltemplate","type":"dfn","url":"#format-1-patch-map-urltemplate"},
+"#format-1-patch-map-uritemplate": {"displayText":"uritemplate","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-1-patch-map-uritemplate"},
 "#format-2-patch-map": {"displayText":"format 2 patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 2 patch map","type":"dfn","url":"#format-2-patch-map"},
 "#format-2-patch-map-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#format-2-patch-map-compatibilityid"},
 "#format-2-patch-map-defaultpatchformat": {"displayText":"defaultpatchformat","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"defaultpatchformat","type":"dfn","url":"#format-2-patch-map-defaultpatchformat"},
@@ -4699,7 +4699,7 @@ let refsData = {
 "#format-2-patch-map-entrycount": {"displayText":"entrycount","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrycount","type":"dfn","url":"#format-2-patch-map-entrycount"},
 "#format-2-patch-map-entryidstringdata": {"displayText":"entryidstringdata","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entryidstringdata","type":"dfn","url":"#format-2-patch-map-entryidstringdata"},
 "#format-2-patch-map-format": {"displayText":"format","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#format-2-patch-map-format"},
-"#format-2-patch-map-urltemplate": {"displayText":"urltemplate","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"urltemplate","type":"dfn","url":"#format-2-patch-map-urltemplate"},
+"#format-2-patch-map-uritemplate": {"displayText":"uritemplate","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-2-patch-map-uritemplate"},
 "#full-invalidation": {"displayText":"full invalidation","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"full invalidation","type":"dfn","url":"#full-invalidation"},
 "#glyph-closure": {"displayText":"glyph closure","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyph closure","type":"dfn","url":"#glyph-closure"},
 "#glyph-keyed-patch": {"displayText":"glyph keyed patch","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyph keyed patch","type":"dfn","url":"#glyph-keyed-patch"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="61233ba8e96a3bed1310f05f20782e5e7dd2446e" name="revision">
+  <meta content="9bfc55dc2c35b2244f08838241b4a2d0d7c49c0a" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2435,9 +2435,9 @@ byte string:
    <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URL strings where patch files are located.
 A string ID is a sequence of bytes. The output of template expansion is a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string.</p>
    <p>To limit the complexity of the template expansion implementation, URI templates in IFT are restricted to only <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.2">Level 1</a> substitution expressions. If a URI template contains expression(s) which do not match the level
-1 grammar (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-2.2">URI Template § section-2.2</a>), then template expansion must result in an error. Additionally, for consistency when
-producing percent encodings as part of template expansion (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3.1">URI Template § section-3.1</a>) IFT implementations must only use uppercase
-letters.</p>
+1 grammar (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-2.2">URI Template § section-2.2</a>) or have variable names other than those defined below, then template expansion must result
+in an error. Additionally, for consistency when producing percent encodings as part of template expansion
+(<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3.1">URI Template § section-3.1</a>) IFT implementations must only use uppercase letters.</p>
    <p>Several variables are defined which are used to produce the expansion of the template:</p>
    <table>
     <tbody>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="8108f4b43a3fa6f7c3d6fd95a598a294822a4055" name="revision">
+  <meta content="32f7e9c3709731a55922172d934a735a43cd8eef" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -871,7 +871,7 @@ to complex scripts like Indic or Arabic.</p>
           <li><a href="#remove-entries-format-2"><span class="secno">5.3.2.2</span> <span class="content">Remove Entries from Format 2</span></a>
           <li><a href="#sparse-bit-set-decoding"><span class="secno">5.3.2.3</span> <span class="content">Sparse Bit Set</span></a>
          </ol>
-        <li><a href="#uri-templates"><span class="secno">5.3.3</span> <span class="content">URI Templates</span></a>
+        <li><a href="#url-templates"><span class="secno">5.3.3</span> <span class="content">URL Templates</span></a>
        </ol>
      </ol>
     <li>
@@ -1078,8 +1078,8 @@ if the font does not support any code points which are needed.</p>
    <p class="note" role="note"><span class="marker">Note:</span> Each individual <code>@font-face</code> block may or may not opt-in to IFT. This is due to the
 variety of ways fonts are used on web pages. Authors have control over which fonts they want to use
 this technology with, and which they do not.</p>
-   <p class="note" role="note"><span class="marker">Note:</span> the IFT tech keyword can be used in conjunction with other font tech specifiers to perform
-font feature selection. For example a <code>@font-face</code> could include two URIs one with <code>tech(incremental, color-COLRv1)</code> and the other with <code>tech(incremental, color-COLRv0)</code>.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> the IFT tech keyword can be used in conjunction with other font tech specifiers to perform</p>
+   <p>font feature selection. For example a <code>@font-face</code> could include two URLs one with <code>tech(incremental, color-COLRv1)</code> and the other with <code>tech(incremental, color-COLRv0)</code>.</p>
    <h3 class="heading settled" data-level="2.1" id="offline-usage"><span class="secno">2.1. </span><span class="content">Offline Usage</span><a class="self-link" href="#offline-usage"></a></h3>
    <p>In some cases a user agent may wish to save a web page for offline use. Saved pages may be viewed while there is no network connection
 and thus it won’t be possible to request any additional patches referenced by an incremental font. Since it won’t be possible extend
@@ -1111,7 +1111,7 @@ an existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset�
 changes encoded according to the format is a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Each <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
    <h3 class="heading settled" data-level="3.3" id="patch-map-dfn"><span class="secno">3.3. </span><span class="content">Patch Map</span><a class="self-link" href="#patch-map-dfn"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map">patch map</dfn> is an <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">open type table</a> which encodes a collection of
-mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URIs which host <a href="#font-patch-formats">patches</a> that
+mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URLs which host <a href="#font-patch-formats">patches</a> that
 extend the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①">incremental font</a>. A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map">patch map</a> table encodes a list of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map-entries">patch map entries</dfn>, where each
 entry has a key and value.  The key of an entry defines the coverage of the entry, which is information on what subset
 definitions will match it. The value specifies information about the patches which should be applied when the entry is
@@ -1134,7 +1134,7 @@ matched. <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map
       <td>
        <ul>
         <li data-md>
-         <p>One or more Patch URIs</p>
+         <p>One or more Patch <a data-link-type="biblio" href="#biblio-whatwg-url" title="URL Standard">URL</a> strings</p>
         <li data-md>
          <p><a href="#font-patch-formats">Patch Format</a></p>
         <li data-md>
@@ -1206,7 +1206,7 @@ needed in future iterations.</p>
     <li data-md>
      <p><var>font subset</var>: an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font④">incremental</a> <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset⑧">font subset</a>.</p>
     <li data-md>
-     <p><var>initial font subset URI</var>: an <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">absolute URI</a> which identifies the location of the initial incremental
+     <p><var>initial font URL</var>: a <a href="https://url.spec.whatwg.org/#concept-url">URL</a> which identifies the location of the initial incremental
 font that <var>font subset</var> was derived from.</p>
     <li data-md>
      <p><var>target subset definition</var>: the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition③">font subset definition</a> that the client wants to extend <var>font subset</var> to cover.</p>
@@ -1232,7 +1232,7 @@ not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-
 invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a> or <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a>. Concatenate the returned entry lists into a single list, <var>entry list</var>.</p>
     <li data-md>
      <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection">Check entry intersection</a> with <var>entry</var> and <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var> from <var>entry list</var>. Additionally remove
-any entries in <var>entry list</var> which have a patch URI which was loaded and applied previously during the execution of this algorithm.</p>
+any entries in <var>entry list</var> which have a patch URL string which was loaded and applied previously during the execution of this algorithm.</p>
     <li data-md>
      <p>If <var>entry list</var> is empty, then the extension operation is finished, return <var>extended font subset</var>.</p>
     <li data-md>
@@ -1250,8 +1250,7 @@ Follow the criteria in <a href="#invalidating-patch-selection">§ 4.4 Selectin
 The criteria for selecting the single entry is left up to the implementation to decide.</p>
      </ul>
     <li data-md>
-     <p>Start a load of <var>patch file</var> (if not already previously started) by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>initial font subset URI</var> as the initial font URI and the first patch URI in <var>entry</var> as the patch URI. If there are any other URIs in <var>entry</var>, then initiate
-loads for those using the same procedure. These may be used during future iterations of this algorithm.
+     <p>Start a load of <var>patch file</var> (if not already previously started) by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>initial font URL</var> as the initial font URL and the first patch URL string in <var>entry</var> as the patch URL string. If there are any other URL strings in <var>entry</var>, then initiate loads for those using the same procedure. These may be used during future iterations of this algorithm.
 Additionally the client may optionally start loads using the same procedure for any entries in <var>entry list</var> which will not be <a href="#font-patch-invalidations">invalidated</a> by <var>entry</var>. The total number of patches that a client can load and apply during a single execution
 of this algorithm is limited to:</p>
      <ul>
@@ -1262,7 +1261,7 @@ of this algorithm is limited to:</p>
      </ul>
      <p>Can be loaded and applied during a single invocation of this algorithm. If either count has been exceeded this is an error invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors②">Handle errors</a>.</p>
     <li data-md>
-     <p>Once the load for <var>patch file</var> is finished, apply it using the appropriate application algorithm (matching the patches format in <var>entry</var>) from <a href="#font-patch-formats">§ 6 Font Patch Formats</a> to apply the <var>patch file</var> using the patch URI and the compatibility id from <var>entry</var> to <var>extended font subset</var>.</p>
+     <p>Once the load for <var>patch file</var> is finished, apply it using the appropriate application algorithm (matching the patches format in <var>entry</var>) from <a href="#font-patch-formats">§ 6 Font Patch Formats</a> to apply the <var>patch file</var> using the patch URL string and the compatibility id from <var>entry</var> to <var>extended font subset</var>.</p>
     <li data-md>
      <p>Go to step 2.</p>
    </ol>
@@ -1419,24 +1418,23 @@ match mode: conjunctive,
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>Patch URI</var>: A <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.1">URI Reference</a> identifying the patch file to load. As a URI reference this may be a
- relative path.</p>
+     <p><var>patch URL string</var>: A <a data-link-type="biblio" href="#biblio-whatwg-url" title="URL Standard">URL</a> string (<a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded) identifying the patch file to load. It  may be a <a href="https://url.spec.whatwg.org/#relative-url-string">relative</a> URL.</p>
     <li data-md>
-     <p><var>Initial Font URI</var>: An <a href="https://www.rfc-editor.org/rfc/rfc3986#section-4.3">absolute URI</a> which identifies the initial incremental font that the
- patch URI was derived from.</p>
+     <p><var>initial font URL</var>: a <a href="https://url.spec.whatwg.org/#concept-url">URL</a> which identifies the location of the initial incremental
+font that <var>font subset</var> was derived from.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>patch file</var>: the content (bytes) identified by <var>Patch URI</var>.</p>
+     <p><var>patch file</var>: the content (bytes) identified by <var>patch URL string</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Perform <a href="https://www.rfc-editor.org/rfc/rfc3986#section-5">reference resolution</a> on <var>Patch URI</var> using <var>Initial Font URI</var> as the base URI to
- produce the <var>target URI</var>.</p>
+     <p>Parse <var>patch URL string</var> into a <a href="https://url.spec.whatwg.org/#concept-url">URL Record</a> using <a href="https://url.spec.whatwg.org/#url-parsing">URL Standard § url-parsing</a>. <var>initial font URL</var> is the <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> and encoding is UTF-8. Store the result
+ in <var>target URL</var>.</p>
     <li data-md>
-     <p>Retrieve the contents of <var>target URI</var> using the fetching capabilities of the implementing user agent. For web browsers, <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[fetch]</a> should be used. When using <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[fetch]</a> a request for patches should use the same CORS settings as the initial request for
+     <p>Retrieve the contents of <var>target URL</var> using the fetching capabilities of the implementing user agent. For web browsers, <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a> should be used. When using <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a> a request for patches should use the same CORS settings as the initial request for
  the IFT font. This means that for a font loaded via CSS the patch request would follow: <a href="https://www.w3.org/TR/css-fonts-4/#font-fetching-requirements"><cite>CSS Fonts 4</cite> § 4.8.2 Font fetching requirements</a>.</p>
     <li data-md>
      <p>Return the retrieved contents as <var>patch file</var>, or an error if the fetch resulted in an error.</p>
@@ -1646,7 +1644,7 @@ to the specific needs of IFT.</p>
    <p>A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑤">patch map</a> is encoded in one of two formats:</p>
    <ul>
     <li data-md>
-     <p>Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URIs. It does
+     <p>Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URL strings. It does
 not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑥">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
     <li data-md>
      <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
@@ -1708,17 +1706,17 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       the most significant bit. Bit 8 is the least significant bit of appliedEntriesBitMap[1] and so on. 
      <tr>
       <td>uint16
-      <td>uriTemplateLength
-      <td> Length of the uriTemplate string. 
+      <td>urlTemplateLength
+      <td> Length of the urlTemplate string. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.3.3 URI Templates</a> which is used to produce URIs associated with each entry.
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#url-templates">§ 5.3.3 URL Templates</a> which is used to produce URL strings associated with each entry.
       Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchformat">patchFormat</dfn>
-      <td> Specifies the format of the patches linked to by uriTemplate.
+      <td> Specifies the format of the patches linked to by urlTemplate.
       Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
    </table>
    <p class="note" role="note"><span class="marker">Note:</span> <a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> is designed to be compatible with the
@@ -1844,13 +1842,13 @@ index and do not build an entry for it.</p>
        <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
 Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate">uriTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>. If
+       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a> following <a href="#url-templates">§ 5.3.3 URL Templates</a>. If
 the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
       <li data-md>
        <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">entry</a> to <var>entry list</var> with a subset definition which contains only the Unicode code point
-set and maps to the generated URI, the patch format specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
+set and maps to the generated URL string, the patch format specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#format-1-patch-map-featuremapoffset" id="ref-for-format-1-patch-map-featuremapoffset">featureMapOffset</a> is not null then, for each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords②">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
@@ -1865,7 +1863,7 @@ skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigne
       <li data-md>
        <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
       <li data-md>
-       <p>Convert <var>mapped entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
+       <p>Convert <var>mapped entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a> following <a href="#url-templates">§ 5.3.3 URL Templates</a>.
 If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this entry.</p>
@@ -1882,8 +1880,8 @@ associated code points as if it wasn’t skipped.</p>
       <li data-md>
        <p>If the constructed set of Unicode code points is empty then, this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑧">EntryMapRecord</a> is invalid skip it.</p>
       <li data-md>
-       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> to <var>entry list</var> which  maps to the generated URI, the patch format
-specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat①">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> in <var>entry list</var> which has the same patch URI as the generated URI then
+       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> to <var>entry list</var> which  maps to the generated URL string, the patch format
+specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat①">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> in <var>entry list</var> which has the same patch URL string as the generated URL string then
 instead modify the existing entry. Add the constructed set of Unicode code points and <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag③">featureTag</a> to the new or
 existing entry’s subset definition.</p>
      </ul>
@@ -1901,7 +1899,7 @@ change the number of bytes.</p>
     <li data-md>
      <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-1-patch-map" id="ref-for-format-1-patch-map①">Format 1 Patch Map</a> encoded patch map. May be modified by this procedure.</p>
     <li data-md>
-     <p><var>patch URI</var>: URI for a patch which identifies the entries to be removed.</p>
+     <p><var>patch URL string</var>: URL string for a patch which identifies the entries to be removed.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -1913,10 +1911,10 @@ change the number of bytes.</p>
       <li data-md>
        <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URI by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate②">uriTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
+       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a> following <a href="#url-templates">§ 5.3.3 URL Templates</a>.
 If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
-       <p>If the generated URI is equal to <var>patch URI</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
+       <p>If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
      </ul>
    </ol>
    <h4 class="heading settled" data-level="5.3.2" id="patch-map-format-2"><span class="secno">5.3.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
@@ -1943,7 +1941,7 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchformat">defaultPatchFormat</dfn>
-      <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
+      <td> Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
       Must be set to one of the format numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
      <tr>
       <td>uint24
@@ -1960,12 +1958,12 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
       May be null (0). Offset is from the start of this table. 
      <tr>
       <td>uint16
-      <td>uriTemplateLength
-      <td> Length of the uriTemplate string. 
+      <td>urlTemplateLength
+      <td> Length of the urlTemplate string. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.3.3 URI Templates</a> which is used to produce URIs associated with each entry.
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#url-templates">§ 5.3.3 URL Templates</a> which is used to produce URL strings associated with each entry.
       Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entries">Mapping Entries</dfn> encoding:</p>
@@ -2110,7 +2108,7 @@ being requested.</p>
        <p>pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
  the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑥">entryIdStringData</a>[<var>current id string byte</var>]
- to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
+ to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-urltemplate" id="ref-for-format-2-patch-map-urltemplate">urlTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
@@ -2139,7 +2137,7 @@ being requested.</p>
     <li data-md>
      <p><var>default patch format</var>: the default patch format if one isn’t specified.</p>
     <li data-md>
-     <p><var>uri template</var>: the URI template used to locate patches.</p>
+     <p><var>url template</var>: the URL template used to locate patches.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -2203,10 +2201,10 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
  If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
+         <p>Convert <var>entry id</var> into a URL string by applying <var>url template</var> following <a href="#url-templates">§ 5.3.3 URL Templates</a>.
  If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
         <li data-md>
-         <p>Add the generated patch URI to <var>entry</var>.</p>
+         <p>Add the generated patch URL string to <var>entry</var>.</p>
         <li data-md>
          <p>If the least significant bit of the read delta value is set, then repeat step 8.</p>
        </ul>
@@ -2219,10 +2217,10 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
  Set <var>entry id</var> to the result.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URI by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
+         <p>Convert <var>entry id</var> into a URL string by applying <var>url template</var> following <a href="#url-templates">§ 5.3.3 URL Templates</a>.
  If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
         <li data-md>
-         <p>Add the generated patch URI to <var>entry</var>.</p>
+         <p>Add the generated patch URL string to <var>entry</var>.</p>
         <li data-md>
          <p>If the most significant bit of the read length value is set, then repeat step 8.</p>
        </ul>
@@ -2261,12 +2259,12 @@ change the number of bytes.</p>
     <li data-md>
      <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map①">Format 2 Patch Map</a> encoded patch map. May be modified by this procedure.</p>
     <li data-md>
-     <p><var>patch URI</var>: URI for a patch which identifies the entries to be removed.</p>
+     <p><var>patch URL string</var>: URL string for a patch which identifies the entries to be removed.</p>
    </ul>
    <p>This algorithm is a modified version of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map①">Interpret Format 2 Patch Map</a>, invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map②">Interpret Format 2 Patch Map</a> with <var>patch map</var> as an input but with the following changes:</p>
    <ul>
     <li data-md>
-     <p>During step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry②">Interpret Format 2 Patch Map Entry</a>: compare the URI generated for only the first delta/length value to <var>patch URI</var> if they are equal then, set bit 6 of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑨">formatFlags</a> to 1. Stop the interpretation process
+     <p>During step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry②">Interpret Format 2 Patch Map Entry</a>: compare the URL string generated for only the first delta/length value to <var>patch URL string</var> if they are equal then, set bit 6 of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑨">formatFlags</a> to 1. Stop the interpretation process
 at this point.</p>
     <li data-md>
      <p>The return value of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map③">Interpret Format 2 Patch Map</a> is not used.</p>
@@ -2433,9 +2431,10 @@ byte string:
 ]
 </pre>
    </div>
-   <h4 class="heading settled" data-level="5.3.3" id="uri-templates"><span class="secno">5.3.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h4>
-   <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URIs where patch files are located.
-A string ID is a sequence of bytes. Several variables are defined which are used to produce the expansion of the template:</p>
+   <h4 class="heading settled" data-level="5.3.3" id="url-templates"><span class="secno">5.3.3. </span><span class="content">URL Templates</span><a class="self-link" href="#url-templates"></a></h4>
+   <p>URL templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URL strings where patch files are located.
+A string ID is a sequence of bytes. The output of template expansion is a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Several variables
+are defined which are used to produce the expansion of the template:</p>
    <table>
     <tbody>
      <tr>
@@ -2777,7 +2776,7 @@ features, and/or design-variation space.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#glyph-keyed-patch" id="ref-for-glyph-keyed-patch">glyph keyed patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
-     <p><var>patch uri</var>: the URI where the patch data is located.</p>
+     <p><var>patch URL string</var>: the URL string where the patch data is located.</p>
     <li data-md>
      <p><var>compatibility id</var>: The compatibility ID from the 'IFT ' or 'IFTX' table of <var>base font subset</var> which listed this patch.</p>
    </ul>
@@ -2827,8 +2826,8 @@ failed. Return an error.</p>
      </ul>
     <li data-md>
      <p>Locate the <a href="#patch-map-table">§ 5.3 Patch Map Table</a> which has the same <a data-link-type="dfn" href="#glyph-keyed-patch-compatibilityid" id="ref-for-glyph-keyed-patch-compatibilityid①">compatibilityId</a> as <var>compatibility id</var>. If it is a
-format 1 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-1-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a> with the patch map table and <var>patch uri</var> as an
-input. Otherwise if it is a format 2 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-2-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a> with the patch map table and <var>patch uri</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.</p>
+format 1 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-1-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a> with the patch map table and <var>patch URL string</var> as an
+input. Otherwise if it is a format 2 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-2-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a> with the patch map table and <var>patch URL string</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.</p>
     <li data-md>
      <p>For each <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> in <var>base font subset</var> which has a tag that was not found in any of
 the entries processed in step 4 or 5, add a copy of that table to <var>extended font subset</var>.</p>
@@ -3160,10 +3159,10 @@ problems on the client or the service hosting the patches. The IFT specification
 number of requests:</p>
    <ol>
     <li data-md>
-     <p><a href="#extending-font-subset">§ 4 Extending a Font Subset</a>: disallows re-requesting the same URI multiple times and has limits on the total number of requests
+     <p><a href="#extending-font-subset">§ 4 Extending a Font Subset</a>: disallows re-requesting the same URL multiple times and has limits on the total number of requests
  that can be issued during the extension process.</p>
     <li data-md>
-     <p><a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file②">Load patch file</a>: specifies the use of <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[fetch]</a> in implementing web browsers and matches the CORS settings for the initial
+     <p><a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file②">Load patch file</a>: specifies the use of <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a> in implementing web browsers and matches the CORS settings for the initial
  font load. As a result cross-origin requests for patch files are disallowed unless the hosting service opts in via the appropriate
  access control headers.</p>
    </ol>
@@ -3410,7 +3409,7 @@ they are defaulted to an empty set.</p>
       <th colspan="2">Compatibility ID = 0x0000_0000_0000_0001
      <tr>
       <th>Subset Definition
-      <th>URI
+      <th>URL
       <th>Format Number
      <tr>
       <td>
@@ -3454,7 +3453,7 @@ they are defaulted to an empty set.</p>
       <th colspan="2">Compatibility ID = 0x0000_0000_0000_0002
      <tr>
       <th>Subset Definition
-      <th>URI
+      <th>URL
       <th>Format Number
      <tr>
       <td>
@@ -3490,7 +3489,7 @@ they are defaulted to an empty set.</p>
    <p><b>Optimized Extension Example</b></p>
    <p class="note" role="note"><span class="marker">Note:</span> this example execution is described as it would be implemented in an optimized client which aims to reduce the number of round trips needing to be
       made to extend the font for a target subset definition. This optimized execution is fully compliant with the extension algorithm but 
-      loads some URIs (the glyph keyed URIs) earlier than specified in the extension algorithm. This is allowed because these patches
+      loads some URLs (the glyph keyed URLs) earlier than specified in the extension algorithm. This is allowed because these patches
       will not be invalidated by the preceding table keyed patch.</p>
    <p>Inputs:</p>
    <ul>
@@ -3547,7 +3546,7 @@ to add support for code points 'a' through 'Z'. Additionally the mapping in the 
         <th colspan="2">Compatibility ID = 0x0000_0000_0000_0006
        <tr>
         <th>Subset Definition
-        <th>URI
+        <th>URL
         <th>Format Number
        <tr>
         <td>
@@ -3562,7 +3561,7 @@ to add support for code points 'a' through 'Z'. Additionally the mapping in the 
        <p>All entries that have data for 'a', ... 'z', and 'A', ..., 'Z' have been removed. Leaving just one entry for the remaining '0', ..., '9' code points.</p>
       <li data-md>
        <p>The font binary has changed and thus the previously listed table keyed patches are no longer valid. As a result the compatibility ID has changed and
-the URI for the remaining '0', ..., '9' entry has changed. The patch at the new URI, //foo.bar/08.tk, is compatible with the updated font.</p>
+the URL for the remaining '0', ..., '9' entry has changed. The patch at the new URL, //foo.bar/08.tk, is compatible with the updated font.</p>
      </ul>
    </ul>
    <p>Iteration 2:</p>
@@ -3584,7 +3583,7 @@ the first one //foo.bar/01.gk.</p>
     <li data-md>
      <p>Step 10 - The fetched patch //foo.bar/01.gk is applied to the current font subset. This patch adds glyph data for code points 'a' through 'm'
 to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/01.gk. The compatibility ID
-and URIs for other entries are unchanged.</p>
+and URLs for other entries are unchanged.</p>
    </ul>
    <p>Iteration 3:</p>
    <ul>
@@ -3602,7 +3601,7 @@ entries intersect:</p>
     <li data-md>
      <p>Step 10 - The fetched patch //foo.bar/04.gk is applied to the current font subset. This patch adds glyph data for code points 'N' through 'Z'
 to the glyf and loca tables. Additionally the mapping in the "IFTX" table is updated to removed the entry for //foo.bar/04.gk. The compatibility ID
-and URIs for other entries are unchanged.</p>
+and URLs for other entries are unchanged.</p>
    </ul>
    <p>Iteration 4:</p>
    <ul>
@@ -3624,7 +3623,7 @@ a subset definition they are defaulted to an empty set.</p>
       <th colspan="2">Compatibility ID = 0x0000_0000_0000_0001
      <tr>
       <th>Subset Definition
-      <th>URI
+      <th>URL
       <th>Format Number
       <th>Ignored?
       <th>Notes
@@ -3918,10 +3917,10 @@ content covered by the target subset definition.</p>
      <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
    <li>
-    uriTemplate
+    urlTemplate
     <ul>
-     <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
+     <li><a href="#format-1-patch-map-urltemplate">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
+     <li><a href="#format-2-patch-map-urltemplate">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -3937,8 +3936,6 @@ content covered by the target subset definition.</p>
    <dd>Chris Lilley. <a href="https://www.w3.org/TR/PFE-evaluation/"><cite>Progressive Font Enrichment: Evaluation Report</cite></a>. 15 October 2020. Note. URL: <a href="https://www.w3.org/TR/PFE-evaluation/">https://www.w3.org/TR/PFE-evaluation/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
-   <dt id="biblio-rfc3986">[RFC3986]
-   <dd>T. Berners-Lee; R. Fielding; L. Masinter. <a href="https://www.rfc-editor.org/rfc/rfc3986"><cite>Uniform Resource Identifier (URI): Generic Syntax</cite></a>. January 2005. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3986">https://www.rfc-editor.org/rfc/rfc3986</a>
    <dt id="biblio-rfc4648">[RFC4648]
    <dd>S. Josefsson. <a href="https://www.rfc-editor.org/rfc/rfc4648"><cite>The Base16, Base32, and Base64 Data Encodings</cite></a>. October 2006. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc4648">https://www.rfc-editor.org/rfc/rfc4648</a>
    <dt id="biblio-rfc6570">[RFC6570]
@@ -3951,6 +3948,8 @@ content covered by the target subset definition.</p>
    <dd><a href="https://www.unicode.org/versions/latest/"><cite>The Unicode Standard</cite></a>. URL: <a href="https://www.unicode.org/versions/latest/">https://www.unicode.org/versions/latest/</a>
    <dt id="biblio-utf-8">[UTF-8]
    <dd>F. Yergeau. <a href="https://www.rfc-editor.org/rfc/rfc3629"><cite>UTF-8, a transformation format of ISO 10646</cite></a>. November 2003. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3629">https://www.rfc-editor.org/rfc/rfc3629</a>
+   <dt id="biblio-whatwg-url">[WHATWG-URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-woff2">[WOFF2]
    <dd>Vladimir Levantovsky. <a href="https://www.w3.org/TR/WOFF2/"><cite>WOFF File Format 2.0</cite></a>. 8 August 2024. REC. URL: <a href="https://www.w3.org/TR/WOFF2/">https://www.w3.org/TR/WOFF2/</a>
   </dl>
@@ -3961,7 +3960,7 @@ content covered by the target subset definition.</p>
    <dt id="biblio-enabling-typography">[ENABLING-TYPOGRAPHY]
    <dd>John Hudson. <a href="https://www.tiro.com/articles/enabling-typography"><cite>Enabling Typography: towards a general model of OpenType Layout</cite></a>. April 15th, 2014. Note. URL: <a href="https://www.tiro.com/articles/enabling-typography">https://www.tiro.com/articles/enabling-typography</a>
    <dt id="biblio-fetch">[FETCH]
-   <dd><a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. 17 June 2024. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-rfc9113">[RFC9113]
    <dd>M. Thomson, Ed.; C. Benfield, Ed.. <a href="https://httpwg.org/specs/rfc9113.html"><cite>HTTP/2</cite></a>. June 2022. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc9113.html">https://httpwg.org/specs/rfc9113.html</a>
    <dt id="biblio-rfc9114">[RFC9114]
@@ -4209,7 +4208,7 @@ let dfnPanelData = {
 "format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.3.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
 "format-1-patch-map-maxglyphmapentryindex": {"dfnID":"format-1-patch-map-maxglyphmapentryindex","dfnText":"maxGlyphMapEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2461"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxglyphmapentryindex"},
 "format-1-patch-map-patchformat": {"dfnID":"format-1-patch-map-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchformat"},{"id":"ref-for-format-1-patch-map-patchformat\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchformat"},
-"format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
+"format-1-patch-map-urltemplate": {"dfnID":"format-1-patch-map-urltemplate","dfnText":"urlTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-urltemplate"},{"id":"ref-for-format-1-patch-map-urltemplate\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-urltemplate\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-urltemplate"},
 "format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.3.2.2. Remove Entries from Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2461"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#format-2-patch-map"},
 "format-2-patch-map-compatibilityid": {"dfnID":"format-2-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-compatibilityid"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-compatibilityid"},
 "format-2-patch-map-defaultpatchformat": {"dfnID":"format-2-patch-map-defaultpatchformat","dfnText":"defaultPatchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-defaultpatchformat"},
@@ -4217,7 +4216,7 @@ let dfnPanelData = {
 "format-2-patch-map-entrycount": {"dfnID":"format-2-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entrycount"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entrycount\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entrycount"},
 "format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2465"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2466"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
 "format-2-patch-map-format": {"dfnID":"format-2-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-format"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-format"},
-"format-2-patch-map-uritemplate": {"dfnID":"format-2-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-uritemplate"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-uritemplate"},
+"format-2-patch-map-urltemplate": {"dfnID":"format-2-patch-map-urltemplate","dfnText":"urlTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-urltemplate"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-urltemplate"},
 "full-invalidation": {"dfnID":"full-invalidation","dfnText":"Full Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-full-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-full-invalidation\u2460"}],"title":"6.1. Formats Summary"}],"url":"#full-invalidation"},
 "glyph-closure": {"dfnID":"glyph-closure","dfnText":"glyph closure","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-closure"}],"title":"7.1. Encoding Considerations"}],"url":"#glyph-closure"},
 "glyph-keyed-patch": {"dfnID":"glyph-keyed-patch","dfnText":"Glyph keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch"},
@@ -4690,7 +4689,7 @@ let refsData = {
 "#format-1-patch-map-maxentryindex": {"displayText":"maxentryindex","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxentryindex","type":"dfn","url":"#format-1-patch-map-maxentryindex"},
 "#format-1-patch-map-maxglyphmapentryindex": {"displayText":"maxglyphmapentryindex","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxglyphmapentryindex","type":"dfn","url":"#format-1-patch-map-maxglyphmapentryindex"},
 "#format-1-patch-map-patchformat": {"displayText":"patchformat","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchformat","type":"dfn","url":"#format-1-patch-map-patchformat"},
-"#format-1-patch-map-uritemplate": {"displayText":"uritemplate","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-1-patch-map-uritemplate"},
+"#format-1-patch-map-urltemplate": {"displayText":"urltemplate","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"urltemplate","type":"dfn","url":"#format-1-patch-map-urltemplate"},
 "#format-2-patch-map": {"displayText":"format 2 patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 2 patch map","type":"dfn","url":"#format-2-patch-map"},
 "#format-2-patch-map-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#format-2-patch-map-compatibilityid"},
 "#format-2-patch-map-defaultpatchformat": {"displayText":"defaultpatchformat","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"defaultpatchformat","type":"dfn","url":"#format-2-patch-map-defaultpatchformat"},
@@ -4698,7 +4697,7 @@ let refsData = {
 "#format-2-patch-map-entrycount": {"displayText":"entrycount","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrycount","type":"dfn","url":"#format-2-patch-map-entrycount"},
 "#format-2-patch-map-entryidstringdata": {"displayText":"entryidstringdata","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entryidstringdata","type":"dfn","url":"#format-2-patch-map-entryidstringdata"},
 "#format-2-patch-map-format": {"displayText":"format","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#format-2-patch-map-format"},
-"#format-2-patch-map-uritemplate": {"displayText":"uritemplate","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-2-patch-map-uritemplate"},
+"#format-2-patch-map-urltemplate": {"displayText":"urltemplate","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"urltemplate","type":"dfn","url":"#format-2-patch-map-urltemplate"},
 "#full-invalidation": {"displayText":"full invalidation","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"full invalidation","type":"dfn","url":"#full-invalidation"},
 "#glyph-closure": {"displayText":"glyph closure","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyph closure","type":"dfn","url":"#glyph-closure"},
 "#glyph-keyed-patch": {"displayText":"glyph keyed patch","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyph keyed patch","type":"dfn","url":"#glyph-keyed-patch"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="32f7e9c3709731a55922172d934a735a43cd8eef" name="revision">
+  <meta content="66cdbe0c9dcac7df8c519e597d96134b023e200d" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1078,8 +1078,8 @@ if the font does not support any code points which are needed.</p>
    <p class="note" role="note"><span class="marker">Note:</span> Each individual <code>@font-face</code> block may or may not opt-in to IFT. This is due to the
 variety of ways fonts are used on web pages. Authors have control over which fonts they want to use
 this technology with, and which they do not.</p>
-   <p class="note" role="note"><span class="marker">Note:</span> the IFT tech keyword can be used in conjunction with other font tech specifiers to perform</p>
-   <p>font feature selection. For example a <code>@font-face</code> could include two URLs one with <code>tech(incremental, color-COLRv1)</code> and the other with <code>tech(incremental, color-COLRv0)</code>.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> the IFT tech keyword can be used in conjunction with other font tech specifiers to perform
+font feature selection. For example a <code>@font-face</code> could include two URLs one with <code>tech(incremental, color-COLRv1)</code> and the other with <code>tech(incremental, color-COLRv0)</code>.</p>
    <h3 class="heading settled" data-level="2.1" id="offline-usage"><span class="secno">2.1. </span><span class="content">Offline Usage</span><a class="self-link" href="#offline-usage"></a></h3>
    <p>In some cases a user agent may wish to save a web page for offline use. Saved pages may be viewed while there is no network connection
 and thus it won’t be possible to request any additional patches referenced by an incremental font. Since it won’t be possible extend
@@ -2433,8 +2433,12 @@ byte string:
    </div>
    <h4 class="heading settled" data-level="5.3.3" id="url-templates"><span class="secno">5.3.3. </span><span class="content">URL Templates</span><a class="self-link" href="#url-templates"></a></h4>
    <p>URL templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URL strings where patch files are located.
-A string ID is a sequence of bytes. The output of template expansion is a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Several variables
-are defined which are used to produce the expansion of the template:</p>
+A string ID is a sequence of bytes. The output of template expansion is a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string.</p>
+   <p>To limit the complexity of the template expansion implementation, URL templates in IFT are restricted to only <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.2">Level 1</a> substitution expressions. If during expansion unsupported operators (level 2 and above)
+or an expression which doesn’t match template grammar is encountered (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>), then template expansion must
+result in an error. Additionally, for consistency when producing percent encodings as part of template expansion
+(<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3.1">URI Template § section-3.1</a>) IFT implementations must only use uppercase letters.</p>
+   <p>Several variables are defined which are used to produce the expansion of the template:</p>
    <table>
     <tbody>
      <tr>
@@ -2472,8 +2476,11 @@ are defined which are used to produce the expansion of the template:</p>
       (For example, when the integer is less than 256 only one byte is encoded.) If the input id is 0 then one
       zero byte is encoded. When the input id is a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
    </table>
-   <div class="example" id="example-76363920">
-    <a class="self-link" href="#example-76363920"></a> 
+   <p class="note" role="note"><span class="marker">Note:</span> since there is a small fixed set of variables and only level one expression are supported for expansion, implementations
+may want to consider a custom optimized template expansion implementation instead of relying on a general purpose implementation
+of <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a>.</p>
+   <div class="example" id="example-21a3582d">
+    <a class="self-link" href="#example-21a3582d"></a> 
     <p>Some example inputs and the corresponding expansions:</p>
     <table>
      <tbody>
@@ -2493,55 +2500,50 @@ are defined which are used to produce the expansion of the template:</p>
        <td>Integer
        <td>//foo.bar/00
       <tr>
-       <td>//foo.bar{/d1,d2,id}
+       <td>//foo.bar/{d1}/{d2}/{id}
        <td>478
        <td>Integer
        <td>//foo.bar/0/F/07F0
       <tr>
-       <td>//foo.bar{/d1,d2,d3,id}
+       <td>//foo.bar/{d1}/{d2}/{d3}/{id}
        <td>123
        <td>Integer
        <td>//foo.bar/C/F/_/FC
       <tr>
-       <td>//foo.bar{/d1,d2,d3,id}
+       <td>//foo.bar/{d1}/{d2}/{d3}/{id}
        <td>baz
        <td>String
        <td>//foo.bar/K/N/G/C9GNK
       <tr>
-       <td>//foo.bar{/d1,d2,d3,id}
+       <td>//foo.bar/{d1}/{d2}/{d3}/{id}
        <td>z
        <td>String
        <td>//foo.bar/8/F/_/F8
       <tr>
-       <td>//foo.bar{/d1,d2,d3,id}
+       <td>//foo.bar/{d1}/{d2}/{d3}/{id}
        <td>àbc
        <td>String
        <td>//foo.bar/O/O/4/OEG64OO
       <tr>
-       <td>//foo.bar{/id64}
+       <td>//foo.bar/{id64}
        <td>14,000,000
        <td>Integer
        <td>//foo.bar/1Z-A
       <tr>
-       <td>//foo.bar{/id64}
+       <td>//foo.bar/{id64}
        <td>0
        <td>Integer
        <td>//foo.bar/AA%3D%3D
       <tr>
-       <td>//foo.bar{/id64}
+       <td>//foo.bar/{id64}
        <td>17,000,000
        <td>Integer
        <td>//foo.bar/AQNmQA%3D%3D
       <tr>
-       <td>//foo.bar{/id64}
+       <td>//foo.bar/{id64}
        <td>àbc
        <td>String
        <td>//foo.bar/w6BiYw%3D%3D
-      <tr>
-       <td>//foo.bar/{+id64}
-       <td>àbcd
-       <td>String
-       <td>//foo.bar/w6BiY2Q=
     </table>
    </div>
    <h2 class="heading settled" data-level="6" id="font-patch-formats"><span class="secno">6. </span><span class="content">Font Patch Formats</span><a class="self-link" href="#font-patch-formats"></a></h2>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="66cdbe0c9dcac7df8c519e597d96134b023e200d" name="revision">
+  <meta content="24413daf1394553b49ad6bb0b941b4bc68e20049" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -871,7 +871,7 @@ to complex scripts like Indic or Arabic.</p>
           <li><a href="#remove-entries-format-2"><span class="secno">5.3.2.2</span> <span class="content">Remove Entries from Format 2</span></a>
           <li><a href="#sparse-bit-set-decoding"><span class="secno">5.3.2.3</span> <span class="content">Sparse Bit Set</span></a>
          </ol>
-        <li><a href="#url-templates"><span class="secno">5.3.3</span> <span class="content">URL Templates</span></a>
+        <li><a href="#uri-templates"><span class="secno">5.3.3</span> <span class="content">URI Templates</span></a>
        </ol>
      </ol>
     <li>
@@ -1711,7 +1711,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#url-templates">§ 5.3.3 URL Templates</a> which is used to produce URL strings associated with each entry.
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.3.3 URI Templates</a> which is used to produce URL strings associated with each entry.
       Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
      <tr>
       <td>uint8
@@ -1842,7 +1842,7 @@ index and do not build an entry for it.</p>
        <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
 Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a> following <a href="#url-templates">§ 5.3.3 URL Templates</a>. If
+       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>. If
 the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
@@ -1863,7 +1863,7 @@ skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigne
       <li data-md>
        <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
       <li data-md>
-       <p>Convert <var>mapped entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a> following <a href="#url-templates">§ 5.3.3 URL Templates</a>.
+       <p>Convert <var>mapped entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
 If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this entry.</p>
@@ -1911,7 +1911,7 @@ change the number of bytes.</p>
       <li data-md>
        <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a> following <a href="#url-templates">§ 5.3.3 URL Templates</a>.
+       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
 If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
       <li data-md>
        <p>If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
@@ -1963,7 +1963,7 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#url-templates">§ 5.3.3 URL Templates</a> which is used to produce URL strings associated with each entry.
+      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.3.3 URI Templates</a> which is used to produce URL strings associated with each entry.
       Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entries">Mapping Entries</dfn> encoding:</p>
@@ -2137,7 +2137,7 @@ being requested.</p>
     <li data-md>
      <p><var>default patch format</var>: the default patch format if one isn’t specified.</p>
     <li data-md>
-     <p><var>url template</var>: the URL template used to locate patches.</p>
+     <p><var>uri template</var>: the URI template used to locate patches.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -2201,7 +2201,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
  If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by applying <var>url template</var> following <a href="#url-templates">§ 5.3.3 URL Templates</a>.
+         <p>Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
  If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
@@ -2217,7 +2217,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
  Set <var>entry id</var> to the result.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by applying <var>url template</var> following <a href="#url-templates">§ 5.3.3 URL Templates</a>.
+         <p>Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
  If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
@@ -2431,10 +2431,10 @@ byte string:
 ]
 </pre>
    </div>
-   <h4 class="heading settled" data-level="5.3.3" id="url-templates"><span class="secno">5.3.3. </span><span class="content">URL Templates</span><a class="self-link" href="#url-templates"></a></h4>
-   <p>URL templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URL strings where patch files are located.
+   <h4 class="heading settled" data-level="5.3.3" id="uri-templates"><span class="secno">5.3.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h4>
+   <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URL strings where patch files are located.
 A string ID is a sequence of bytes. The output of template expansion is a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string.</p>
-   <p>To limit the complexity of the template expansion implementation, URL templates in IFT are restricted to only <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.2">Level 1</a> substitution expressions. If during expansion unsupported operators (level 2 and above)
+   <p>To limit the complexity of the template expansion implementation, URI templates in IFT are restricted to only <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.2">Level 1</a> substitution expressions. If during expansion unsupported operators (level 2 and above)
 or an expression which doesn’t match template grammar is encountered (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>), then template expansion must
 result in an error. Additionally, for consistency when producing percent encodings as part of template expansion
 (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3.1">URI Template § section-3.1</a>) IFT implementations must only use uppercase letters.</p>
@@ -3109,7 +3109,7 @@ patch mapping prior to receiving all of the font data and potentially initiate r
 in any order in the patch file. So for the same reasons encoders should consider placing updates to the mapping tables plus any
 additional tables needed to decode the mapping tables as early as possible in the patch file.</p>
    <p><b>Choosing the input ID encoding</b></p>
-   <p>The specification supports two encodings for embedding patch IDs in the URL template. The first is <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a>,
+   <p>The specification supports two encodings for embedding patch IDs in the URI template. The first is <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a>,
 which is a good match for pre-generated patches that will typically be stored in a filesystem. Base32hex encoding only uses the
 letters 0-9 and A-V, which are safe letters for a file name in every commonly used filesystem, with no risk of collisions due to
 case-insensitivity. Because the string is embedded without padding this format cannot be reliably decoded, so it may be a poor

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="24413daf1394553b49ad6bb0b941b4bc68e20049" name="revision">
+  <meta content="61233ba8e96a3bed1310f05f20782e5e7dd2446e" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2434,10 +2434,10 @@ byte string:
    <h4 class="heading settled" data-level="5.3.3" id="uri-templates"><span class="secno">5.3.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h4>
    <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URL strings where patch files are located.
 A string ID is a sequence of bytes. The output of template expansion is a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string.</p>
-   <p>To limit the complexity of the template expansion implementation, URI templates in IFT are restricted to only <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.2">Level 1</a> substitution expressions. If during expansion unsupported operators (level 2 and above)
-or an expression which doesn’t match template grammar is encountered (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>), then template expansion must
-result in an error. Additionally, for consistency when producing percent encodings as part of template expansion
-(<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3.1">URI Template § section-3.1</a>) IFT implementations must only use uppercase letters.</p>
+   <p>To limit the complexity of the template expansion implementation, URI templates in IFT are restricted to only <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.2">Level 1</a> substitution expressions. If a URI template contains expression(s) which do not match the level
+1 grammar (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-2.2">URI Template § section-2.2</a>), then template expansion must result in an error. Additionally, for consistency when
+producing percent encodings as part of template expansion (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3.1">URI Template § section-3.1</a>) IFT implementations must only use uppercase
+letters.</p>
    <p>Several variables are defined which are used to produce the expansion of the template:</p>
    <table>
     <tbody>


### PR DESCRIPTION
Based on the discussion in #259:
- Stop using rfc3986 and instead use whatwg URL which supersedes rfc3986.
- Limit URL templates to level one operators, this will make it trivial for client implementations to implement template substitution and avoids needing to pull in a complete general purpose rfc6570 implementation.
- Clarify percent encoding always produces upper case letters.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/263.html" title="Last updated on Mar 20, 2025, 8:04 PM UTC (57bd8f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/263/32f7e9c...57bd8f5.html" title="Last updated on Mar 20, 2025, 8:04 PM UTC (57bd8f5)">Diff</a>