### PR TITLE
Cleanup references to rfc6570.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -744,7 +744,7 @@ first referrer is set to the initial font's URL, second URL resolution uses the 
 
 <dfn abstract-op>Handle errors</dfn>
 
-If the extending the font subset process has failed with an error then, some of the data within the font may not be fully loaded and as
+If the extending the font subset process has failed with an error, then some of the data within the font may not be fully loaded and as
 a result rendering content which relies on the missing data may result in incorrect renderings. The client may choose to continue using
 the font, but should only use it for the rendering of code points, features, and design space that are fully loaded according to
 [[#ift-font-coverage]]. Rendering of all other content should fallback to a different font following normal client fallback logic.
@@ -1285,7 +1285,7 @@ The algorithm:
         Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.
 
     *  Convert <var>entry index</var> into a URL string by invoking [$Expand URL Template$] with [=Format 1 Patch Map/urlTemplate=]
-        and <var>entry index</var> as inputs. If the template expansion results in an error then, return
+        and <var>entry index</var> as inputs. If the template expansion results in an error, then return
         an error.
 
     *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
@@ -1313,8 +1313,7 @@ The algorithm:
         [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
 
     *  Convert <var>mapped entry index</var> into a URL string by invoking [$Expand URL Template$] with [=Format 1 Patch Map/urlTemplate=]
-        and <var>mapped entry index</var> as inputs. If the template expansion results in an error then,
-        return an error.
+        and <var>mapped entry index</var> as inputs. If the template expansion results in an error, then return an error.
 
     *  If the bit for <var>mapped entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this entry.
 
@@ -1366,7 +1365,7 @@ The algorithm:
         <var>entry index</var>.
 
     *  Convert <var>entry index</var> into a URL string by invoking [$Expand URL Template$] with [=Format 1 Patch Map/urlTemplate=]
-        and <var>entry index</var> as inputs. If the template expansion results in an error then, return
+        and <var>entry index</var> as inputs. If the template expansion results in an error, then return
         an error.
 
     *  If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in
@@ -1763,7 +1762,7 @@ The algorithm:
              If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.
 
          *  Convert <var>entry id</var> into a URL string by invoking [$Expand URL Template$] with <var>url template</var>
-             and <var>entry id</var> as inputs. If the template expansion results in an error then, return an error.
+             and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
 
@@ -1777,7 +1776,7 @@ The algorithm:
              Set <var>entry id</var> to the result. Increment <var>consumed id string bytes</var> by the number of bytes read.
 
          *  Convert <var>entry id</var> into a URL string by invoking [$Expand URL Template$] with <var>url template</var>
-             and <var>entry id</var> as inputs. If the template expansion results in an error then, return an error.
+             and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
 
@@ -1790,14 +1789,14 @@ The algorithm:
          *  Set <var>entry id</var> to <var>entry id</var> + 1.
 
          *  Convert <var>entry id</var> into a URL string by invoking [$Expand URL Template$] with <var>url template</var>
-             and <var>entry id</var> as inputs. If the template expansion results in an error then, return an error.
+             and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
 
     *  Otherwise if <var>id string bytes</var> is present, then:
 
          *  Convert <var>entry id</var> into a URL string by invoking [$Expand URL Template$] with <var>url template</var>
-             and <var>entry id</var> as inputs. If the template expansion results in an error then, return an error.
+             and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.
 
          *  Add the generated patch URL string to <var>entry</var>.
 

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="9594d696a6b35c22f97b072a1d64db603c204dfb" name="revision">
+  <meta content="f01ad7ce382baa9299972ae49ac6bc45136e7803" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1472,7 +1472,7 @@ Otherwise return an error.</p>
    <p class="note" role="note"><span class="marker">Note:</span> the fetch settings aim to match those used for CSS font loading <a href="https://www.w3.org/TR/css-fonts-4/#font-fetching-requirements"><cite>CSS Fonts 4</cite> § 4.8.2 Font fetching requirements</a>, but with a couple of differences:
 first referrer is set to the initial font’s URL, second URL resolution uses the initial font as the base instead of the stylesheet.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-errors">Handle errors</dfn></p>
-   <p>If the extending the font subset process has failed with an error then, some of the data within the font may not be fully loaded and as
+   <p>If the extending the font subset process has failed with an error, then some of the data within the font may not be fully loaded and as
 a result rendering content which relies on the missing data may result in incorrect renderings. The client may choose to continue using
 the font, but should only use it for the rendering of code points, features, and design space that are fully loaded according to <a href="#ift-font-coverage">§ 4.6 Determining what Content a Font can Render</a>. Rendering of all other content should fallback to a different font following normal client fallback logic.</p>
    <p>If the error occurred during <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file①">Load patch file</a>, then the client may continue trying to extend the font subset. In step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</a> within each invalidation grouping any patches which failed to load are excluded from selection.
@@ -1900,7 +1900,7 @@ index and do not build an entry for it.</p>
        <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
 Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a> and <var>entry index</var> as inputs. If the template expansion results in an error then, return
+       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a> and <var>entry index</var> as inputs. If the template expansion results in an error, then return
 an error.</p>
       <li data-md>
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
@@ -1921,8 +1921,7 @@ skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigne
       <li data-md>
        <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
       <li data-md>
-       <p>Convert <var>mapped entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template①">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a> and <var>mapped entry index</var> as inputs. If the template expansion results in an error then,
-return an error.</p>
+       <p>Convert <var>mapped entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template①">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a> and <var>mapped entry index</var> as inputs. If the template expansion results in an error, then return an error.</p>
       <li data-md>
        <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this entry.</p>
       <li data-md>
@@ -1969,7 +1968,7 @@ change the number of bytes.</p>
       <li data-md>
        <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template②">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a> and <var>entry index</var> as inputs. If the template expansion results in an error then, return
+       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template②">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a> and <var>entry index</var> as inputs. If the template expansion results in an error, then return
 an error.</p>
       <li data-md>
        <p>If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
@@ -2274,7 +2273,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
  If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template③">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error then, return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template③">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
         <li data-md>
@@ -2289,7 +2288,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
  Set <var>entry id</var> to the result. Increment <var>consumed id string bytes</var> by the number of bytes read.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template④">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error then, return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template④">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
         <li data-md>
@@ -2305,7 +2304,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
         <li data-md>
          <p>Set <var>entry id</var> to <var>entry id</var> + 1.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑤">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error then, return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑤">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
        </ul>
@@ -2313,7 +2312,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
        <p>Otherwise if <var>id string bytes</var> is present, then:</p>
        <ul>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑥">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error then, return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑥">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
        </ul>


### PR DESCRIPTION
After the switch to opcode URL templates some references to rfc6570 were accidentally left in the spec text. This removes them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/284.html" title="Last updated on Jul 15, 2025, 7:43 PM UTC (4e487f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/284/9594d69...4e487f0.html" title="Last updated on Jul 15, 2025, 7:43 PM UTC (4e487f0)">Diff</a>