### PR TITLE
Add a note to the font compression section recommending WOFF2.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -928,8 +928,9 @@ For [[WOFF2]] special care must be taken. If an incremental font will be encoded
 2. The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in
     [[WOFF2#table_format]].
 
-Note: since WOFF2 outperforms WOFF even with glyf/loca transformations disabled it is generally recommended that IFT fonts are WOFF2 compressed
-(with glyf/loca transformations disabled when the font used table keyed patches) prior to serving.
+Note: Given that WOFF2 compression outperforms WOFF even with glyf/loca transformations disabled it is generally recommended 
+that IFT fonts are compressed using WOFF2, with glyf/loca transformations disabled when the encoding updates those tables using
+table-keyed patches.
 
 CFF and CFF2 Incremental Fonts {#cff}
 -------------------------------------

--- a/Overview.bs
+++ b/Overview.bs
@@ -928,6 +928,8 @@ For [[WOFF2]] special care must be taken. If an incremental font will be encoded
 2. The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in
     [[WOFF2#table_format]].
 
+Note: since WOFF2 outperforms WOFF even with glyf/loca transformations disabled it is generally recommended that IFT fonts are WOFF2 compressed
+(with glyf/loca transformations disabled when the font used table keyed patches) prior to serving.
 
 CFF and CFF2 Incremental Fonts {#cff}
 -------------------------------------

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="cef27ab3b9e788971e39e03f9e208c8fd877788f" name="revision">
+  <meta content="ca92138bcf39e5dfdf08e58f91539502075bf9ed" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1621,6 +1621,8 @@ file, the compressed font needs to be decoded before attempting to extend it.</p
     <li data-md>
      <p>The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in <a href="https://www.w3.org/TR/WOFF2/#table_format"><cite>WOFF 2.0</cite> § 5 Compressed data format</a>.</p>
    </ol>
+   <p class="note" role="note"><span class="marker">Note:</span> since WOFF2 outperforms WOFF even with glyf/loca transformations disabled it is generally recommended that IFT fonts are WOFF2 compressed
+(with glyf/loca transformations disabled when the font used table keyed patches) prior to serving.</p>
    <h3 class="heading settled" data-level="5.2" id="cff"><span class="secno">5.2. </span><span class="content">CFF and CFF2 Incremental Fonts</span><a class="self-link" href="#cff"></a></h3>
    <p>For incremental fonts that contain glyph outlines stored in a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff#">CFF</a> or <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#">CFF2</a> table there are some
 additional restrictions:</p>
@@ -2619,7 +2621,7 @@ encoding can make use of more than one patch format.</p>
       <td><a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation">No Invalidation</a>
    </table>
    <h3 class="heading settled" data-level="6.2" id="table-keyed"><span class="secno">6.2. </span><span class="content">Table Keyed</span><a class="self-link" href="#table-keyed"></a></h3>
-   <p>A table keyed patch contains a collection of patches which are applied to the individual <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. A table keyed encoded patch consists of a short header followed
+   <p>A table keyed patch contains a collection of patches which are applied to the individual <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15#section-3.2">shared LZ77 dictionary</a>. A table keyed encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
 or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="table-keyed-patch">Table keyed patch</dfn> encoding:</p>
@@ -2726,7 +2728,7 @@ are listed in the <a data-link-type="dfn" href="#table-keyed-patch-patches" id="
        <p>If bit 0 (least significant bit) of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags①">flags</a> is set, then decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream①">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a>. No shared dictionary is used. If the decoded data is larger than <a data-link-type="dfn" href="#tablepatch-maxuncompressedlength" id="ref-for-tablepatch-maxuncompressedlength">maxUncompressedLength</a> return an error. If there is any data in <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream②">brotliStream</a> which was not used by the decoding process return an error.
 Add a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag②">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream③">brotliStream</a>. Continue to the next entry.</p>
       <li data-md>
-       <p>Otherwise, decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream④">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a> and using the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag③">tag</a> in <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09#section-3.2">shared LZ77 dictionary</a>. If no such table exists return an error. If the decoded data is
+       <p>Otherwise, decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream④">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10">Brotli Compressed Data Format § section-10</a> and using the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag③">tag</a> in <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15#section-3.2">shared LZ77 dictionary</a>. If no such table exists return an error. If the decoded data is
 larger than <a data-link-type="dfn" href="#tablepatch-maxuncompressedlength" id="ref-for-tablepatch-maxuncompressedlength①">maxUncompressedLength</a> return an error. If there is any data in <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream⑤">brotliStream</a> which was
 not used by the decoding process return an error. Add a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag④">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream⑥">brotliStream</a>.</p>
      </ul>
@@ -3998,7 +4000,7 @@ content covered by the target subset definition.</p>
    <dt id="biblio-rfc7932">[RFC7932]
    <dd>J. Alakuijala; Z. Szabadka. <a href="https://www.rfc-editor.org/rfc/rfc7932"><cite>Brotli Compressed Data Format</cite></a>. July 2016. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc7932">https://www.rfc-editor.org/rfc/rfc7932</a>
    <dt id="biblio-shared-brotli">[Shared-Brotli]
-   <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09"><cite>Shared Brotli Compressed Data Format</cite></a>. Sep 2022. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-09</a>
+   <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15"><cite>Shared Brotli Compressed Data Format</cite></a>. Feb 2025. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15</a>
    <dt id="biblio-unicode">[UNICODE]
    <dd><a href="https://www.unicode.org/versions/latest/"><cite>The Unicode Standard</cite></a>. URL: <a href="https://www.unicode.org/versions/latest/">https://www.unicode.org/versions/latest/</a>
    <dt id="biblio-utf-8">[UTF-8]


### PR DESCRIPTION
For #270 add a note which recommends the usage of WOFF2 with IFT fonts (with the usual caveat of avoiding glyf/loca transformations).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/271.html" title="Last updated on May 1, 2025, 12:13 AM UTC (48195fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/271/ca92138...48195fe.html" title="Last updated on May 1, 2025, 12:13 AM UTC (48195fe)">Diff</a>