### PR TITLE
Remove conformance keywords (should) from 'Note:' in 4.6

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -890,8 +890,8 @@ according to [[#target-subset-definitions]] then the missing data will be loaded
 relevant patch is loading. Once the missing patch arrives and has been applied the rendering of the affected
 code points may change as a result of the substitution.
 
-Note: The "supported_spans(...)" check above should not be used to drive incremental font extension. Target subset definitions for full
-executions of [$Extend an Incremental Font Subset$] should follow the guidelines in [[#target-subset-definitions]].
+Note: The "supported_spans(...)" check above is not intended to be used to drive incremental font extension. Guidelines for
+forming target subset definitions for executions of [$Extend an Incremental Font Subset$] are given in [[#target-subset-definitions]].
 
 <h3 algorithm id="fully-expanding-a-font">Fully Expanding a Font</h3>
 


### PR DESCRIPTION
Fixes #289