### PR TITLE
Remove conformance keyword from 'font subset' definition.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -307,14 +307,14 @@ needed to render a subset of:
 *  [[open-type/featuretags|layout features]],
 *  and [[open-type/otvaroverview#terminology|design-variation space]].
 
-supported by the original font. When a subsetted font is used to render text using any combination of the subset
-code points, [[open-type/featuretags|layout features]], or [[open-type/otvaroverview#terminology|design-variation space]]
-it should render identically to the original font. This includes rendering with the use of any optional typographic
+supported by the original font. When a properly constructed font subset is used to render text using any combination of the
+subset code points, [[open-type/featuretags|layout features]], or [[open-type/otvaroverview#terminology|design-variation space]]
+it renders identically to the original font. This includes rendering with the use of any optional typographic
 features that a renderer may choose to use from the original font, such as hinting instructions. Design variation spaces
 are specified using the user-axis scales ([[open-type/otvaroverview#coordinate-scales-and-normalization]]).
 
 A <dfn dfn>font subset definition</dfn> describes the minimum data (code points, layout features,
-variation axis space) that a [=font subset=] should support.
+variation axis space) that a [=font subset=] supports.
 
 Note: For convenience the remainder of this document links to the [[open-type]] specification which is a copy of
 [[!iso14496-22]].


### PR DESCRIPTION
This definition is just describing what the concept of a font subset is and should not be including conformance requirements. It's better to state those more directly in the relevant sections later on. In this case requirements for font subset rendering equivalence in encodings are currently introduced in the encoder section. Fixes #288