### PR TITLE
Drop rfc6570 uri templates, replace with opcode encoded template.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -2180,10 +2180,10 @@ Some example inputs and the corresponding expansions. Values in "Template Bytes"
 <table>
   <tr><th>Template Bytes</th><th>Input ID</th><th>ID Type</th><th>Expansion</th></tr>
   <tr>
-    <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 128]</td>
+    <td>[16, 'h', 't', 't', 'p', 's', ':', '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 128]</td>
     <td>123</td>
     <td>Integer</td>
-    <td>//foo.bar/FC</td>
+    <td>https://foo.bar/FC</td>
   </tr>
   <tr>
     <td>[8, 'f', 'o', 'o', '?', 'b', 'a', 'r', '=', 128]</td>
@@ -2198,16 +2198,16 @@ Some example inputs and the corresponding expansions. Values in "Template Bytes"
     <td>//foo.bar/00</td>
   </tr>
   <tr>
-    <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 128]</td>
+    <td>[5, '/', 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 128]</td>
     <td>478</td>
     <td>Integer</td>
-    <td>foo/0/F/07F0</td>
+    <td>/foo/0/F/07F0</td>
   </tr>
   <tr>
-    <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>
+    <td>[5, '/', 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>
     <td>123</td>
     <td>Integer</td>
-    <td>foo/C/F/_/FC</td>
+    <td>/foo/C/F/_/FC</td>
   </tr>
   <tr>
     <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>

--- a/Overview.bs
+++ b/Overview.bs
@@ -2137,21 +2137,21 @@ The algorithm:
   <tr>
     <td><var>d2</var></td>
     <td>
-      The second last character of the string in the <var>id32</var> variable.
+      The second to last character of the string in the <var>id32</var> variable.
       If the <var>id32</var> variable has less than 2 characters then, the value is the character _ (U+005F).
     </td>
   </tr>
   <tr>
     <td><var>d3</var></td>
     <td>
-      The third last character of the string in the <var>id32</var> variable.
+      The third to last character of the string in the <var>id32</var> variable.
       If the <var>id32</var> variable has less than 3 characters then, the value is the character _ (U+005F).
     </td>
   </tr>
   <tr>
     <td><var>d4</var></td>
     <td>
-      The fourth last character of the string in the <var>id32</var> variable.
+      The fourth to last character of the string in the <var>id32</var> variable.
       If the <var>id32</var> variable has less than 4 characters then, the value is the character _ (U+005F).
     </td>
   </tr>
@@ -2171,72 +2171,78 @@ The algorithm:
 
 <div class="example">
 
-Some example inputs and the corresponding expansions:
+Some example inputs and the corresponding expansions. Values in "Template Bytes" column are provided as C style byte arrays.
 
 <table>
   <tr><th>Template Bytes</th><th>Input ID</th><th>ID Type</th><th>Expansion</th></tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 128]</td>
+    <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 128]</td>
     <td>123</td>
     <td>Integer</td>
     <td>//foo.bar/FC</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 128]</td>
+    <td>[8, 'f', 'o', 'o', '?', 'b', 'a', 'r', '=', 128]</td>
+    <td>123</td>
+    <td>Integer</td>
+    <td>foo?bar=FC</td>
+  </tr>
+  <tr>
+    <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 128]</td>
     <td>0</td>
     <td>Integer</td>
     <td>//foo.bar/00</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 128]</td>
+    <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 128]</td>
     <td>478</td>
     <td>Integer</td>
-    <td>//foo.bar/0/F/07F0</td>
+    <td>foo/0/F/07F0</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]</td>
+    <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>
     <td>123</td>
     <td>Integer</td>
-    <td>//foo.bar/C/F/_/FC</td>
+    <td>foo/C/F/_/FC</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]</td>
+    <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>
     <td>baz</td>
     <td>String</td>
-    <td>//foo.bar/K/N/G/C9GNK</td>
+    <td>foo/K/N/G/C9GNK</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]</td>
-    <td>z</td>
+    <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>
+     <td>z</td>
     <td>String</td>
-    <td>//foo.bar/8/F/_/F8</td>
+    <td>foo/8/F/_/F8</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]</td>
-    <td>àbc</td>
+    <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>
+     <td>àbc</td>
     <td>String</td>
-    <td>//foo.bar/O/O/4/OEG64OO</td>
+    <td>foo/O/O/4/OEG64OO</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 133]</td>
+    <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]</td>
     <td>14,000,000</td>
     <td>Integer</td>
     <td>//foo.bar/1Z-A</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 133]</td>
+    <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]</td>
     <td>0</td>
     <td>Integer</td>
     <td>//foo.bar/AA%3D%3D</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 133]</td>
+    <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]</td>
     <td>17,000,000</td>
     <td>Integer</td>
     <td>//foo.bar/AQNmQA%3D%3D</td>
   </tr>
   <tr>
-    <td>[10, /, /, f, o, o, ., b, a, r, /, 133]</td>
+    <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]</td>
     <td>àbc</td>
     <td>String</td>
     <td>//foo.bar/w6BiYw%3D%3D</td>

--- a/Overview.bs
+++ b/Overview.bs
@@ -2045,19 +2045,20 @@ The algorithm outputs:
 
 The algorithm:
 
-1. Initialize <var>URL string</var> to an empty byte array.
+1. Initialize <var>URL string</var> to an empty byte array. <var>url template bytes</var> is used as a queue in the remaining steps.
+    Read operations remove bytes from the front of the queue (starting with the byte at index 0).
 
 2. Read the next byte of <var>url template bytes</var> into <var>op code</var>. If there are no remaining bytes, then
     expansion is finished, return <var>URL string</var>.
 
 3. If the most significant bit of <var>op code</var> is not set, then:
 
-     *  Interpret the 7 least significant bits of <var>op code</var> as an unsigned integer, <var>number of literal bytes</var>.
+     *  Interpret the 7 least significant bits of <var>op code</var> as an unsigned integer, <var>number of literals</var>.
 
-     *  If <var>number of literal bytes</var> is 0, then return an error.
+     *  If <var>number of literals</var> is 0, then return an error.
    
-     *  Read <var>number of literal bytes</var> from <var>url template bytes</var> into <var>literal bytes</var>. If there are not
-         enough remaining bytes in <var>url template bytes</var>, then return an error.
+     *  Read the next <var>number of literals</var> bytes from <var>url template bytes</var> into <var>literal bytes</var>.
+         If there are not enough remaining bytes in <var>url template bytes</var>, then return an error.
    
      *  Check that <var>literal bytes</var> is a valid UTF-8 encoded string according to [[UTF-8#section-4]].
          If it is not, then return an error.

--- a/Overview.bs
+++ b/Overview.bs
@@ -1087,24 +1087,23 @@ the encoded bytes at the start of every iteration to pick up any changes made in
   </tr>
   <tr>
     <td>uint16</td>
-    <td>uriTemplateLength</td>
+    <td>urlTemplateLength</td>
     <td>
-      Length of the uriTemplate string.
+      Length of the urlTemplate byte array.
     </td>
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
+    <td><dfn for="Format 1 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
     <td>
-      A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URL strings associated with each entry.
-      Must be a valid [[!UTF-8]] sequence.
+      A byte array containing a [[#url-templates|URL Template]] which is used to produce URL strings associated with each entry.
     </td>
   </tr>
   <tr>
     <td>uint8</td>
     <td><dfn for="Format 1 Patch Map">patchFormat</dfn></td>
     <td>
-      Specifies the format of the patches linked to by uriTemplate.
+      Specifies the format of the patches linked to by urlTemplate.
       Must be set to one of the format numbers from  the [[#font-patch-formats-summary]] table.
     </td>
   </tr>
@@ -1285,8 +1284,9 @@ The algorithm:
         [[open-type/cmap|cmap]] table of <var>font subset</var>. Ignore any glyph indices that are not mapped by [[open-type/cmap|cmap]].
         Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.
 
-    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]]. If
-        the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
+    *  Convert <var>entry index</var> into a URL string by invoking [$Expand URL Template$] with [=Format 1 Patch Map/urlTemplate=]
+        and <var>entry index</var> as inputs. If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return
+        an error.
 
     *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
 
@@ -1312,8 +1312,9 @@ The algorithm:
     *  If [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] is greater than
         [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
 
-    *  Convert <var>mapped entry index</var> into a URL string by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
-        If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
+    *  Convert <var>mapped entry index</var> into a URL string by invoking [$Expand URL Template$] with [=Format 1 Patch Map/urlTemplate=]
+        and <var>mapped entry index</var> as inputs. If the template expansion results in an error (see: [[rfc6570#section-3]]) then,
+        return an error.
 
     *  If the bit for <var>mapped entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this entry.
 
@@ -1364,8 +1365,9 @@ The algorithm:
     *  If the bit for <var>entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this
         <var>entry index</var>.
 
-    *  Convert <var>entry index</var> into a URL string by applying [=Format 1 Patch Map/uriTemplate=] following [[#uri-templates]].
-        If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
+    *  Convert <var>entry index</var> into a URL string by invoking [$Expand URL Template$] with [=Format 1 Patch Map/urlTemplate=]
+        and <var>entry index</var> as inputs. If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return
+        an error.
 
     *  If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in
         [=Format 1 Patch Map/appliedEntriesBitMap=] to 1.
@@ -1408,7 +1410,7 @@ The algorithm:
     <td>uint8</td>
     <td><dfn for="Format 2 Patch Map">defaultPatchFormat</dfn></td>
     <td>
-      Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
+      Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
       Must be set to one of the format numbers from the [[#font-patch-formats-summary]] table.
     </td>
   </tr>
@@ -1432,17 +1434,16 @@ The algorithm:
   </tr>
   <tr>
     <td>uint16</td>
-    <td>uriTemplateLength</td>
+    <td>urlTemplateLength</td>
     <td>
-      Length of the uriTemplate string.
+      Length of the urlTemplate byte array.
     </td>
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 2 Patch Map">uriTemplate</dfn>[uriTemplateLength]</td>
+    <td><dfn for="Format 2 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
     <td>
-      A [[!UTF-8]] encoded string. Contains a [[#uri-templates]] which is used to produce URL strings associated with each entry.
-      Must be a valid [[!UTF-8]] sequence.
+      A byte array containing a [[#url-templates|URL Template]] which is used to produce URL strings associated with each entry.
     </td>
   </tr>
   <tr>
@@ -1672,7 +1673,7 @@ The algorithm:
          to the end of <var>patch map</var> if [=Format 2 Patch Map/entryIdStringData=] is non zero,
          <var>last entry id</var>,
          [=Format 2 Patch Map/defaultPatchFormat=], and
-         [=Format 2 Patch Map/uriTemplate=].
+         [=Format 2 Patch Map/urlTemplate=].
 
      *  Set <var>last entry id</var> to the returned entry id.
 
@@ -1701,7 +1702,7 @@ The inputs to this algorithm are:
 
 * <var>default patch format</var>: the default patch format if one isn't specified.
 
-* <var>uri template</var>: the URI template used to locate patches.
+* <var>url template</var>: the URL template used to locate patches.
 
 The algorithm outputs:
 
@@ -1761,8 +1762,9 @@ The algorithm:
          *  Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
              If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.
 
-         *  Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following [[#uri-templates]].
-             If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
+         *  Convert <var>entry id</var> into a URL string by invoking [$Expand URL Template$] with <var>url template</var>
+             and <var>entry id</var> as inputs. If the template expansion results in an error (see: [[rfc6570#section-3]])
+             then, return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
 
@@ -1775,8 +1777,9 @@ The algorithm:
          *  Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
              Set <var>entry id</var> to the result. Increment <var>consumed id string bytes</var> by the number of bytes read.
 
-         *  Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following [[#uri-templates]].
-             If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
+         *  Convert <var>entry id</var> into a URL string by invoking [$Expand URL Template$] with <var>url template</var>
+             and <var>entry id</var> as inputs. If the template expansion results in an error (see: [[rfc6570#section-3]])
+             then, return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
 
@@ -1788,15 +1791,17 @@ The algorithm:
 
          *  Set <var>entry id</var> to <var>entry id</var> + 1.
 
-         *  Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following [[#uri-templates]].
-             If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
+         *  Convert <var>entry id</var> into a URL string by invoking [$Expand URL Template$] with <var>url template</var>
+             and <var>entry id</var> as inputs. If the template expansion results in an error (see: [[rfc6570#section-3]])
+             then, return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
 
     *  Otherwise if <var>id string bytes</var> is present, then:
 
-         *  Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following [[#uri-templates]].
-             If the template expansion results in an error (see: [[rfc6570#section-3]]) then, return an error.
+         *  Convert <var>entry id</var> into a URL string by invoking [$Expand URL Template$] with <var>url template</var>
+             and <var>entry id</var> as inputs. If the template expansion results in an error (see: [[rfc6570#section-3]])
+             then, return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
 
@@ -2016,145 +2021,222 @@ to give the smallest encodings for most unicode code point sets typically encoun
   ```
 </div>
 
-### URI Templates ### {#uri-templates}
+### URL Templates ### {#url-templates}
 
-URI templates [[!rfc6570]] are used to convert numeric or string IDs into URL strings where patch files are located.
-A string ID is a sequence of bytes. The output of template expansion is a [[!UTF-8]] encoded string.
+URL templates are used to compress the URL strings associated with each patch map entry. Each patch mapping table
+provides a URL template and then the URL string for each entry is produced by expanding the common template using
+each entry's ID as an input. The output of template expansion is a [[!UTF-8]] encoded string.
 
-To limit the complexity of the template expansion implementation, URI templates in IFT are restricted to only
-[[rfc6570#section-1.2|Level 1]] substitution expressions. If a URI template contains expression(s) which do not match the level
-1 grammar ([[rfc6570#section-2.2]]) or have variable names other than those defined below, then template expansion must result
-in an error. Additionally, for consistency when producing percent encodings as part of template expansion
-([[rfc6570#section-3.1]]) IFT implementations must only use uppercase letters.
+URL templates are encoded as a series of one byte op codes that either insert literal values, or insert values
+based on the input entry ID.
 
-Several variables are defined which are used to produce the expansion of the template:
+The algorithm for decoding and expanding a URL template follows.
 
+<dfn abstract-op>Expand URL Template</dfn>
+
+The inputs to this algorithm are:
+
+* <var>url template bytes</var>: an array of bytes the contains the URL template.
+* <var>entry ID</var>: the ID of an entry. May be either an unsigned integer or an array of bytes.
+
+The algorithm outputs:
+
+* <var>URL string</var>: an array of bytes representing the URL string. Encoded as [[!UTF-8]].
+
+The algorithm:
+
+1. Initialize <var>URL string</var> to an empty byte array.
+
+2. Read the next byte of <var>url template bytes</var> into <var>op code</var>. If there are no remaining bytes, then
+    expansion is finished, return <var>URL string</var>.
+
+3. If the most significant bit of <var>op code</var> is not set, then:
+
+     *  Interpret the 7 least significant bits of <var>op code</var> as an unsigned integer, <var>number of literal bytes</var>.
+   
+     *  Read <var>number of literal bytes</var> from <var>url template bytes</var> into <var>literal bytes</var>.
+   
+     *  Check that <var>literal bytes</var> is a valid UTF-8 encoded string according to [[UTF-8#section-4]].
+         If it is not, return an error.
+
+     *  Append <var>literal bytes</var> to the end of <var>URL string</var>.
+
+     *  Go to step 2.
+
+4. If the most significant bit of <var>op code</var> is set, then:
+
+     *  Look up <var>op code</var> in the proceeding <b>Op Code Reference Table</b>. Perform the operation specified
+         in the "Insertion Operation" column. If <var>op code</var> is not found in the table, then return an error.
+
+     *  Go to step 2.
+
+
+<b>Op Code Reference Table</b>
 <table>
-  <tr><th>Variable</th><th>Value</th></tr>
   <tr>
-    <td><code>id</code></td>
+    <th>Name</th><th>Op Code Value</th><th>Insertion Operation</th>
+  </tr>
+  <tr>
+    <td>Insert id32</td><td>128 (0b10000000)</td>
     <td>
-      The input id encoded as a [[rfc4648#section-7|base32hex]] string (using the digits 0-9, A-V) with padding
-      omitted.  When the id is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
-      but then all leading bytes that are equal to 0 are removed before encoding.  (For example, when the
-      integer is less than 256 only one byte is encoded.) If the input id is 0 then one zero byte is encoded. When the input
-      id is a string the raw bytes are encoded as base32hex.
+      Append the value of the <var>id32</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
     </td>
   </tr>
   <tr>
-    <td><code>d1</code></td>
+    <td>Insert d1</td><td>129 (0b10000001)</td>
     <td>
-      The last character of the string in the <code>id</code> variable.
-      If <code>id</code> variable is empty then, the value is the character _ (U+005F).
+      Append the value of the <var>d1</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
     </td>
   </tr>
   <tr>
-    <td><code>d2</code></td>
+    <td>Insert d2</td><td>130 (0b10000010)</td>
     <td>
-      The second last character of the string in the <code>id</code> variable.
-      If the <code>id</code> variable has less than 2 characters then, the value is the character _ (U+005F).
+      Append the value of the <var>d2</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
     </td>
   </tr>
   <tr>
-    <td><code>d3</code></td>
+    <td>Insert d3</td><td>131 (0b10000011)</td>
     <td>
-      The third last character of the string in the <code>id</code> variable.
-      If the <code>id</code> variable has less than 3 characters then, the value is the character _ (U+005F).
+      Append the value of the <var>d3</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
     </td>
   </tr>
   <tr>
-    <td><code>d4</code></td>
+    <td>Insert d4</td><td>132 (0b10000100)</td>
     <td>
-      The fourth last character of the string in the <code>id</code> variable.
-      If the <code>id</code> variable has less than 4 characters then, the value is the character _ (U+005F).
+      Append the value of the <var>d4</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
     </td>
   </tr>
   <tr>
-    <td><code>id64</code></td>
+    <td>Insert id64</td><td>133 (0b10000101)</td>
     <td>
-      The input id encoded as a [[rfc4648#section-5|base64url]] string (using the digits A-Z, a-z, 0-9, -
-      (minus) and _ (underline)) with padding included. Because the padding character is '=', it must
-      be URL-encoded as "%3D'.  When the id is an unsigned integer it must first be converted to a big
-      endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding. 
-      (For example, when the integer is less than 256 only one byte is encoded.) If the input id is 0 then one
-      zero byte is encoded. When the input id is a string its raw bytes are encoded as
-      [[rfc4648#section-5|base64url]].
+      Append the value of the <var>id64</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
     </td>
   </tr>
 </table>
 
-Note: since there is a small fixed set of variables and only level one expression are supported for expansion, implementations
-may want to consider a custom optimized template expansion implementation instead of relying on a general purpose implementation
-of [[!rfc6570]].
+<b>Expansion Variables</b>
+<table>
+  <tr><th>Variable</th><th>Value</th></tr>
+  <tr>
+    <td><var>id32</var></td>
+    <td>
+      The input <var>entry ID</var> encoded as a [[rfc4648#section-7|base32hex]] string (using the digits 0-9, A-V) with padding
+      omitted.  When <var>entry ID</var> is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
+      but then all leading bytes that are equal to 0 are removed before encoding.  (For example, when the
+      integer is less than 256 only one byte is encoded.) If <var>entry ID</var> is 0 then one zero byte is encoded. When
+      <var>entry ID</var> is a string the raw bytes are encoded as base32hex.
+    </td>
+  </tr>
+  <tr>
+    <td><var>d1</var></td>
+    <td>
+      The last character of the string in the <var>id32</var> variable.
+      If <var>id32</var> variable is empty then, the value is the character _ (U+005F).
+    </td>
+  </tr>
+  <tr>
+    <td><var>d2</var></td>
+    <td>
+      The second last character of the string in the <var>id32</var> variable.
+      If the <var>id32</var> variable has less than 2 characters then, the value is the character _ (U+005F).
+    </td>
+  </tr>
+  <tr>
+    <td><var>d3</var></td>
+    <td>
+      The third last character of the string in the <var>id32</var> variable.
+      If the <var>id32</var> variable has less than 3 characters then, the value is the character _ (U+005F).
+    </td>
+  </tr>
+  <tr>
+    <td><var>d4</var></td>
+    <td>
+      The fourth last character of the string in the <var>id32</var> variable.
+      If the <var>id32</var> variable has less than 4 characters then, the value is the character _ (U+005F).
+    </td>
+  </tr>
+  <tr>
+    <td><var>id64</var></td>
+    <td>
+      The input <var>entry ID</var> encoded as a [[rfc4648#section-5|base64url]] string (using the digits A-Z, a-z, 0-9, -
+      (minus) and _ (underline)) with padding included. Because the padding character is '=', it must
+      be URL-encoded as '%3D'.  When <var>entry ID</var> is an unsigned integer it must first be converted to a big
+      endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding. 
+      (For example, when the integer is less than 256 only one byte is encoded.) If the <var>entry ID</var> is 0 then one
+      zero byte is encoded. When the <var>entry ID</var> is a string its raw bytes are encoded as
+      [[rfc4648#section-5|base64url]].
+    </td>
+  </tr>
+</table>
 
 <div class="example">
 
 Some example inputs and the corresponding expansions:
 
 <table>
-  <tr><th>Template</th><th>Input ID</th><th>ID Type</th><th>Expansion</th></tr>
+  <tr><th>Template Bytes</th><th>Input ID</th><th>ID Type</th><th>Expansion</th></tr>
   <tr>
-    <td>//foo.bar/{id}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 128]</td>
     <td>123</td>
     <td>Integer</td>
     <td>//foo.bar/FC</td>
   </tr>
   <tr>
-    <td>//foo.bar/{id}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 128]</td>
     <td>0</td>
     <td>Integer</td>
     <td>//foo.bar/00</td>
   </tr>
   <tr>
-    <td>//foo.bar/{d1}/{d2}/{id}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 128]</td>
     <td>478</td>
     <td>Integer</td>
     <td>//foo.bar/0/F/07F0</td>
   </tr>
   <tr>
-    <td>//foo.bar/{d1}/{d2}/{d3}/{id}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]</td>
     <td>123</td>
     <td>Integer</td>
     <td>//foo.bar/C/F/_/FC</td>
   </tr>
   <tr>
-    <td>//foo.bar/{d1}/{d2}/{d3}/{id}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]</td>
     <td>baz</td>
     <td>String</td>
     <td>//foo.bar/K/N/G/C9GNK</td>
   </tr>
   <tr>
-    <td>//foo.bar/{d1}/{d2}/{d3}/{id}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]</td>
     <td>z</td>
     <td>String</td>
     <td>//foo.bar/8/F/_/F8</td>
   </tr>
   <tr>
-    <td>//foo.bar/{d1}/{d2}/{d3}/{id}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]</td>
     <td>àbc</td>
     <td>String</td>
     <td>//foo.bar/O/O/4/OEG64OO</td>
   </tr>
   <tr>
-    <td>//foo.bar/{id64}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 133]</td>
     <td>14,000,000</td>
     <td>Integer</td>
     <td>//foo.bar/1Z-A</td>
   </tr>
   <tr>
-    <td>//foo.bar/{id64}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 133]</td>
     <td>0</td>
     <td>Integer</td>
     <td>//foo.bar/AA%3D%3D</td>
   </tr>
   <tr>
-    <td>//foo.bar/{id64}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 133]</td>
     <td>17,000,000</td>
     <td>Integer</td>
     <td>//foo.bar/AQNmQA%3D%3D</td>
   </tr>
   <tr>
-    <td>//foo.bar/{id64}</td>
+    <td>[10, /, /, f, o, o, ., b, a, r, /, 133]</td>
     <td>àbc</td>
     <td>String</td>
     <td>//foo.bar/w6BiYw%3D%3D</td>
@@ -2849,7 +2931,7 @@ additional tables needed to decode the mapping tables as early as possible in th
 
 <b>Choosing the input ID encoding</b>
 
-The specification supports two encodings for embedding patch IDs in the URI template. The first is [[rfc4648#section-7|base32hex]],
+The specification supports two encodings for embedding patch IDs in the URL template. The first is [[rfc4648#section-7|base32hex]],
 which is a good match for pre-generated patches that will typically be stored in a filesystem. Base32hex encoding only uses the
 letters 0-9 and A-V, which are safe letters for a file name in every commonly used filesystem, with no risk of collisions due to
 case-insensitivity. Because the string is embedded without padding this format cannot be reliably decoded, so it may be a poor

--- a/Overview.bs
+++ b/Overview.bs
@@ -2053,11 +2053,14 @@ The algorithm:
 3. If the most significant bit of <var>op code</var> is not set, then:
 
      *  Interpret the 7 least significant bits of <var>op code</var> as an unsigned integer, <var>number of literal bytes</var>.
+
+     *  If <var>number of literal bytes</var> is 0, then return an error.
    
-     *  Read <var>number of literal bytes</var> from <var>url template bytes</var> into <var>literal bytes</var>.
+     *  Read <var>number of literal bytes</var> from <var>url template bytes</var> into <var>literal bytes</var>. If there are not
+         enough remaining bytes in <var>url template bytes</var>, then return an error.
    
      *  Check that <var>literal bytes</var> is a valid UTF-8 encoded string according to [[UTF-8#section-4]].
-         If it is not, return an error.
+         If it is not, then return an error.
 
      *  Append <var>literal bytes</var> to the end of <var>URL string</var>.
 
@@ -2207,21 +2210,15 @@ Some example inputs and the corresponding expansions. Values in "Template Bytes"
   </tr>
   <tr>
     <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>
-    <td>baz</td>
+    <td>['b', 'a', 'z']</td>
     <td>String</td>
     <td>foo/K/N/G/C9GNK</td>
   </tr>
   <tr>
     <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>
-     <td>z</td>
+     <td>['z']</td>
     <td>String</td>
     <td>foo/8/F/_/F8</td>
-  </tr>
-  <tr>
-    <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]</td>
-     <td>àbc</td>
-    <td>String</td>
-    <td>foo/O/O/4/OEG64OO</td>
   </tr>
   <tr>
     <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]</td>
@@ -2243,9 +2240,39 @@ Some example inputs and the corresponding expansions. Values in "Template Bytes"
   </tr>
   <tr>
     <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]</td>
-    <td>àbc</td>
+    <td>[0xc3, 0xa0, 0x62, 0x63]</td>
     <td>String</td>
     <td>//foo.bar/w6BiYw%3D%3D</td>
+  </tr>
+</table>
+
+In the following examples expansion is expected to fail and return an error:
+
+<table>
+  <tr><th>Template Bytes</th><th>Input ID</th><th>ID Type</th><th>Failure Reason</th></tr>
+  <tr>
+    <td>[4, 'f', 'o', 'o', '/', 150]</td>
+    <td>123</td>
+    <td>Integer</td>
+    <td>Op code 150 is not valid</td>
+  </tr>
+  <tr>
+    <td>[4, 'f', 'o', 'o', '/', 0, 128]</td>
+    <td>123</td>
+    <td>Integer</td>
+    <td>Op code 0 is not valid</td>
+  </tr>
+  <tr>
+    <td>[10, 'f', 'o', 'o', '/', 128]</td>
+    <td>123</td>
+    <td>Integer</td>
+    <td>Not enough bytes in template for literal copy op code 10.</td>
+  </tr>
+  <tr>
+    <td>[4, 'f', 'o', 'o', 0x85, 128]</td>
+    <td>123</td>
+    <td>Integer</td>
+    <td>Literal bytes are not valid UTF-8.</td>
   </tr>
 </table>
 

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="252865307057fa6f4c1a05727fba880d5d3301bf" name="revision">
+  <meta content="d980726397bb6bbea8bde06bedf3a8d2f64a1a5b" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2550,7 +2550,8 @@ based on the input entry ID.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Initialize <var>URL string</var> to an empty byte array.</p>
+     <p>Initialize <var>URL string</var> to an empty byte array. <var>url template bytes</var> is used as a queue in the remaining steps.
+Read operations remove bytes from the front of the queue (starting with the byte at index 0).</p>
     <li data-md>
      <p>Read the next byte of <var>url template bytes</var> into <var>op code</var>. If there are no remaining bytes, then
 expansion is finished, return <var>URL string</var>.</p>
@@ -2558,12 +2559,12 @@ expansion is finished, return <var>URL string</var>.</p>
      <p>If the most significant bit of <var>op code</var> is not set, then:</p>
      <ul>
       <li data-md>
-       <p>Interpret the 7 least significant bits of <var>op code</var> as an unsigned integer, <var>number of literal bytes</var>.</p>
+       <p>Interpret the 7 least significant bits of <var>op code</var> as an unsigned integer, <var>number of literals</var>.</p>
       <li data-md>
-       <p>If <var>number of literal bytes</var> is 0, then return an error.</p>
+       <p>If <var>number of literals</var> is 0, then return an error.</p>
       <li data-md>
-       <p>Read <var>number of literal bytes</var> from <var>url template bytes</var> into <var>literal bytes</var>. If there are not
- enough remaining bytes in <var>url template bytes</var>, then return an error.</p>
+       <p>Read the next <var>number of literals</var> bytes from <var>url template bytes</var> into <var>literal bytes</var>.
+ If there are not enough remaining bytes in <var>url template bytes</var>, then return an error.</p>
       <li data-md>
        <p>Check that <var>literal bytes</var> is a valid UTF-8 encoded string according to <a href="https://www.rfc-editor.org/rfc/rfc3629#section-4">UTF-8, a transformation format of ISO 10646 § section-4</a>.
  If it is not, then return an error.</p>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="69f4a4dc1446319ac1a932bf17dafae8cc4d1911" name="revision">
+  <meta content="0c71595032d18cfdf3bac0ccd4f5e4ab242c910f" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -871,7 +871,7 @@ to complex scripts like Indic or Arabic.</p>
           <li><a href="#remove-entries-format-2"><span class="secno">5.3.2.2</span> <span class="content">Remove Entries from Format 2</span></a>
           <li><a href="#sparse-bit-set-decoding"><span class="secno">5.3.2.3</span> <span class="content">Sparse Bit Set</span></a>
          </ol>
-        <li><a href="#uri-templates"><span class="secno">5.3.3</span> <span class="content">URI Templates</span></a>
+        <li><a href="#url-templates"><span class="secno">5.3.3</span> <span class="content">URL Templates</span></a>
        </ol>
      </ol>
     <li>
@@ -1754,17 +1754,16 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       the most significant bit. Bit 8 is the least significant bit of appliedEntriesBitMap[1] and so on. 
      <tr>
       <td>uint16
-      <td>uriTemplateLength
-      <td> Length of the uriTemplate string. 
+      <td>urlTemplateLength
+      <td> Length of the urlTemplate byte array. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.3.3 URI Templates</a> which is used to produce URL strings associated with each entry.
-      Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
+      <td> A byte array containing a <a href="#url-templates">URL Template</a> which is used to produce URL strings associated with each entry. 
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchformat">patchFormat</dfn>
-      <td> Specifies the format of the patches linked to by uriTemplate.
+      <td> Specifies the format of the patches linked to by urlTemplate.
       Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
      <tr>
       <td>uint32
@@ -1900,8 +1899,8 @@ index and do not build an entry for it.</p>
        <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
 Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate">uriTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>. If
-the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
+       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a> and <var>entry index</var> as inputs. If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return
+an error.</p>
       <li data-md>
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
       <li data-md>
@@ -1921,8 +1920,8 @@ skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigne
       <li data-md>
        <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
       <li data-md>
-       <p>Convert <var>mapped entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate①">uriTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
-If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
+       <p>Convert <var>mapped entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template①">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a> and <var>mapped entry index</var> as inputs. If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then,
+return an error.</p>
       <li data-md>
        <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this entry.</p>
       <li data-md>
@@ -1969,8 +1968,8 @@ change the number of bytes.</p>
       <li data-md>
        <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by applying <a data-link-type="dfn" href="#format-1-patch-map-uritemplate" id="ref-for-format-1-patch-map-uritemplate②">uriTemplate</a> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
-If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
+       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template②">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a> and <var>entry index</var> as inputs. If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return
+an error.</p>
       <li data-md>
        <p>If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
      </ul>
@@ -2005,7 +2004,7 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchformat">defaultPatchFormat</dfn>
-      <td> Specifies the format of the patches linked to by uriTemplate (unless overridden by an entry).
+      <td> Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
       Must be set to one of the format numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table. 
      <tr>
       <td>uint24
@@ -2022,13 +2021,12 @@ If the template expansion results in an error (see: <a href="https://www.rfc-edi
       May be null (0). Offset is from the start of this table. 
      <tr>
       <td>uint16
-      <td>uriTemplateLength
-      <td> Length of the uriTemplate string. 
+      <td>urlTemplateLength
+      <td> Length of the urlTemplate byte array. 
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-uritemplate">uriTemplate</dfn>[uriTemplateLength]
-      <td> A <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string. Contains a <a href="#uri-templates">§ 5.3.3 URI Templates</a> which is used to produce URL strings associated with each entry.
-      Must be a valid <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> sequence. 
+      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
+      <td> A byte array containing a <a href="#url-templates">URL Template</a> which is used to produce URL strings associated with each entry. 
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-cffcharstringsoffset">cffCharStringsOffset</dfn>
@@ -2182,7 +2180,7 @@ being requested.</p>
        <p>pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
  the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑥">entryIdStringData</a>[<var>current id string byte</var>]
- to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-uritemplate" id="ref-for-format-2-patch-map-uritemplate">uriTemplate</a>.</p>
+ to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-urltemplate" id="ref-for-format-2-patch-map-urltemplate">urlTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
@@ -2211,7 +2209,7 @@ being requested.</p>
     <li data-md>
      <p><var>default patch format</var>: the default patch format if one isn’t specified.</p>
     <li data-md>
-     <p><var>uri template</var>: the URI template used to locate patches.</p>
+     <p><var>url template</var>: the URL template used to locate patches.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
@@ -2275,8 +2273,8 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
  If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
- If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template③">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>)
+ then, return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
         <li data-md>
@@ -2291,8 +2289,8 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
  Set <var>entry id</var> to the result. Increment <var>consumed id string bytes</var> by the number of bytes read.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
- If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template④">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>)
+ then, return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
         <li data-md>
@@ -2308,8 +2306,8 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
         <li data-md>
          <p>Set <var>entry id</var> to <var>entry id</var> + 1.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
- If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑤">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>)
+ then, return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
        </ul>
@@ -2317,8 +2315,8 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
        <p>Otherwise if <var>id string bytes</var> is present, then:</p>
        <ul>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by applying <var>uri template</var> following <a href="#uri-templates">§ 5.3.3 URI Templates</a>.
- If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>) then, return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑥">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error (see: <a href="https://www.rfc-editor.org/rfc/rfc6570#section-3">URI Template § section-3</a>)
+ then, return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
        </ul>
@@ -2529,116 +2527,189 @@ byte string:
 ]
 </pre>
    </div>
-   <h4 class="heading settled" data-level="5.3.3" id="uri-templates"><span class="secno">5.3.3. </span><span class="content">URI Templates</span><a class="self-link" href="#uri-templates"></a></h4>
-   <p>URI templates <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a> are used to convert numeric or string IDs into URL strings where patch files are located.
-A string ID is a sequence of bytes. The output of template expansion is a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string.</p>
-   <p>To limit the complexity of the template expansion implementation, URI templates in IFT are restricted to only <a href="https://www.rfc-editor.org/rfc/rfc6570#section-1.2">Level 1</a> substitution expressions. If a URI template contains expression(s) which do not match the level
-1 grammar (<a href="https://www.rfc-editor.org/rfc/rfc6570#section-2.2">URI Template § section-2.2</a>) or have variable names other than those defined below, then template expansion must result
-in an error. Additionally, for consistency when producing percent encodings as part of template expansion
-(<a href="https://www.rfc-editor.org/rfc/rfc6570#section-3.1">URI Template § section-3.1</a>) IFT implementations must only use uppercase letters.</p>
-   <p>Several variables are defined which are used to produce the expansion of the template:</p>
+   <h4 class="heading settled" data-level="5.3.3" id="url-templates"><span class="secno">5.3.3. </span><span class="content">URL Templates</span><a class="self-link" href="#url-templates"></a></h4>
+   <p>URL templates are used to compress the URL strings associated with each patch map entry. Each patch mapping table
+provides a URL template and then the URL string for each entry is produced by expanding the common template using
+each entry’s ID as an input. The output of template expansion is a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string.</p>
+   <p>URL templates are encoded as a series of one byte op codes that either insert literal values, or insert values
+based on the input entry ID.</p>
+   <p>The algorithm for decoding and expanding a URL template follows.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-expand-url-template">Expand URL Template</dfn></p>
+   <p>The inputs to this algorithm are:</p>
+   <ul>
+    <li data-md>
+     <p><var>url template bytes</var>: an array of bytes the contains the URL template.</p>
+    <li data-md>
+     <p><var>entry ID</var>: the ID of an entry. May be either an unsigned integer or an array of bytes.</p>
+   </ul>
+   <p>The algorithm outputs:</p>
+   <ul>
+    <li data-md>
+     <p><var>URL string</var>: an array of bytes representing the URL string. Encoded as <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a>.</p>
+   </ul>
+   <p>The algorithm:</p>
+   <ol>
+    <li data-md>
+     <p>Initialize <var>URL string</var> to an empty byte array.</p>
+    <li data-md>
+     <p>Read the next byte of <var>url template bytes</var> into <var>op code</var>. If there are no remaining bytes, then
+expansion is finished, return <var>URL string</var>.</p>
+    <li data-md>
+     <p>If the most significant bit of <var>op code</var> is not set, then:</p>
+     <ul>
+      <li data-md>
+       <p>Interpret the 7 least significant bits of <var>op code</var> as an unsigned integer, <var>number of literal bytes</var>.</p>
+      <li data-md>
+       <p>Read <var>number of literal bytes</var> from <var>url template bytes</var> into <var>literal bytes</var>.</p>
+      <li data-md>
+       <p>Check that <var>literal bytes</var> is a valid UTF-8 encoded string according to <a href="https://www.rfc-editor.org/rfc/rfc3629#section-4">UTF-8, a transformation format of ISO 10646 § section-4</a>.
+ If it is not, return an error.</p>
+      <li data-md>
+       <p>Append <var>literal bytes</var> to the end of <var>URL string</var>.</p>
+      <li data-md>
+       <p>Go to step 2.</p>
+     </ul>
+    <li data-md>
+     <p>If the most significant bit of <var>op code</var> is set, then:</p>
+     <ul>
+      <li data-md>
+       <p>Look up <var>op code</var> in the proceeding <b>Op Code Reference Table</b>. Perform the operation specified
+ in the "Insertion Operation" column. If <var>op code</var> is not found in the table, then return an error.</p>
+      <li data-md>
+       <p>Go to step 2.</p>
+     </ul>
+   </ol>
+   <p><b>Op Code Reference Table</b></p>
+   <table>
+    <tbody>
+     <tr>
+      <th>Name
+      <th>Op Code Value
+      <th>Insertion Operation
+     <tr>
+      <td>Insert id32
+      <td>128 (0b10000000)
+      <td> Append the value of the <var>id32</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+     <tr>
+      <td>Insert d1
+      <td>129 (0b10000001)
+      <td> Append the value of the <var>d1</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+     <tr>
+      <td>Insert d2
+      <td>130 (0b10000010)
+      <td> Append the value of the <var>d2</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+     <tr>
+      <td>Insert d3
+      <td>131 (0b10000011)
+      <td> Append the value of the <var>d3</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+     <tr>
+      <td>Insert d4
+      <td>132 (0b10000100)
+      <td> Append the value of the <var>d4</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+     <tr>
+      <td>Insert id64
+      <td>133 (0b10000101)
+      <td> Append the value of the <var>id64</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+   </table>
+   <p><b>Expansion Variables</b></p>
    <table>
     <tbody>
      <tr>
       <th>Variable
       <th>Value
      <tr>
-      <td><code>id</code>
-      <td> The input id encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a> string (using the digits 0-9, A-V) with padding
-      omitted.  When the id is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
+      <td><var>id32</var>
+      <td> The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a> string (using the digits 0-9, A-V) with padding
+      omitted.  When <var>entry ID</var> is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
       but then all leading bytes that are equal to 0 are removed before encoding.  (For example, when the
-      integer is less than 256 only one byte is encoded.) If the input id is 0 then one zero byte is encoded. When the input
-      id is a string the raw bytes are encoded as base32hex. 
+      integer is less than 256 only one byte is encoded.) If <var>entry ID</var> is 0 then one zero byte is encoded. When <var>entry ID</var> is a string the raw bytes are encoded as base32hex. 
      <tr>
-      <td><code>d1</code>
-      <td> The last character of the string in the <code>id</code> variable.
-      If <code>id</code> variable is empty then, the value is the character _ (U+005F). 
+      <td><var>d1</var>
+      <td> The last character of the string in the <var>id32</var> variable.
+      If <var>id32</var> variable is empty then, the value is the character _ (U+005F). 
      <tr>
-      <td><code>d2</code>
-      <td> The second last character of the string in the <code>id</code> variable.
-      If the <code>id</code> variable has less than 2 characters then, the value is the character _ (U+005F). 
+      <td><var>d2</var>
+      <td> The second last character of the string in the <var>id32</var> variable.
+      If the <var>id32</var> variable has less than 2 characters then, the value is the character _ (U+005F). 
      <tr>
-      <td><code>d3</code>
-      <td> The third last character of the string in the <code>id</code> variable.
-      If the <code>id</code> variable has less than 3 characters then, the value is the character _ (U+005F). 
+      <td><var>d3</var>
+      <td> The third last character of the string in the <var>id32</var> variable.
+      If the <var>id32</var> variable has less than 3 characters then, the value is the character _ (U+005F). 
      <tr>
-      <td><code>d4</code>
-      <td> The fourth last character of the string in the <code>id</code> variable.
-      If the <code>id</code> variable has less than 4 characters then, the value is the character _ (U+005F). 
+      <td><var>d4</var>
+      <td> The fourth last character of the string in the <var>id32</var> variable.
+      If the <var>id32</var> variable has less than 4 characters then, the value is the character _ (U+005F). 
      <tr>
-      <td><code>id64</code>
-      <td> The input id encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a> string (using the digits A-Z, a-z, 0-9, -
+      <td><var>id64</var>
+      <td> The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a> string (using the digits A-Z, a-z, 0-9, -
       (minus) and _ (underline)) with padding included. Because the padding character is '=', it must
-      be URL-encoded as "%3D'.  When the id is an unsigned integer it must first be converted to a big
+      be URL-encoded as '%3D'.  When <var>entry ID</var> is an unsigned integer it must first be converted to a big
       endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding. 
-      (For example, when the integer is less than 256 only one byte is encoded.) If the input id is 0 then one
-      zero byte is encoded. When the input id is a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
+      (For example, when the integer is less than 256 only one byte is encoded.) If the <var>entry ID</var> is 0 then one
+      zero byte is encoded. When the <var>entry ID</var> is a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
    </table>
-   <p class="note" role="note"><span class="marker">Note:</span> since there is a small fixed set of variables and only level one expression are supported for expansion, implementations
-may want to consider a custom optimized template expansion implementation instead of relying on a general purpose implementation
-of <a data-link-type="biblio" href="#biblio-rfc6570" title="URI Template">[rfc6570]</a>.</p>
-   <div class="example" id="example-21a3582d">
-    <a class="self-link" href="#example-21a3582d"></a> 
+   <div class="example" id="example-7e8ab422">
+    <a class="self-link" href="#example-7e8ab422"></a> 
     <p>Some example inputs and the corresponding expansions:</p>
     <table>
      <tbody>
       <tr>
-       <th>Template
+       <th>Template Bytes
        <th>Input ID
        <th>ID Type
        <th>Expansion
       <tr>
-       <td>//foo.bar/{id}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 128]
        <td>123
        <td>Integer
        <td>//foo.bar/FC
       <tr>
-       <td>//foo.bar/{id}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 128]
        <td>0
        <td>Integer
        <td>//foo.bar/00
       <tr>
-       <td>//foo.bar/{d1}/{d2}/{id}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 128]
        <td>478
        <td>Integer
        <td>//foo.bar/0/F/07F0
       <tr>
-       <td>//foo.bar/{d1}/{d2}/{d3}/{id}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]
        <td>123
        <td>Integer
        <td>//foo.bar/C/F/_/FC
       <tr>
-       <td>//foo.bar/{d1}/{d2}/{d3}/{id}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]
        <td>baz
        <td>String
        <td>//foo.bar/K/N/G/C9GNK
       <tr>
-       <td>//foo.bar/{d1}/{d2}/{d3}/{id}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]
        <td>z
        <td>String
        <td>//foo.bar/8/F/_/F8
       <tr>
-       <td>//foo.bar/{d1}/{d2}/{d3}/{id}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]
        <td>àbc
        <td>String
        <td>//foo.bar/O/O/4/OEG64OO
       <tr>
-       <td>//foo.bar/{id64}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 133]
        <td>14,000,000
        <td>Integer
        <td>//foo.bar/1Z-A
       <tr>
-       <td>//foo.bar/{id64}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 133]
        <td>0
        <td>Integer
        <td>//foo.bar/AA%3D%3D
       <tr>
-       <td>//foo.bar/{id64}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 133]
        <td>17,000,000
        <td>Integer
        <td>//foo.bar/AQNmQA%3D%3D
       <tr>
-       <td>//foo.bar/{id64}
+       <td>[10, /, /, f, o, o, ., b, a, r, /, 133]
        <td>àbc
        <td>String
        <td>//foo.bar/w6BiYw%3D%3D
@@ -3207,7 +3278,7 @@ patch mapping prior to receiving all of the font data and potentially initiate r
 in any order in the patch file. So for the same reasons encoders should consider placing updates to the mapping tables plus any
 additional tables needed to decode the mapping tables as early as possible in the patch file.</p>
    <p><b>Choosing the input ID encoding</b></p>
-   <p>The specification supports two encodings for embedding patch IDs in the URI template. The first is <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a>,
+   <p>The specification supports two encodings for embedding patch IDs in the URL template. The first is <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a>,
 which is a good match for pre-generated patches that will typically be stored in a filesystem. Base32hex encoding only uses the
 letters 0-9 and A-V, which are safe letters for a file name in every commonly used filesystem, with no risk of collisions due to
 case-insensitivity. Because the string is embedded without padding this format cannot be reliably decoded, so it may be a poor
@@ -3941,6 +4012,7 @@ content covered by the target subset definition.</p>
    <li><a href="#featurerecord-entrymapcount">entryMapCount</a><span>, in § 5.3.1</span>
    <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 5.3.1</span>
    <li><a href="#feature-map-entrymaprecords">entryMapRecords</a><span>, in § 5.3.1</span>
+   <li><a href="#abstract-opdef-expand-url-template">Expand URL Template</a><span>, in § 5.3.3</span>
    <li><a href="#abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</a><span>, in § 4.3</span>
    <li><a href="#mapping-entry-featurecount">featureCount</a><span>, in § 5.3.2</span>
    <li><a href="#feature-map">Feature Map</a><span>, in § 5.3.1</span>
@@ -4031,10 +4103,10 @@ content covered by the target subset definition.</p>
      <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
    <li>
-    uriTemplate
+    urlTemplate
     <ul>
-     <li><a href="#format-1-patch-map-uritemplate">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#format-2-patch-map-uritemplate">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
+     <li><a href="#format-1-patch-map-urltemplate">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
+     <li><a href="#format-2-patch-map-urltemplate">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
     </ul>
   </ul>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -4311,6 +4383,7 @@ let dfnPanelData = {
 "abstract-opdef-apply-table-keyed-patch": {"dfnID":"abstract-opdef-apply-table-keyed-patch","dfnText":"Apply table keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-table-keyed-patch"},
 "abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2461"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2462"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2463"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2464"}],"title":"Example 1: Table and Glyph Keyed Patches"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2465"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2466"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2467"}],"title":"Example 2: Glyph Keyed Patches with Child Entries"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
+"abstract-opdef-expand-url-template": {"dfnID":"abstract-opdef-expand-url-template","dfnText":"Expand URL Template","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-expand-url-template"},{"id":"ref-for-abstract-opdef-expand-url-template\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-abstract-opdef-expand-url-template\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"},{"refs":[{"id":"ref-for-abstract-opdef-expand-url-template\u2462"},{"id":"ref-for-abstract-opdef-expand-url-template\u2463"},{"id":"ref-for-abstract-opdef-expand-url-template\u2464"},{"id":"ref-for-abstract-opdef-expand-url-template\u2465"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#abstract-opdef-expand-url-template"},
 "abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"}],"title":"4.5. Target Subset Definition"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2464"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2465"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2466"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2467"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2468"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u24ea"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u2460"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u2461"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "abstract-opdef-fully-expand-a-font-subset": {"dfnID":"abstract-opdef-fully-expand-a-font-subset","dfnText":"Fully Expand a Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset"}],"title":"2.1. Offline Usage"},{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2460"},{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2461"}],"title":"7. Encoding"}],"url":"#abstract-opdef-fully-expand-a-font-subset"},
 "abstract-opdef-handle-errors": {"dfnID":"abstract-opdef-handle-errors","dfnText":"Handle errors","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-handle-errors"},{"id":"ref-for-abstract-opdef-handle-errors\u2460"},{"id":"ref-for-abstract-opdef-handle-errors\u2461"},{"id":"ref-for-abstract-opdef-handle-errors\u2462"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-handle-errors"},
@@ -4352,7 +4425,7 @@ let dfnPanelData = {
 "format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.3.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
 "format-1-patch-map-maxglyphmapentryindex": {"dfnID":"format-1-patch-map-maxglyphmapentryindex","dfnText":"maxGlyphMapEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2461"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxglyphmapentryindex"},
 "format-1-patch-map-patchformat": {"dfnID":"format-1-patch-map-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchformat"},{"id":"ref-for-format-1-patch-map-patchformat\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchformat"},
-"format-1-patch-map-uritemplate": {"dfnID":"format-1-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate"},{"id":"ref-for-format-1-patch-map-uritemplate\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-uritemplate\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-uritemplate"},
+"format-1-patch-map-urltemplate": {"dfnID":"format-1-patch-map-urltemplate","dfnText":"urlTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-urltemplate"},{"id":"ref-for-format-1-patch-map-urltemplate\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-urltemplate\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-urltemplate"},
 "format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.3.2.2. Remove Entries from Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2461"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#format-2-patch-map"},
 "format-2-patch-map-cff2charstringsoffset": {"dfnID":"format-2-patch-map-cff2charstringsoffset","dfnText":"cff2CharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-cff2charstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-format-2-patch-map-cff2charstringsoffset\u2460"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#format-2-patch-map-cff2charstringsoffset"},
 "format-2-patch-map-cffcharstringsoffset": {"dfnID":"format-2-patch-map-cffcharstringsoffset","dfnText":"cffCharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-cffcharstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-format-2-patch-map-cffcharstringsoffset\u2460"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#format-2-patch-map-cffcharstringsoffset"},
@@ -4363,7 +4436,7 @@ let dfnPanelData = {
 "format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2465"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2466"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
 "format-2-patch-map-flags": {"dfnID":"format-2-patch-map-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-flags"},{"id":"ref-for-format-2-patch-map-flags\u2460"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#format-2-patch-map-flags"},
 "format-2-patch-map-format": {"dfnID":"format-2-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-format"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-format"},
-"format-2-patch-map-uritemplate": {"dfnID":"format-2-patch-map-uritemplate","dfnText":"uriTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-uritemplate"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-uritemplate"},
+"format-2-patch-map-urltemplate": {"dfnID":"format-2-patch-map-urltemplate","dfnText":"urlTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-urltemplate"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-urltemplate"},
 "full-invalidation": {"dfnID":"full-invalidation","dfnText":"Full Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-full-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-full-invalidation\u2460"}],"title":"6.1. Formats Summary"}],"url":"#full-invalidation"},
 "glyph-closure": {"dfnID":"glyph-closure","dfnText":"glyph closure","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-closure"}],"title":"7.1. Encoding Considerations"}],"url":"#glyph-closure"},
 "glyph-keyed-patch": {"dfnID":"glyph-keyed-patch","dfnText":"Glyph keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch"},
@@ -4800,6 +4873,7 @@ function genLinkingSyntaxes(dfn) {
 {
 let refsData = {
 "#abstract-opdef-check-entry-intersection": {"displayText":"Check entry intersection","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Check entry intersection","type":"abstract-op","url":"#abstract-opdef-check-entry-intersection"},
+"#abstract-opdef-expand-url-template": {"displayText":"Expand URL Template","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Expand URL Template","type":"abstract-op","url":"#abstract-opdef-expand-url-template"},
 "#abstract-opdef-extend-an-incremental-font-subset": {"displayText":"Extend an Incremental Font Subset","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Extend an Incremental Font Subset","type":"abstract-op","url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "#abstract-opdef-fully-expand-a-font-subset": {"displayText":"Fully Expand a Font Subset","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Fully Expand a Font Subset","type":"abstract-op","url":"#abstract-opdef-fully-expand-a-font-subset"},
 "#abstract-opdef-handle-errors": {"displayText":"Handle errors","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Handle errors","type":"abstract-op","url":"#abstract-opdef-handle-errors"},
@@ -4839,7 +4913,7 @@ let refsData = {
 "#format-1-patch-map-maxentryindex": {"displayText":"maxentryindex","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxentryindex","type":"dfn","url":"#format-1-patch-map-maxentryindex"},
 "#format-1-patch-map-maxglyphmapentryindex": {"displayText":"maxglyphmapentryindex","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxglyphmapentryindex","type":"dfn","url":"#format-1-patch-map-maxglyphmapentryindex"},
 "#format-1-patch-map-patchformat": {"displayText":"patchformat","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchformat","type":"dfn","url":"#format-1-patch-map-patchformat"},
-"#format-1-patch-map-uritemplate": {"displayText":"uritemplate","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-1-patch-map-uritemplate"},
+"#format-1-patch-map-urltemplate": {"displayText":"urltemplate","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"urltemplate","type":"dfn","url":"#format-1-patch-map-urltemplate"},
 "#format-2-patch-map": {"displayText":"format 2 patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 2 patch map","type":"dfn","url":"#format-2-patch-map"},
 "#format-2-patch-map-cff2charstringsoffset": {"displayText":"cff2charstringsoffset","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cff2charstringsoffset","type":"dfn","url":"#format-2-patch-map-cff2charstringsoffset"},
 "#format-2-patch-map-cffcharstringsoffset": {"displayText":"cffcharstringsoffset","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cffcharstringsoffset","type":"dfn","url":"#format-2-patch-map-cffcharstringsoffset"},
@@ -4850,7 +4924,7 @@ let refsData = {
 "#format-2-patch-map-entryidstringdata": {"displayText":"entryidstringdata","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entryidstringdata","type":"dfn","url":"#format-2-patch-map-entryidstringdata"},
 "#format-2-patch-map-flags": {"displayText":"flags","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"flags","type":"dfn","url":"#format-2-patch-map-flags"},
 "#format-2-patch-map-format": {"displayText":"format","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#format-2-patch-map-format"},
-"#format-2-patch-map-uritemplate": {"displayText":"uritemplate","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"uritemplate","type":"dfn","url":"#format-2-patch-map-uritemplate"},
+"#format-2-patch-map-urltemplate": {"displayText":"urltemplate","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"urltemplate","type":"dfn","url":"#format-2-patch-map-urltemplate"},
 "#full-invalidation": {"displayText":"full invalidation","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"full invalidation","type":"dfn","url":"#full-invalidation"},
 "#glyph-closure": {"displayText":"glyph closure","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyph closure","type":"dfn","url":"#glyph-closure"},
 "#glyph-keyed-patch": {"displayText":"glyph keyed patch","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyph keyed patch","type":"dfn","url":"#glyph-keyed-patch"},

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="0c71595032d18cfdf3bac0ccd4f5e4ab242c910f" name="revision">
+  <meta content="0dbd615b617cb6076b9df6c152514450188eb4af" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2629,15 +2629,15 @@ expansion is finished, return <var>URL string</var>.</p>
       If <var>id32</var> variable is empty then, the value is the character _ (U+005F). 
      <tr>
       <td><var>d2</var>
-      <td> The second last character of the string in the <var>id32</var> variable.
+      <td> The second to last character of the string in the <var>id32</var> variable.
       If the <var>id32</var> variable has less than 2 characters then, the value is the character _ (U+005F). 
      <tr>
       <td><var>d3</var>
-      <td> The third last character of the string in the <var>id32</var> variable.
+      <td> The third to last character of the string in the <var>id32</var> variable.
       If the <var>id32</var> variable has less than 3 characters then, the value is the character _ (U+005F). 
      <tr>
       <td><var>d4</var>
-      <td> The fourth last character of the string in the <var>id32</var> variable.
+      <td> The fourth to last character of the string in the <var>id32</var> variable.
       If the <var>id32</var> variable has less than 4 characters then, the value is the character _ (U+005F). 
      <tr>
       <td><var>id64</var>
@@ -2648,9 +2648,9 @@ expansion is finished, return <var>URL string</var>.</p>
       (For example, when the integer is less than 256 only one byte is encoded.) If the <var>entry ID</var> is 0 then one
       zero byte is encoded. When the <var>entry ID</var> is a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
    </table>
-   <div class="example" id="example-7e8ab422">
-    <a class="self-link" href="#example-7e8ab422"></a> 
-    <p>Some example inputs and the corresponding expansions:</p>
+   <div class="example" id="example-ed261c7f">
+    <a class="self-link" href="#example-ed261c7f"></a> 
+    <p>Some example inputs and the corresponding expansions. Values in "Template Bytes" column are provided as C style byte arrays.</p>
     <table>
      <tbody>
       <tr>
@@ -2659,57 +2659,62 @@ expansion is finished, return <var>URL string</var>.</p>
        <th>ID Type
        <th>Expansion
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 128]
+       <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 128]
        <td>123
        <td>Integer
        <td>//foo.bar/FC
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 128]
+       <td>[8, 'f', 'o', 'o', '?', 'b', 'a', 'r', '=', 128]
+       <td>123
+       <td>Integer
+       <td>foo?bar=FC
+      <tr>
+       <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 128]
        <td>0
        <td>Integer
        <td>//foo.bar/00
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 128]
+       <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 128]
        <td>478
        <td>Integer
-       <td>//foo.bar/0/F/07F0
+       <td>foo/0/F/07F0
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]
+       <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
        <td>123
        <td>Integer
-       <td>//foo.bar/C/F/_/FC
+       <td>foo/C/F/_/FC
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]
+       <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
        <td>baz
        <td>String
-       <td>//foo.bar/K/N/G/C9GNK
+       <td>foo/K/N/G/C9GNK
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]
+       <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
        <td>z
        <td>String
-       <td>//foo.bar/8/F/_/F8
+       <td>foo/8/F/_/F8
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 129, 1, /, 130, 1, /, 131, 1, /, 128]
+       <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
        <td>àbc
        <td>String
-       <td>//foo.bar/O/O/4/OEG64OO
+       <td>foo/O/O/4/OEG64OO
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 133]
+       <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]
        <td>14,000,000
        <td>Integer
        <td>//foo.bar/1Z-A
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 133]
+       <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]
        <td>0
        <td>Integer
        <td>//foo.bar/AA%3D%3D
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 133]
+       <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]
        <td>17,000,000
        <td>Integer
        <td>//foo.bar/AQNmQA%3D%3D
       <tr>
-       <td>[10, /, /, f, o, o, ., b, a, r, /, 133]
+       <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]
        <td>àbc
        <td>String
        <td>//foo.bar/w6BiYw%3D%3D

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="d980726397bb6bbea8bde06bedf3a8d2f64a1a5b" name="revision">
+  <meta content="c94b7d54b9336616f25a4c0c08dc68642635a6bd" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2652,8 +2652,8 @@ expansion is finished, return <var>URL string</var>.</p>
       (For example, when the integer is less than 256 only one byte is encoded.) If the <var>entry ID</var> is 0 then one
       zero byte is encoded. When the <var>entry ID</var> is a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
    </table>
-   <div class="example" id="example-13e51108">
-    <a class="self-link" href="#example-13e51108"></a> 
+   <div class="example" id="example-305f10ca">
+    <a class="self-link" href="#example-305f10ca"></a> 
     <p>Some example inputs and the corresponding expansions. Values in "Template Bytes" column are provided as C style byte arrays.</p>
     <table>
      <tbody>
@@ -2663,10 +2663,10 @@ expansion is finished, return <var>URL string</var>.</p>
        <th>ID Type
        <th>Expansion
       <tr>
-       <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 128]
+       <td>[16, 'h', 't', 't', 'p', 's', ':', '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 128]
        <td>123
        <td>Integer
-       <td>//foo.bar/FC
+       <td>https://foo.bar/FC
       <tr>
        <td>[8, 'f', 'o', 'o', '?', 'b', 'a', 'r', '=', 128]
        <td>123
@@ -2678,15 +2678,15 @@ expansion is finished, return <var>URL string</var>.</p>
        <td>Integer
        <td>//foo.bar/00
       <tr>
-       <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 128]
+       <td>[5, '/', 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 128]
        <td>478
        <td>Integer
-       <td>foo/0/F/07F0
+       <td>/foo/0/F/07F0
       <tr>
-       <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
+       <td>[5, '/', 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
        <td>123
        <td>Integer
-       <td>foo/C/F/_/FC
+       <td>/foo/C/F/_/FC
       <tr>
        <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
        <td>['b', 'a', 'z']

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="0dbd615b617cb6076b9df6c152514450188eb4af" name="revision">
+  <meta content="252865307057fa6f4c1a05727fba880d5d3301bf" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -2560,10 +2560,13 @@ expansion is finished, return <var>URL string</var>.</p>
       <li data-md>
        <p>Interpret the 7 least significant bits of <var>op code</var> as an unsigned integer, <var>number of literal bytes</var>.</p>
       <li data-md>
-       <p>Read <var>number of literal bytes</var> from <var>url template bytes</var> into <var>literal bytes</var>.</p>
+       <p>If <var>number of literal bytes</var> is 0, then return an error.</p>
+      <li data-md>
+       <p>Read <var>number of literal bytes</var> from <var>url template bytes</var> into <var>literal bytes</var>. If there are not
+ enough remaining bytes in <var>url template bytes</var>, then return an error.</p>
       <li data-md>
        <p>Check that <var>literal bytes</var> is a valid UTF-8 encoded string according to <a href="https://www.rfc-editor.org/rfc/rfc3629#section-4">UTF-8, a transformation format of ISO 10646 § section-4</a>.
- If it is not, return an error.</p>
+ If it is not, then return an error.</p>
       <li data-md>
        <p>Append <var>literal bytes</var> to the end of <var>URL string</var>.</p>
       <li data-md>
@@ -2648,8 +2651,8 @@ expansion is finished, return <var>URL string</var>.</p>
       (For example, when the integer is less than 256 only one byte is encoded.) If the <var>entry ID</var> is 0 then one
       zero byte is encoded. When the <var>entry ID</var> is a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
    </table>
-   <div class="example" id="example-ed261c7f">
-    <a class="self-link" href="#example-ed261c7f"></a> 
+   <div class="example" id="example-13e51108">
+    <a class="self-link" href="#example-13e51108"></a> 
     <p>Some example inputs and the corresponding expansions. Values in "Template Bytes" column are provided as C style byte arrays.</p>
     <table>
      <tbody>
@@ -2685,19 +2688,14 @@ expansion is finished, return <var>URL string</var>.</p>
        <td>foo/C/F/_/FC
       <tr>
        <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
-       <td>baz
+       <td>['b', 'a', 'z']
        <td>String
        <td>foo/K/N/G/C9GNK
       <tr>
        <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
-       <td>z
+       <td>['z']
        <td>String
        <td>foo/8/F/_/F8
-      <tr>
-       <td>[4, 'f', 'o', 'o', '/', 129, 1, '/', 130, 1, '/', 131, 1, '/', 128]
-       <td>àbc
-       <td>String
-       <td>foo/O/O/4/OEG64OO
       <tr>
        <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]
        <td>14,000,000
@@ -2715,9 +2713,38 @@ expansion is finished, return <var>URL string</var>.</p>
        <td>//foo.bar/AQNmQA%3D%3D
       <tr>
        <td>[10, '/', '/', 'f', 'o', 'o', '.', 'b', 'a', 'r', '/', 133]
-       <td>àbc
+       <td>[0xc3, 0xa0, 0x62, 0x63]
        <td>String
        <td>//foo.bar/w6BiYw%3D%3D
+    </table>
+    <p>In the following examples expansion is expected to fail and return an error:</p>
+    <table>
+     <tbody>
+      <tr>
+       <th>Template Bytes
+       <th>Input ID
+       <th>ID Type
+       <th>Failure Reason
+      <tr>
+       <td>[4, 'f', 'o', 'o', '/', 150]
+       <td>123
+       <td>Integer
+       <td>Op code 150 is not valid
+      <tr>
+       <td>[4, 'f', 'o', 'o', '/', 0, 128]
+       <td>123
+       <td>Integer
+       <td>Op code 0 is not valid
+      <tr>
+       <td>[10, 'f', 'o', 'o', '/', 128]
+       <td>123
+       <td>Integer
+       <td>Not enough bytes in template for literal copy op code 10.
+      <tr>
+       <td>[4, 'f', 'o', 'o', 0x85, 128]
+       <td>123
+       <td>Integer
+       <td>Literal bytes are not valid UTF-8.
     </table>
    </div>
    <h2 class="heading settled" data-level="6" id="font-patch-formats"><span class="secno">6. </span><span class="content">Font Patch Formats</span><a class="self-link" href="#font-patch-formats"></a></h2>


### PR DESCRIPTION
Since url templates is primarily a compression mechanism internal to the IFT tables there is no need for templates to be human readable. By switching to an opcode based approach we significantly simplify the template expansion process leading to simpler client implementations.

See: https://github.com/w3c/IFT/issues/259#issuecomment-2794840010 for context and more details.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/281.html" title="Last updated on Jun 11, 2025, 6:42 PM UTC (03af9d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/281/6e79bc4...03af9d4.html" title="Last updated on Jun 11, 2025, 6:42 PM UTC (03af9d4)">Diff</a>