### PR TITLE
For fonts with CFF or CFF2 tables add a field to the patch map with o

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -951,6 +951,9 @@ simplified. They allow glyph data to be inserted into CFF/CFF2 tables without ch
 encoded in the CFF/CFF2 table. The stored CFF/CFF2 offsets allow the client to locate the CharStrings INDEX without needing to
 parse any other parts of the CFF/CFF2 table.
 
+Note: that in some cases a CFF or CFF2 table may be added or changed by a table keyed patch. In these cases the patch
+will need to also add or update the charstrings offset to reflect the new or changed contents.
+
 CFF or CFF2 subroutinization is compatible with the incremental font transfer. However, naive subroutinization will tend
 to reduce patch size while increasing the size of the initial file. Also, WOFF2 has often been shown to compress a
 non-subroutinized font more effectively than its subroutinized equivalent (at the cost of a significantly larger

--- a/Overview.bs
+++ b/Overview.bs
@@ -941,9 +941,15 @@ additional restrictions:
 * CFF and CFF2 tables in an incremental font must not have any other data elements that overlap the CharStrings INDEX data
     structure.
 
-These two requirements allow for the glyph keyed patch application implementation on CFF and CFF2 tables to be significantly
+* The 'IFT ' [=patch map=] table must contain an offset
+    ([=Format 1 Patch Map/cffCharStringsOffset=], [=Format 1 Patch Map/cff2CharStringsOffset=]
+    [=Format 2 Patch Map/cffCharStringsOffset=], or [=Format 2 Patch Map/cff2CharStringsOffset=])
+    to the start of the CharStrings INDEX data for the CFF and/or CFF2 table. 
+
+These three requirements allow for the glyph keyed patch application implementation on CFF and CFF2 tables to be significantly
 simplified. They allow glyph data to be inserted into CFF/CFF2 tables without changing the offsets to any other data elements
-encoded in the CFF/CFF2 table.
+encoded in the CFF/CFF2 table. The stored CFF/CFF2 offsets allow the client to locate the CharStrings INDEX without needing to
+parse any other parts of the CFF/CFF2 table.
 
 CFF or CFF2 subroutinization is compatible with the incremental font transfer. However, naive subroutinization will tend
 to reduce patch size while increasing the size of the initial file. Also, WOFF2 has often been shown to compress a
@@ -1053,6 +1059,24 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td>
       Specifies the format of the patches linked to by uriTemplate.
       Must be set to one of the format numbers from  the [[#font-patch-formats-summary]] table.
+    </td>
+  </tr>
+  <tr>
+    <td>uint32</td>
+    <td><dfn for="Format 1 Patch Map">cffCharStringsOffset</dfn></td>
+    <td>
+      Only present in an 'IFT ' table (never in 'IFTX') when the font also contains a [[open-type/CFF|CFF]] table.
+      Gives the offset from the start of the [[open-type/CFF|CFF]] table to the CharStrings INDEX data structure of the
+      [[open-type/CFF|CFF]] table.
+    </td>
+  </tr>
+  <tr>
+    <td>uint32</td>
+    <td><dfn for="Format 1 Patch Map">cff2CharStringsOffset</dfn></td>
+    <td>
+      Only present in an 'IFT ' table (never in 'IFTX') when the font also contains a [[open-type/CFF2|CFF2]] table.
+      Gives the offset from the start of the [[open-type/CFF|CFF2]] table to the CharStrings INDEX data structure of the
+      [[open-type/CFF2|CFF2]] table.
     </td>
   </tr>
 </table>
@@ -1366,6 +1390,25 @@ The algorithm:
       Must be a valid [[!UTF-8]] sequence.
     </td>
   </tr>
+  <tr>
+    <td>uint32</td>
+    <td><dfn for="Format 2 Patch Map">cffCharStringsOffset</dfn></td>
+    <td>
+      Only present in an 'IFT ' table (never in 'IFTX') when the font also contains a [[open-type/CFF|CFF]] table.
+      Gives the offset from the start of the [[open-type/CFF|CFF]] table to the CharStrings INDEX data structure of the
+      [[open-type/CFF|CFF]] table.
+    </td>
+  </tr>
+  <tr>
+    <td>uint32</td>
+    <td><dfn for="Format 2 Patch Map">cff2CharStringsOffset</dfn></td>
+    <td>
+      Only present in an 'IFT ' table (never in 'IFTX') when the font also contains a [[open-type/CFF2|CFF2]] table.
+      Gives the offset from the start of the [[open-type/CFF|CFF2]] table to the CharStrings INDEX data structure of the
+      [[open-type/CFF2|CFF2]] table.
+    </td>
+  </tr>
+
 </table>
 
 <dfn>Mapping Entries</dfn> encoding:

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="af20875480cf8993bff352a924de66ddf41cb7aa" name="revision">
+  <meta content="16dd8d63842c9a70ad289d06e10bc32a7f146400" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1640,6 +1640,8 @@ to the start of the CharStrings INDEX data for the CFF and/or CFF2 table.</p>
 simplified. They allow glyph data to be inserted into CFF/CFF2 tables without changing the offsets to any other data elements
 encoded in the CFF/CFF2 table. The stored CFF/CFF2 offsets allow the client to locate the CharStrings INDEX without needing to
 parse any other parts of the CFF/CFF2 table.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> that in some cases a CFF or CFF2 table may be added or changed by a table keyed patch. In these cases the patch
+will need to also add or update the charstrings offset to reflect the new or changed contents.</p>
    <p>CFF or CFF2 subroutinization is compatible with the incremental font transfer. However, naive subroutinization will tend
 to reduce patch size while increasing the size of the initial file. Also, WOFF2 has often been shown to compress a
 non-subroutinized font more effectively than its subroutinized equivalent (at the cost of a significantly larger

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="449ee2b392835f2256cc8febefea2ea936584add" name="revision">
+  <meta content="af20875480cf8993bff352a924de66ddf41cb7aa" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1631,17 +1631,22 @@ table (followed only by 0 padding to a four-byte word boundary).</p>
     <li data-md>
      <p>CFF and CFF2 tables in an incremental font must not have any other data elements that overlap the CharStrings INDEX data
 structure.</p>
+    <li data-md>
+     <p>The 'IFT ' <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑤">patch map</a> table must contain an offset
+(<a data-link-type="dfn" href="#format-1-patch-map-cffcharstringsoffset" id="ref-for-format-1-patch-map-cffcharstringsoffset">cffCharStringsOffset</a>, <a data-link-type="dfn" href="#format-1-patch-map-cff2charstringsoffset" id="ref-for-format-1-patch-map-cff2charstringsoffset">cff2CharStringsOffset</a> <a data-link-type="dfn" href="#format-2-patch-map-cffcharstringsoffset" id="ref-for-format-2-patch-map-cffcharstringsoffset">cffCharStringsOffset</a>, or <a data-link-type="dfn" href="#format-2-patch-map-cff2charstringsoffset" id="ref-for-format-2-patch-map-cff2charstringsoffset">cff2CharStringsOffset</a>)
+to the start of the CharStrings INDEX data for the CFF and/or CFF2 table.</p>
    </ul>
-   <p>These two requirements allow for the glyph keyed patch application implementation on CFF and CFF2 tables to be significantly
+   <p>These three requirements allow for the glyph keyed patch application implementation on CFF and CFF2 tables to be significantly
 simplified. They allow glyph data to be inserted into CFF/CFF2 tables without changing the offsets to any other data elements
-encoded in the CFF/CFF2 table.</p>
+encoded in the CFF/CFF2 table. The stored CFF/CFF2 offsets allow the client to locate the CharStrings INDEX without needing to
+parse any other parts of the CFF/CFF2 table.</p>
    <p>CFF or CFF2 subroutinization is compatible with the incremental font transfer. However, naive subroutinization will tend
 to reduce patch size while increasing the size of the initial file. Also, WOFF2 has often been shown to compress a
 non-subroutinized font more effectively than its subroutinized equivalent (at the cost of a significantly larger
 uncompressed file).  Therefore, it is recommended that subroutinzation either be avoided, used moderately, or customized
 to the specific needs of IFT.</p>
    <h3 class="heading settled" data-level="5.3" id="patch-map-table"><span class="secno">5.3. </span><span class="content">Patch Map Table</span><a class="self-link" href="#patch-map-table"></a></h3>
-   <p>A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑤">patch map</a> is encoded in one of two formats:</p>
+   <p>A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑥">patch map</a> is encoded in one of two formats:</p>
    <ul>
     <li data-md>
      <p>Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URL strings. It does
@@ -1718,6 +1723,16 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchformat">patchFormat</dfn>
       <td> Specifies the format of the patches linked to by uriTemplate.
       Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
+     <tr>
+      <td>uint32
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-cffcharstringsoffset">cffCharStringsOffset</dfn>
+      <td> Only present in an 'IFT ' table (never in 'IFTX') when the font also contains a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table.
+      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table to the CharStrings INDEX data structure of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table. 
+     <tr>
+      <td>uint32
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-cff2charstringsoffset">cff2CharStringsOffset</dfn>
+      <td> Only present in an 'IFT ' table (never in 'IFTX') when the font also contains a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table.
+      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF2</a> table to the CharStrings INDEX data structure of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table. 
    </table>
    <p class="note" role="note"><span class="marker">Note:</span> <a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> is designed to be compatible with the
       proposed <a href="https://github.com/harfbuzz/boring-expansion-spec/tree/main">future font format extension</a> to allow for more
@@ -1965,6 +1980,16 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
       <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.3.3 URI Templates</a> which is used to produce URL strings associated with each entry.
       Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
+     <tr>
+      <td>uint32
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-cffcharstringsoffset">cffCharStringsOffset</dfn>
+      <td> Only present in an 'IFT ' table (never in 'IFTX') when the font also contains a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table.
+      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table to the CharStrings INDEX data structure of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table. 
+     <tr>
+      <td>uint32
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-cff2charstringsoffset">cff2CharStringsOffset</dfn>
+      <td> Only present in an 'IFT ' table (never in 'IFTX') when the font also contains a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table.
+      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF2</a> table to the CharStrings INDEX data structure of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table. 
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entries">Mapping Entries</dfn> encoding:</p>
    <table>
@@ -2080,12 +2105,12 @@ being requested.</p>
       <td> End (inclusive) of the segment. Must be greater than or equal to start. This value uses the user axis scale: <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
    </table>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="5.3.2.1" id="interpreting-patch-map-format-2"><span class="secno">5.3.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
-   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑥">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
+   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑦">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map">Format 2 Patch Map</a> encoded <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑦">patch map</a>.</p>
+     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map">Format 2 Patch Map</a> encoded <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑧">patch map</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -2850,7 +2875,7 @@ The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-fon
      <p>Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
 of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①⓪">Extend an Incremental Font Subset</a>.</p>
     <li data-md>
-     <p>Must respect patch invalidation criteria. Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑧">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
+     <p>Must respect patch invalidation criteria. Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑨">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
  for the invalidation mode declared by the associated <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①①">patch map entries</a>.</p>
     <li data-md>
      <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
@@ -3799,6 +3824,18 @@ content covered by the target subset definition.</p>
      <li><a href="#glyph-keyed-patch-brotlistream">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
      <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
+   <li>
+    cff2CharStringsOffset
+    <ul>
+     <li><a href="#format-1-patch-map-cff2charstringsoffset">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
+     <li><a href="#format-2-patch-map-cff2charstringsoffset">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
+    </ul>
+   <li>
+    cffCharStringsOffset
+    <ul>
+     <li><a href="#format-1-patch-map-cffcharstringsoffset">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
+     <li><a href="#format-2-patch-map-cffcharstringsoffset">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
+    </ul>
    <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 4.3</span>
    <li><a href="#mapping-entry-childentryindices">childEntryIndices</a><span>, in § 5.3.2</span>
    <li><a href="#mapping-entry-childentrymatchmodeandcount">childEntryMatchModeAndCount</a><span>, in § 5.3.2</span>
@@ -4203,6 +4240,8 @@ let dfnPanelData = {
 "font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2461"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"},{"id":"ref-for-font-subset-definition\u2463"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2468"},{"id":"ref-for-font-subset-definition\u2460\u24ea"},{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"},{"id":"ref-for-font-subset-definition\u2460\u2466"},{"id":"ref-for-font-subset-definition\u2460\u2467"},{"id":"ref-for-font-subset-definition\u2460\u2468"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
 "format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
 "format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
+"format-1-patch-map-cff2charstringsoffset": {"dfnID":"format-1-patch-map-cff2charstringsoffset","dfnText":"cff2CharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-cff2charstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"}],"url":"#format-1-patch-map-cff2charstringsoffset"},
+"format-1-patch-map-cffcharstringsoffset": {"dfnID":"format-1-patch-map-cffcharstringsoffset","dfnText":"cffCharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-cffcharstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"}],"url":"#format-1-patch-map-cffcharstringsoffset"},
 "format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
 "format-1-patch-map-featuremapoffset": {"dfnID":"format-1-patch-map-featuremapoffset","dfnText":"featureMapOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-featuremapoffset"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-featuremapoffset"},
 "format-1-patch-map-format": {"dfnID":"format-1-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-format"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-format\u2460"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-format"},
@@ -4212,6 +4251,8 @@ let dfnPanelData = {
 "format-1-patch-map-patchformat": {"dfnID":"format-1-patch-map-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchformat"},{"id":"ref-for-format-1-patch-map-patchformat\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchformat"},
 "format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
 "format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.3.2.2. Remove Entries from Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2461"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#format-2-patch-map"},
+"format-2-patch-map-cff2charstringsoffset": {"dfnID":"format-2-patch-map-cff2charstringsoffset","dfnText":"cff2CharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-cff2charstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"}],"url":"#format-2-patch-map-cff2charstringsoffset"},
+"format-2-patch-map-cffcharstringsoffset": {"dfnID":"format-2-patch-map-cffcharstringsoffset","dfnText":"cffCharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-cffcharstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"}],"url":"#format-2-patch-map-cffcharstringsoffset"},
 "format-2-patch-map-compatibilityid": {"dfnID":"format-2-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-compatibilityid"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-compatibilityid"},
 "format-2-patch-map-defaultpatchformat": {"dfnID":"format-2-patch-map-defaultpatchformat","dfnText":"defaultPatchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-defaultpatchformat"},
 "format-2-patch-map-entries": {"dfnID":"format-2-patch-map-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entries"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entries"},
@@ -4255,7 +4296,7 @@ let dfnPanelData = {
 "partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2461"},{"id":"ref-for-partial-invalidation\u2462"},{"id":"ref-for-partial-invalidation\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
 "patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
-"patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map\u2461"},{"id":"ref-for-patch-map\u2462"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-patch-map\u2463"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2464"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2465"},{"id":"ref-for-patch-map\u2466"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map\u2467"}],"title":"7. Encoding"}],"url":"#patch-map"},
+"patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map\u2461"},{"id":"ref-for-patch-map\u2462"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-patch-map\u2463"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2464"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-patch-map\u2465"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2466"},{"id":"ref-for-patch-map\u2467"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map\u2468"}],"title":"7. Encoding"}],"url":"#patch-map"},
 "patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"},{"id":"ref-for-patch-map-entries\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2462"},{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"7. Encoding"}],"url":"#patch-map-entries"},
 "sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
 "table-keyed-patch": {"dfnID":"table-keyed-patch","dfnText":"Table keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch"},
@@ -4684,6 +4725,8 @@ let refsData = {
 "#font-subset-definition": {"displayText":"font subset definition","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"font subset definition","type":"dfn","url":"#font-subset-definition"},
 "#format-1-patch-map": {"displayText":"format 1 patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 1 patch map","type":"dfn","url":"#format-1-patch-map"},
 "#format-1-patch-map-appliedentriesbitmap": {"displayText":"appliedentriesbitmap","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"appliedentriesbitmap","type":"dfn","url":"#format-1-patch-map-appliedentriesbitmap"},
+"#format-1-patch-map-cff2charstringsoffset": {"displayText":"cff2charstringsoffset","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cff2charstringsoffset","type":"dfn","url":"#format-1-patch-map-cff2charstringsoffset"},
+"#format-1-patch-map-cffcharstringsoffset": {"displayText":"cffcharstringsoffset","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cffcharstringsoffset","type":"dfn","url":"#format-1-patch-map-cffcharstringsoffset"},
 "#format-1-patch-map-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#format-1-patch-map-compatibilityid"},
 "#format-1-patch-map-featuremapoffset": {"displayText":"featuremapoffset","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featuremapoffset","type":"dfn","url":"#format-1-patch-map-featuremapoffset"},
 "#format-1-patch-map-format": {"displayText":"format","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#format-1-patch-map-format"},
@@ -4693,6 +4736,8 @@ let refsData = {
 "#format-1-patch-map-patchformat": {"displayText":"patchformat","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchformat","type":"dfn","url":"#format-1-patch-map-patchformat"},
 "#format-1-patch-map-uritemplate": {"displayText":"uritemplate","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-1-patch-map-uritemplate"},
 "#format-2-patch-map": {"displayText":"format 2 patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 2 patch map","type":"dfn","url":"#format-2-patch-map"},
+"#format-2-patch-map-cff2charstringsoffset": {"displayText":"cff2charstringsoffset","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cff2charstringsoffset","type":"dfn","url":"#format-2-patch-map-cff2charstringsoffset"},
+"#format-2-patch-map-cffcharstringsoffset": {"displayText":"cffcharstringsoffset","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cffcharstringsoffset","type":"dfn","url":"#format-2-patch-map-cffcharstringsoffset"},
 "#format-2-patch-map-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#format-2-patch-map-compatibilityid"},
 "#format-2-patch-map-defaultpatchformat": {"displayText":"defaultpatchformat","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"defaultpatchformat","type":"dfn","url":"#format-2-patch-map-defaultpatchformat"},
 "#format-2-patch-map-entries": {"displayText":"entries","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entries","type":"dfn","url":"#format-2-patch-map-entries"},


### PR DESCRIPTION
- Specified to only be on the 'IFT ' table so it's not duplicated in fonts which also have an IFTX patchmap.
- Required to be present and accurate when font has CFF and/or CFF2.

For #260


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/265.html" title="Last updated on Mar 31, 2025, 6:14 PM UTC (0ac20ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/265/af20875...0ac20ee.html" title="Last updated on Mar 31, 2025, 6:14 PM UTC (0ac20ee)">Diff</a>