### PR TITLE
CR July 2025

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -30,6 +30,7 @@ Abstract: This specification defines a method to incrementally transfer a font
 <pre class=link-defaults>
 spec:fetch; type:dfn; for:/; text:status
 spec:fetch; type:dfn; for:/; text:response
+spec: i18n-glossary; urlPrefix: https://www.w3.org/TR/i18n-glossary/; type: dfn; text: shaping
 </pre>
 
 <pre class=biblio>
@@ -796,10 +797,11 @@ once. Alternatively, the client may instead break the content up into smaller sp
 the extension algorithm on each of the smaller subset definitions. Either approach will ultimately produce a font which equivalently
 renders the overall content as long as:
 
-*  Each span of text which generates a subset definition is built from only one or more complete shaping units.
+*  Each span of text which generates a subset definition is built from only one or more complete [=shaping=] units.
 
-*  Where a shaping unit is a span of text which the client will process together as a single unit during
-    <a href="https://harfbuzz.github.io/what-is-harfbuzz.html#what-is-text-shaping">text shaping</a>.
+*  Where a shaping unit is a span of text which the client will process together as a single unit 
+    during [=shaping=].
+    <!-- <a href="https://harfbuzz.github.io/what-is-harfbuzz.html#what-is-text-shaping">text shaping</a>. -->
 
 
 Determining what Content a Font can Render {#ift-font-coverage}
@@ -815,7 +817,7 @@ for code points which do not yet have the corresponding glyph data loaded. As a 
 [[open-type/cmap|cmap]] table to determine code point presence. Instead the following procedure can be used by a client to check what
 parts of some content an incremental font can render:
 
-* Split the content up into the shaping units (see [[#target-subset-definitions]]) on which the content will be processed during text
+* Split the content up into the <dfn export>shaping units</dfn> (see [[#target-subset-definitions]]) on which the content will be processed during text
     shaping.
 
 * For each shaping unit there are two checks:
@@ -826,7 +828,7 @@ parts of some content an incremental font can render:
     * Second, compute the corresponding [=font subset definition=] and execute the [$Extend an Incremental Font Subset$] algorithm,
         stopping at step 6. If the entry list is not empty then the incremental font does not fully support rendering the shaping unit.
 
-* Any shaping units that passed both checks can be rendered in their entirety with the font.
+* Any [=shaping units=] that passed both checks can be rendered in their entirety with the font.
 
 The client may also wish to know what the font can render at a more granular level than a shaping unit. The following pseudo code
 demonstrates a possible method for splitting a shaping unit which failed the above check up into spans which can be rendered using the
@@ -877,7 +879,7 @@ def supports_subset_def(ift_font, subset_def):
   #   entry list is empty.
 </pre>
 
-Any text from the shaping unit which is not covered by one of the returned spans is not supported by the incremental font and should
+Any text from the [=shaping unit=] which is not covered by one of the returned spans is not supported by the incremental font and should
 be rendered with a fallback font. Each span should be shaped in isolation (ie. each span becomes a new shaping unit).
 Because this method splits a shaping unit up, not all features of the original font, such as multi code point substitutions, may be
 present. If the client is correctly following the [$Extend an Incremental Font Subset$] algorithm with a subset definition formed

--- a/Overview.bs
+++ b/Overview.bs
@@ -1,12 +1,15 @@
 <pre class='metadata'>
 Title: Incremental Font Transfer
 Shortname: IFT
-Status: WD
+Status: CR
 Prepare for TR: yes
-Date: 2025-07-15
+Date: 2025-07-31
+Deadline: 2025-10-31
 Group: webfontswg
 Level: none
 Markup Shorthands: css no
+Status Text: There is currently no implementation report. A test suite is under development.
+Implementation Report: https://wpt.fyi/results/IFT
 TR: https://www.w3.org/TR/IFT/
 ED: https://w3c.github.io/IFT/Overview.html
 Editor: Chris Lilley, W3C, https://svgees.us/, w3cid 1438
@@ -3095,6 +3098,14 @@ number of requests:
      access control headers.
 
 <h2 id=changes>Changes</h2>
+
+<p id="changes-20250715"><a href="https://www.w3.org/TR/2025/WD-IFT-20250715/">Working Draft of 15 July 2025</a>
+  (see <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
+
+<ul>
+  <li>Removed an unused item from references</li>
+  <li>Defined and exported the term "shaping unit"</li>
+</ul>
 
 <p id="changes-20250220">Since the <a href="https://www.w3.org/TR/2025/WD-IFT-20250220/">Working 
   Draft of 20 February 2025</a> (see 

--- a/Overview.bs
+++ b/Overview.bs
@@ -799,7 +799,7 @@ renders the overall content as long as:
 
 *  Each span of text which generates a subset definition is built from only one or more complete [=shaping=] units.
 
-*  Where a shaping unit is a span of text which the client will process together as a single unit 
+*  Where a <dfn export>shaping unit</dfn> is a span of text which the client will process together as a single unit 
     during [=shaping=].
     <!-- <a href="https://harfbuzz.github.io/what-is-harfbuzz.html#what-is-text-shaping">text shaping</a>. -->
 
@@ -817,7 +817,7 @@ for code points which do not yet have the corresponding glyph data loaded. As a 
 [[open-type/cmap|cmap]] table to determine code point presence. Instead the following procedure can be used by a client to check what
 parts of some content an incremental font can render:
 
-* Split the content up into the <dfn export>shaping units</dfn> (see [[#target-subset-definitions]]) on which the content will be processed during text
+* Split the content up into the [=shaping units=] (see [[#target-subset-definitions]]) on which the content will be processed during text
     shaping.
 
 * For each shaping unit there are two checks:

--- a/Overview.html
+++ b/Overview.html
@@ -3,10 +3,10 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Incremental Font Transfer</title>
-  <meta content="WD" name="w3c-status">
+  <meta content="CR" name="w3c-status">
   <meta content="Bikeshed version b25686b9f, updated Fri Mar 14 14:15:20 2025 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="e31b26eef10774a5e7ffec695bf0c9a3c38154a3" name="revision">
+  <meta content="6bf35822bc60c4533fffedad60734010e9089d4b" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -744,19 +744,19 @@ var[data-var-color="6"] { --var-vg: #FFBCF2; }
 	var[data-var-color="6"] { --var-vg: #ff0000; }
 }
 </style>
-  <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-WD" rel="stylesheet">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-CR" rel="stylesheet">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#WD">W3C Working Draft</a>, <time class="dt-updated" datetime="2025-07-15">15 July 2025</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CR">W3C Candidate Recommendation Snapshot</a>, <time class="dt-updated" datetime="2025-07-31">31 July 2025</time></p>
    <details open>
     <summary>More details about this document</summary>
     <div data-fill-with="spec-metadata">
      <dl>
       <dt>This version:
-      <dd><a class="u-url" href="https://www.w3.org/TR/2025/WD-IFT-20250715/">https://www.w3.org/TR/2025/WD-IFT-20250715/</a>
+      <dd><a class="u-url" href="https://www.w3.org/TR/2025/CR-IFT-20250731/">https://www.w3.org/TR/2025/CR-IFT-20250731/</a>
       <dt>Latest published version:
       <dd><a href="https://www.w3.org/TR/IFT/">https://www.w3.org/TR/IFT/</a>
       <dt>Editor's Draft:
@@ -766,6 +766,8 @@ var[data-var-color="6"] { --var-vg: #FFBCF2; }
       <dt>Feedback:
       <dd><span><a href="mailto:public-webfonts-wg@w3.org?subject=%5BIFT%5D%20YOUR%20TOPIC%20HERE">public-webfonts-wg@w3.org</a> with subject line “<kbd>[IFT] <i data-lt>… message topic …</i></kbd>” (<a href="https://lists.w3.org/Archives/Public/public-webfonts-wg/" rel="discussion">archives</a>)</span>
       <dd><a href="https://github.com/w3c/PFE/issues/">GitHub</a>
+      <dt>Implementation Report:
+      <dd><a href="https://wpt.fyi/results/IFT">https://wpt.fyi/results/IFT</a>
       <dt class="editor">Editors:
       <dd class="editor p-author h-card vcard" data-editor-id="1438"><a class="p-name fn u-url url" href="https://svgees.us/">Chris Lilley</a> (<span class="p-org org">W3C</span>)
       <dd class="editor p-author h-card vcard" data-editor-id="73905"><a class="p-name fn u-email email" href="mailto:grieger@google.com">Garret Rieger</a> (<span class="p-org org">Google Inc.</span>)
@@ -790,24 +792,28 @@ to complex scripts like Indic or Arabic.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
-   <p> <em>This section describes the status of this document at the time of
-  its publication. A list of
-  current W3C publications and the latest revision of this technical report
-  can be found in the <a href="https://www.w3.org/TR/">W3C technical reports
-  index.</a></em> </p>
-   <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Working Draft using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation
-      track</a>. This document is intended to become a W3C Recommendation. </p>
+   <p> <em>This section describes the status of this document at the time of its publication.
+		A list of current W3C publications and the latest revision of this technical report
+		can be found in the <a href="https://www.w3.org/TR/">W3C standards and drafts index.</a></em> </p>
+   <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Candidate Recommendation using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation
+      track</a>. This document is intended to become a W3C Recommendation.
+	This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="2025-10-31">31 October 2025</time> in order
+	to ensure the opportunity for wide review. </p>
    <p> If you wish to make comments regarding this document, please <a href="https://github.com/w3c/PFE/issues/new">file an issue on the specification repository</a>. </p>
-   <p> Publication as a Working Draft does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. This is a draft document and may be updated, replaced, or
-  obsoleted by other documents at any time. It is inappropriate to cite this
-  document as other than a work in progress. </p>
+   <p> Publication as a Candidate Recommendation does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
+      A Candidate Recommendation Snapshot has received <a href="https://www.w3.org/policies/process/20231103/#dfn-wide-review">wide review</a>, is intended to
+      gather implementation experience, and has commitments from Working Group members to <a href="https://www.w3.org/policies/patent-policy/#sec-Requirements">royalty-free licensing</a> for implementations. </p>
+   <p> A <a href>preliminary implementation report</a> is available. </p>
    <p> This document was produced by a group operating under
-  the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
-  W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
-  that page also includes instructions for disclosing a patent.
-  An individual who has actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
+	the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
+	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/44556/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
+	that page also includes instructions for disclosing a patent.
+	An individual who has actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
    <p> This document is governed by the <a href="https://www.w3.org/policies/process/20231103/" id="w3c_process_revision">03 November 2023 W3C Process Document</a>. </p>
+   <p> For changes since the last draft,
+	see the <a href="#changes">Changes</a> section. </p>
    <p></p>
+   <p>There is currently no implementation report. A test suite is under development.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">
@@ -3421,6 +3427,11 @@ number of requests:</p>
  access control headers.</p>
    </ol>
    <h2 class="heading settled" data-level="10" id="changes"><span class="secno">10. </span><span class="content">Changes</span><a class="self-link" href="#changes"></a></h2>
+   <p id="changes-20250715"><a href="https://www.w3.org/TR/2025/WD-IFT-20250715/">Working Draft of 15 July 2025</a> (see <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
+   <ul>
+    <li>Removed an unused item from references
+    <li>Defined and exported the term "shaping unit"
+   </ul>
    <p id="changes-20250220">Since the <a href="https://www.w3.org/TR/2025/WD-IFT-20250220/">Working 
   Draft of 20 February 2025</a> (see <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
    <ul>

--- a/Overview.html
+++ b/Overview.html
@@ -6,7 +6,7 @@
   <meta content="WD" name="w3c-status">
   <meta content="Bikeshed version b25686b9f, updated Fri Mar 14 14:15:20 2025 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="163f1dea0f1e0c4b69bd29decea2be476d400c55" name="revision">
+  <meta content="e31b26eef10774a5e7ffec695bf0c9a3c38154a3" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -1517,7 +1517,7 @@ renders the overall content as long as:</p>
     <li data-md>
      <p>Each span of text which generates a subset definition is built from only one or more complete <a data-link-type="dfn" href="https://www.w3.org/TR/i18n-glossary/#dfn-shaping" id="ref-for-dfn-shaping">shaping</a> units.</p>
     <li data-md>
-     <p>Where a shaping unit is a span of text which the client will process together as a single unit
+     <p>Where a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="shaping-unit">shaping unit</dfn> is a span of text which the client will process together as a single unit
 during <a data-link-type="dfn" href="https://www.w3.org/TR/i18n-glossary/#dfn-shaping" id="ref-for-dfn-shaping①">shaping</a>.</p>
    </ul>
    <h3 class="heading settled" data-level="4.6" id="ift-font-coverage"><span class="secno">4.6. </span><span class="content">Determining what Content a Font can Render</span><a class="self-link" href="#ift-font-coverage"></a></h3>
@@ -1530,7 +1530,7 @@ for code points which do not yet have the corresponding glyph data loaded. As a 
 parts of some content an incremental font can render:</p>
    <ul>
     <li data-md>
-     <p>Split the content up into the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="shaping-units">shaping units</dfn> (see <a href="#target-subset-definitions">§ 4.5 Target Subset Definition</a>) on which the content will be processed during text
+     <p>Split the content up into the <a data-link-type="dfn" href="#shaping-unit" id="ref-for-shaping-unit">shaping units</a> (see <a href="#target-subset-definitions">§ 4.5 Target Subset Definition</a>) on which the content will be processed during text
 shaping.</p>
     <li data-md>
      <p>For each shaping unit there are two checks:</p>
@@ -1543,7 +1543,7 @@ shaping.</p>
 stopping at step 6. If the entry list is not empty then the incremental font does not fully support rendering the shaping unit.</p>
      </ul>
     <li data-md>
-     <p>Any <a data-link-type="dfn" href="#shaping-units" id="ref-for-shaping-units">shaping units</a> that passed both checks can be rendered in their entirety with the font.</p>
+     <p>Any <a data-link-type="dfn" href="#shaping-unit" id="ref-for-shaping-unit①">shaping units</a> that passed both checks can be rendered in their entirety with the font.</p>
    </ul>
    <p>The client may also wish to know what the font can render at a more granular level than a shaping unit. The following pseudo code
 demonstrates a possible method for splitting a shaping unit which failed the above check up into spans which can be rendered using the
@@ -1591,7 +1591,7 @@ incremental font:</p>
   <c- c1># - After executing the "Extend an Incremental Font Subset" algorithm on ift_font with subset_def and stopping at step 6 the</c->
   <c- c1>#   entry list is empty.</c->
 </pre>
-   <p>Any text from the <a data-link-type="dfn" href="#shaping-units" id="ref-for-shaping-units①">shaping unit</a> which is not covered by one of the returned spans is not supported by the incremental font and should
+   <p>Any text from the <a data-link-type="dfn" href="#shaping-unit" id="ref-for-shaping-unit②">shaping unit</a> which is not covered by one of the returned spans is not supported by the incremental font and should
 be rendered with a fallback font. Each span should be shaped in isolation (ie. each span becomes a new shaping unit).
 Because this method splits a shaping unit up, not all features of the original font, such as multi code point substitutions, may be
 present. If the client is correctly following the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑥">Extend an Incremental Font Subset</a> algorithm with a subset definition formed
@@ -4209,7 +4209,7 @@ content covered by the target subset definition.</p>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.3.1.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 5.3.2.2</span>
-   <li><a href="#shaping-units">shaping units</a><span>, in § 4.6</span>
+   <li><a href="#shaping-unit">shaping unit</a><span>, in § 4.5</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.3.2.3</span>
    <li><a href="#design-space-segment-start">start</a><span>, in § 5.3.2</span>
    <li><a href="#table-keyed-patch">Table keyed patch</a><span>, in § 6.2</span>
@@ -4600,7 +4600,7 @@ let dfnPanelData = {
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
 "patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"},{"id":"ref-for-patch-map\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-patch-map\u2464"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2465"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-patch-map\u2466"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2467"},{"id":"ref-for-patch-map\u2468"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map\u2460\u24ea"}],"title":"7. Encoding"}],"url":"#patch-map"},
 "patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"},{"id":"ref-for-patch-map-entries\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2462"},{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"7. Encoding"}],"url":"#patch-map-entries"},
-"shaping-units": {"dfnID":"shaping-units","dfnText":"shaping units","external":false,"refSections":[{"refs":[{"id":"ref-for-shaping-units"},{"id":"ref-for-shaping-units\u2460"}],"title":"4.6. Determining what Content a Font can Render"}],"url":"#shaping-units"},
+"shaping-unit": {"dfnID":"shaping-unit","dfnText":"shaping unit","external":false,"refSections":[{"refs":[{"id":"ref-for-shaping-unit"},{"id":"ref-for-shaping-unit\u2460"},{"id":"ref-for-shaping-unit\u2461"}],"title":"4.6. Determining what Content a Font can Render"}],"url":"#shaping-unit"},
 "sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
 "table-keyed-patch": {"dfnID":"table-keyed-patch","dfnText":"Table keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch"},
 "table-keyed-patch-compatibilityid": {"dfnID":"table-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-compatibilityid"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-compatibilityid"},
@@ -5089,7 +5089,7 @@ let refsData = {
 "#patch-format": {"displayText":"patch format","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch format","type":"dfn","url":"#patch-format"},
 "#patch-map": {"displayText":"patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map","type":"dfn","url":"#patch-map"},
 "#patch-map-entries": {"displayText":"patch map entries","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map entries","type":"dfn","url":"#patch-map-entries"},
-"#shaping-units": {"displayText":"shaping units","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"shaping units","type":"dfn","url":"#shaping-units"},
+"#shaping-unit": {"displayText":"shaping unit","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"shaping unit","type":"dfn","url":"#shaping-unit"},
 "#sparse-bit-set": {"displayText":"sparse bit set","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"sparse bit set","type":"dfn","url":"#sparse-bit-set"},
 "#table-keyed-patch": {"displayText":"table keyed patch","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"table keyed patch","type":"dfn","url":"#table-keyed-patch"},
 "#table-keyed-patch-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Table keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#table-keyed-patch-compatibilityid"},

--- a/Overview.html
+++ b/Overview.html
@@ -4,9 +4,9 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Incremental Font Transfer</title>
   <meta content="WD" name="w3c-status">
-  <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
+  <meta content="Bikeshed version b25686b9f, updated Fri Mar 14 14:15:20 2025 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="f01ad7ce382baa9299972ae49ac6bc45136e7803" name="revision">
+  <meta content="163f1dea0f1e0c4b69bd29decea2be476d400c55" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
 .conform:hover {background: #31668f; color: white}
@@ -790,10 +790,11 @@ to complex scripts like Indic or Arabic.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
-   <p><em>This section describes the status of this document at the time of its 
-    publication. A list of current W3C publications and the latest revision of this 
-    technical report can be found in the <a href="https://www.w3.org/TR/">W3C 
-    standards and drafts index</a>.</em></p>
+   <p> <em>This section describes the status of this document at the time of
+  its publication. A list of
+  current W3C publications and the latest revision of this technical report
+  can be found in the <a href="https://www.w3.org/TR/">W3C technical reports
+  index.</a></em> </p>
    <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Working Draft using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation
       track</a>. This document is intended to become a W3C Recommendation. </p>
    <p> If you wish to make comments regarding this document, please <a href="https://github.com/w3c/PFE/issues/new">file an issue on the specification repository</a>. </p>
@@ -1514,9 +1515,10 @@ the extension algorithm on each of the smaller subset definitions. Either approa
 renders the overall content as long as:</p>
    <ul>
     <li data-md>
-     <p>Each span of text which generates a subset definition is built from only one or more complete shaping units.</p>
+     <p>Each span of text which generates a subset definition is built from only one or more complete <a data-link-type="dfn" href="https://www.w3.org/TR/i18n-glossary/#dfn-shaping" id="ref-for-dfn-shaping">shaping</a> units.</p>
     <li data-md>
-     <p>Where a shaping unit is a span of text which the client will process together as a single unit during <a href="https://harfbuzz.github.io/what-is-harfbuzz.html#what-is-text-shaping">text shaping</a>.</p>
+     <p>Where a shaping unit is a span of text which the client will process together as a single unit
+during <a data-link-type="dfn" href="https://www.w3.org/TR/i18n-glossary/#dfn-shaping" id="ref-for-dfn-shaping①">shaping</a>.</p>
    </ul>
    <h3 class="heading settled" data-level="4.6" id="ift-font-coverage"><span class="secno">4.6. </span><span class="content">Determining what Content a Font can Render</span><a class="self-link" href="#ift-font-coverage"></a></h3>
    <p>Given some incremental font (whether the initial font or one that has been partially extended) a client may wish to know what content
@@ -1528,7 +1530,7 @@ for code points which do not yet have the corresponding glyph data loaded. As a 
 parts of some content an incremental font can render:</p>
    <ul>
     <li data-md>
-     <p>Split the content up into the shaping units (see <a href="#target-subset-definitions">§ 4.5 Target Subset Definition</a>) on which the content will be processed during text
+     <p>Split the content up into the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="shaping-units">shaping units</dfn> (see <a href="#target-subset-definitions">§ 4.5 Target Subset Definition</a>) on which the content will be processed during text
 shaping.</p>
     <li data-md>
      <p>For each shaping unit there are two checks:</p>
@@ -1541,7 +1543,7 @@ shaping.</p>
 stopping at step 6. If the entry list is not empty then the incremental font does not fully support rendering the shaping unit.</p>
      </ul>
     <li data-md>
-     <p>Any shaping units that passed both checks can be rendered in their entirety with the font.</p>
+     <p>Any <a data-link-type="dfn" href="#shaping-units" id="ref-for-shaping-units">shaping units</a> that passed both checks can be rendered in their entirety with the font.</p>
    </ul>
    <p>The client may also wish to know what the font can render at a more granular level than a shaping unit. The following pseudo code
 demonstrates a possible method for splitting a shaping unit which failed the above check up into spans which can be rendered using the
@@ -1589,7 +1591,7 @@ incremental font:</p>
   <c- c1># - After executing the "Extend an Incremental Font Subset" algorithm on ift_font with subset_def and stopping at step 6 the</c->
   <c- c1>#   entry list is empty.</c->
 </pre>
-   <p>Any text from the shaping unit which is not covered by one of the returned spans is not supported by the incremental font and should
+   <p>Any text from the <a data-link-type="dfn" href="#shaping-units" id="ref-for-shaping-units①">shaping unit</a> which is not covered by one of the returned spans is not supported by the incremental font and should
 be rendered with a fallback font. Each span should be shaped in isolation (ie. each span becomes a new shaping unit).
 Because this method splits a shaping unit up, not all features of the original font, such as multi code point substitutions, may be
 present. If the client is correctly following the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑥">Extend an Incremental Font Subset</a> algorithm with a subset definition formed
@@ -4207,6 +4209,7 @@ content covered by the target subset definition.</p>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.3.1.2</span>
    <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 5.3.2.2</span>
+   <li><a href="#shaping-units">shaping units</a><span>, in § 4.6</span>
    <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.3.2.3</span>
    <li><a href="#design-space-segment-start">start</a><span>, in § 5.3.2</span>
    <li><a href="#table-keyed-patch">Table keyed patch</a><span>, in § 6.2</span>
@@ -4241,6 +4244,11 @@ content covered by the target subset definition.</p>
      <li><span class="dfn-paneled" id="55213b5b">request</span>
      <li><span class="dfn-paneled" id="dc1cd39b">URL</span>
     </ul>
+   <li>
+    <a data-link-type="biblio">[I18N-GLOSSARY]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="ba516e0e">shaping</span>
+    </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -4249,6 +4257,8 @@ content covered by the target subset definition.</p>
    <dd>Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-4/"><cite>CSS Fonts Module Level 4</cite></a>. 1 February 2024. WD. URL: <a href="https://www.w3.org/TR/css-fonts-4/">https://www.w3.org/TR/css-fonts-4/</a>
    <dt id="biblio-fetch">[FETCH]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-i18n-glossary">[I18N-GLOSSARY]
+   <dd>Richard Ishida; Addison Phillips. <a href="https://www.w3.org/TR/i18n-glossary/"><cite>Internationalization Glossary</cite></a>. 17 October 2024. NOTE. URL: <a href="https://www.w3.org/TR/i18n-glossary/">https://www.w3.org/TR/i18n-glossary/</a>
    <dt id="biblio-iso14496-22">[ISO14496-22]
    <dd><a href="https://www.iso.org/standard/87621.html"><cite>Information technology — Coding of audio-visual objects — Part 22: Open Font Format</cite></a>. Under development. URL: <a href="https://www.iso.org/standard/87621.html">https://www.iso.org/standard/87621.html</a>
    <dt id="biblio-open-type">[OPEN-TYPE]
@@ -4507,6 +4517,7 @@ let dfnPanelData = {
 "abstract-opdef-load-patch-file": {"dfnID":"abstract-opdef-load-patch-file","dfnText":"Load patch file","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file"},{"id":"ref-for-abstract-opdef-load-patch-file\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file\u2461"}],"title":"9. Security Considerations"}],"url":"#abstract-opdef-load-patch-file"},
 "abstract-opdef-remove-entries-from-format-1-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-1-patch-map","dfnText":"Remove Entries from Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-1-patch-map"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-1-patch-map"},
 "abstract-opdef-remove-entries-from-format-2-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-2-patch-map","dfnText":"Remove Entries from Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-2-patch-map"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-2-patch-map"},
+"ba516e0e": {"dfnID":"ba516e0e","dfnText":"shaping","external":true,"refSections":[{"refs":[{"id":"ref-for-dfn-shaping"},{"id":"ref-for-dfn-shaping\u2460"}],"title":"4.5. Target Subset Definition"}],"url":"https://www.w3.org/TR/i18n-glossary/#dfn-shaping"},
 "branch-factor-encoding": {"dfnID":"branch-factor-encoding","dfnText":"Branch Factor Encoding","external":false,"refSections":[{"refs":[{"id":"ref-for-branch-factor-encoding"},{"id":"ref-for-branch-factor-encoding\u2460"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#branch-factor-encoding"},
 "cb98f71f": {"dfnID":"cb98f71f","dfnText":"mode","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-request-mode"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"https://fetch.spec.whatwg.org/#concept-request-mode"},
 "dc1cd39b": {"dfnID":"dc1cd39b","dfnText":"URL","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-request-url"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"https://fetch.spec.whatwg.org/#concept-request-url"},
@@ -4589,6 +4600,7 @@ let dfnPanelData = {
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
 "patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"},{"id":"ref-for-patch-map\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-patch-map\u2464"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2465"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-patch-map\u2466"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2467"},{"id":"ref-for-patch-map\u2468"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map\u2460\u24ea"}],"title":"7. Encoding"}],"url":"#patch-map"},
 "patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"},{"id":"ref-for-patch-map-entries\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2462"},{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"7. Encoding"}],"url":"#patch-map-entries"},
+"shaping-units": {"dfnID":"shaping-units","dfnText":"shaping units","external":false,"refSections":[{"refs":[{"id":"ref-for-shaping-units"},{"id":"ref-for-shaping-units\u2460"}],"title":"4.6. Determining what Content a Font can Render"}],"url":"#shaping-units"},
 "sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
 "table-keyed-patch": {"dfnID":"table-keyed-patch","dfnText":"Table keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch"},
 "table-keyed-patch-compatibilityid": {"dfnID":"table-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-compatibilityid"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-compatibilityid"},
@@ -5077,6 +5089,7 @@ let refsData = {
 "#patch-format": {"displayText":"patch format","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch format","type":"dfn","url":"#patch-format"},
 "#patch-map": {"displayText":"patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map","type":"dfn","url":"#patch-map"},
 "#patch-map-entries": {"displayText":"patch map entries","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map entries","type":"dfn","url":"#patch-map-entries"},
+"#shaping-units": {"displayText":"shaping units","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"shaping units","type":"dfn","url":"#shaping-units"},
 "#sparse-bit-set": {"displayText":"sparse bit set","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"sparse bit set","type":"dfn","url":"#sparse-bit-set"},
 "#table-keyed-patch": {"displayText":"table keyed patch","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"table keyed patch","type":"dfn","url":"#table-keyed-patch"},
 "#table-keyed-patch-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Table keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#table-keyed-patch-compatibilityid"},
@@ -5096,6 +5109,7 @@ let refsData = {
 "https://fetch.spec.whatwg.org/#concept-request-url": {"displayText":"URL","export":true,"for_":["request"],"level":"1","normative":true,"shortname":"fetch","spec":"fetch","status":"current","text":"url","type":"dfn","url":"https://fetch.spec.whatwg.org/#concept-request-url"},
 "https://fetch.spec.whatwg.org/#process-response-end-of-body": {"displayText":"processResponseConsumeBody","export":true,"for_":["fetch"],"level":"1","normative":true,"shortname":"fetch","spec":"fetch","status":"current","text":"processresponseconsumebody","type":"dfn","url":"https://fetch.spec.whatwg.org/#process-response-end-of-body"},
 "https://fetch.spec.whatwg.org/#request-initiator-type": {"displayText":"initiator type","export":true,"for_":["request"],"level":"1","normative":true,"shortname":"fetch","spec":"fetch","status":"current","text":"initiator type","type":"dfn","url":"https://fetch.spec.whatwg.org/#request-initiator-type"},
+"https://www.w3.org/TR/i18n-glossary/#dfn-shaping": {"displayText":"shaping","export":true,"for_":[],"level":"1","normative":false,"shortname":"i18n-glossary","spec":"i18n-glossary","status":"snapshot","text":"shaping","type":"dfn","url":"https://www.w3.org/TR/i18n-glossary/#dfn-shaping"},
 };
 
 function mkRefHint(link, ref) {

--- a/Overview.html
+++ b/Overview.html
@@ -795,7 +795,7 @@ to complex scripts like Indic or Arabic.</p>
    <p> <em>This section describes the status of this document at the time of its publication.
 		A list of current W3C publications and the latest revision of this technical report
 		can be found in the <a href="https://www.w3.org/TR/">W3C standards and drafts index.</a></em> </p>
-   <p> This document was produced by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Candidate Recommendation using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation
+   <p> This document was published by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Candidate Recommendation Snapshot using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 	This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="2025-10-31">31 October 2025</time> in order
 	to ensure the opportunity for wide review. </p>
@@ -803,7 +803,7 @@ to complex scripts like Indic or Arabic.</p>
    <p> Publication as a Candidate Recommendation does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
       A Candidate Recommendation Snapshot has received <a href="https://www.w3.org/policies/process/20231103/#dfn-wide-review">wide review</a>, is intended to
       gather implementation experience, and has commitments from Working Group members to <a href="https://www.w3.org/policies/patent-policy/#sec-Requirements">royalty-free licensing</a> for implementations. </p>
-   <p> A <a href>preliminary implementation report</a> is available. </p>
+   <p> There is currently no preliminary implementation report. A test suite is under development.</p>
    <p> This document was produced by a group operating under
 	the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/44556/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
@@ -813,7 +813,6 @@ to complex scripts like Indic or Arabic.</p>
    <p> For changes since the last draft,
 	see the <a href="#changes">Changes</a> section. </p>
    <p></p>
-   <p>There is currently no implementation report. A test suite is under development.</p>
   </div>
   <div data-fill-with="at-risk"></div>
   <nav data-fill-with="table-of-contents" id="toc">


### PR DESCRIPTION
The autogenerated html from Bikeshed did not pass pubrules so I edited the status section until it did.

I should make a pull request on the bikeshed boilerplate repo to fix that in a more robust way. 

This includes the text shaping definition link.

Meanwhile this document passes and will be published this week.

Approval:
https://github.com/w3c/transitions/issues/732#issuecomment-3117245240


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/pull/287.html" title="Last updated on Jul 28, 2025, 2:38 PM UTC (1eb1ec4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/IFT/287/ee7741e...1eb1ec4.html" title="Last updated on Jul 28, 2025, 2:38 PM UTC (1eb1ec4)">Diff</a>