### PR TITLE
Add client/encoder tags to the conformance spans.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -82,8 +82,10 @@ spec: i18n-glossary; urlPrefix: https://www.w3.org/TR/i18n-glossary/; type: dfn;
 </pre>
 
 <style>
-.conform:hover {background: #31668f; color: white}
-.conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
+.conform:hover {background: #DFD}
+.conform:target {padding: 2px; border: 2px solid #ACA; background: #DFD }
+.client:before {content: "client: "; background: #9F9; padding:4px; border: thin solid green}
+.encoder:before {content: "encoder: "; background: #F99; padding:4px; border: thin solid maroon}
 
 table {
   width: 100%;
@@ -758,7 +760,7 @@ If the error occurred during [$Load patch file$], then the client may continue t
 If an invalidation group is non empty and being selected from, but only contains failed patches then extension has failed and cannot
 continue.
 
-<span class="conform" id="conform-stop-extend-after-errors">In the case of all other errors the client must not attempt to further extend the font subset.</span>
+<span class="conform client" id="conform-stop-extend-after-errors">In the case of all other errors the client must not attempt to further extend the font subset.</span>
 
 Selecting Invalidating Patches {#invalidating-patch-selection}
 --------------------------------------------------------------
@@ -768,7 +770,7 @@ patch entry from a list of candidate entries. The selection criteria used has a 
 perform the extension. Round trips are costly so for maximum performance patches should be selected in a way that minimizes the total number of needed
 round trips.
 
-<span class="conform" id="conform-required-selection-criteria">The following selection criteria minimizes round trips and must be used by the client when selecting a single partial or full invalidation patch in step 8
+<span class="conform client" id="conform-required-selection-criteria">The following selection criteria minimizes round trips and must be used by the client when selecting a single partial or full invalidation patch in step 8
 of [$Extend an Incremental Font Subset$]</span>:
 
 1.  If one or more candidate entries have previously had their associated patch file loaded by step 9 of [$Extend an Incremental Font Subset$],
@@ -935,7 +937,7 @@ Extensions to the Font Format {#font-format-extensions}
 
 An [=incremental font=] follows the existing [[open-type|OpenType]] format, but includes two new
 [[open-type/otff#table-directory|tables]] identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both
-[=patch map|patch maps=]. <span class="conform" id="conform-require-ift-table">All incremental fonts must contain the 'IFT ' table.</span> The 'IFTX' table is optional. When both tables are
+[=patch map|patch maps=]. <span class="conform client" id="conform-require-ift-table">All incremental fonts must contain the 'IFT ' table.</span> The 'IFTX' table is optional. When both tables are
 present, the mapping of the font as a whole is the union of the mappings of the two tables. The two new tables are used only in this
 specification and are not being added to the [[open-type|Open-Type]] specification.
 
@@ -975,13 +977,13 @@ CFF and CFF2 Incremental Fonts {#cff}
 For incremental fonts that contain glyph outlines stored in a [[open-type/cff|CFF]] or [[open-type/cff2|CFF2]] table there are some
 additional restrictions:
 
-* <span class="conform" id="conform-charstrings-location">CFF and CFF2 tables in an incremental font must have the CharStrings INDEX data structure be last element of the
+* <span class="conform client" id="conform-charstrings-location">CFF and CFF2 tables in an incremental font must have the CharStrings INDEX data structure be last element of the
     table (followed only by 0 padding to a four-byte word boundary).</span>
 
-* <span class="conform" id="conform-cff-tables-no-overlap">CFF and CFF2 tables in an incremental font must not have any other data elements that overlap the CharStrings INDEX data
+* <span class="conform client" id="conform-cff-tables-no-overlap">CFF and CFF2 tables in an incremental font must not have any other data elements that overlap the CharStrings INDEX data
     structure.</span>
 
-* <span class="conform" id="conform-ift-table-contians-offset">The 'IFT ' [=patch map=] table must contain an offset
+* <span class="conform client" id="conform-ift-table-contians-offset">The 'IFT ' [=patch map=] table must contain an offset
     ([=Format 1 Patch Map/cffCharStringsOffset=], [=Format 1 Patch Map/cff2CharStringsOffset=]
     [=Format 2 Patch Map/cffCharStringsOffset=], or [=Format 2 Patch Map/cff2CharStringsOffset=])
     to the start of the CharStrings INDEX data for the CFF and/or CFF2 table.</span>
@@ -1059,12 +1061,12 @@ the encoded bytes at the start of every iteration to pick up any changes made in
   <tr>
     <td>uint16</td>
     <td><dfn for="Format 1 Patch Map">maxGlyphMapEntryIndex</dfn></td>
-    <td><span class="conform" id="conform-format1-entry-index-maximum">The largest [=Glyph Map=] entry index encoded in this table. Must be less than or equal to maxEntryIndex.</span></td>
+    <td><span class="conform client" id="conform-format1-entry-index-maximum">The largest [=Glyph Map=] entry index encoded in this table. Must be less than or equal to maxEntryIndex.</span></td>
   </tr>
   <tr>
     <td>uint24</td>
     <td><dfn for="Format 1 Patch Map">glyphCount</dfn></td>
-    <td><span class="conform" id="conform-format1-glyph-count-matches">Number of glyphs that mappings are provided for.
+    <td><span class="conform client" id="conform-format1-glyph-count-matches">Number of glyphs that mappings are provided for.
         Must match the number of glyphs in the the font file.</span>
 
         Note: the number of glyphs in the font is encoded in the font file. At the time of writing, this value is listed in the
@@ -1109,7 +1111,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td><dfn for="Format 1 Patch Map">patchFormat</dfn></td>
     <td>
       Specifies the format of the patches linked to by urlTemplate.
-      <span class="conform" id="conform-format1-valid-format-number">Must be set to one of the format numbers from  the [[#font-patch-formats-summary]] table.</span>
+      <span class="conform client" id="conform-format1-valid-format-number">Must be set to one of the format numbers from  the [[#font-patch-formats-summary]] table.</span>
     </td>
   </tr>
   <tr>
@@ -1415,7 +1417,7 @@ The algorithm:
     <td><dfn for="Format 2 Patch Map">defaultPatchFormat</dfn></td>
     <td>
       Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
-      <span class="conform" id="conform-format2-valid-format-number">Must be set to one of the format numbers from the [[#font-patch-formats-summary]] table.</span>
+      <span class="conform client" id="conform-format2-valid-format-number">Must be set to one of the format numbers from the [[#font-patch-formats-summary]] table.</span>
     </td>
   </tr>
   <tr>
@@ -1639,7 +1641,7 @@ being requested.
     <td>Fixed</td>
     <td><dfn for="Design Space Segment">end</dfn></td>
     <td>
-      End (inclusive) of the segment. <span class="conform" id="conform-design-space-segment-end-valid-value">Must be greater than or equal to start.</span> This value uses the user axis scale:
+      End (inclusive) of the segment. <span class="conform client" id="conform-design-space-segment-end-valid-value">Must be greater than or equal to start.</span> This value uses the user axis scale:
       [[open-type/otvaroverview#coordinate-scales-and-normalization]].
     </td>
   </tr>
@@ -2125,7 +2127,7 @@ The algorithm:
     <td><var>id32</var></td>
     <td>
       The input <var>entry ID</var> encoded as a [[rfc4648#section-7|base32hex]] string (using the digits 0-9, A-V) with padding
-      omitted.  <span class="conform" id="conform-entry-id-must-be-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
+      omitted.  <span class="conform client" id="conform-entry-id-must-be-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
       but then all leading bytes that are equal to 0 are removed before encoding.</span>  (For example, when the
       integer is less than 256 only one byte is encoded.) If <var>entry ID</var> is 0 then one zero byte is encoded. When
       <var>entry ID</var> is a string the raw bytes are encoded as base32hex.
@@ -2163,8 +2165,8 @@ The algorithm:
     <td><var>id64</var></td>
     <td>
       The input <var>entry ID</var> encoded as a [[rfc4648#section-5|base64url]] string (using the digits A-Z, a-z, 0-9, -
-      (minus) and _ (underline)) with padding included. <span class="conform" id="conform-equal-sign-encoded">Because the padding character is '=', it must
-      be URL-encoded as '%3D'.</span>  <span class="conform" id="conform-entry-id-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big
+      (minus) and _ (underline)) with padding included. <span class="conform client" id="conform-equal-sign-encoded">Because the padding character is '=', it must
+      be URL-encoded as '%3D'.</span>  <span class="conform client" id="conform-entry-id-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big
       endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding.</span>
       (For example, when the integer is less than 256 only one byte is encoded.) If the <var>entry ID</var> is 0 then one
       zero byte is encoded. When the <var>entry ID</var> is a string its raw bytes are encoded as
@@ -2343,7 +2345,7 @@ or remove tables in a [=font subset=].
   <tr>
     <td>Tag</td>
     <td>format</td>
-    <td><span class="conform" id="conform-table-keyed-format-equals-iftk">Identifies the format as table keyed, must be set to 'iftk'</span></td>
+    <td><span class="conform client" id="conform-table-keyed-format-equals-iftk">Identifies the format as table keyed, must be set to 'iftk'</span></td>
   </tr>
   <tr>
     <td>uint32</td>
@@ -2363,7 +2365,7 @@ or remove tables in a [=font subset=].
   <tr>
     <td>Offset32</td>
     <td><dfn for="Table keyed patch">patches</dfn>[patchesCount+1]</td>
-    <td>Each entry is an offset from the start of this table to a [=TablePatch=]. <span class="conform" id="conform-table-keyed-patches-sort-ascending">Offsets must be sorted in ascending order.</span></td>
+    <td>Each entry is an offset from the start of this table to a [=TablePatch=]. <span class="conform client" id="conform-table-keyed-patches-sort-ascending">Offsets must be sorted in ascending order.</span></td>
   </tr>
 </table>
 
@@ -2480,7 +2482,7 @@ A glyph keyed patch contains a collection of data chunks that are each associate
   <tr>
     <td>Tag</td>
     <td>format</td>
-    <td><span class="conform" id="conform-conform-glyph-keyed-format-equals-ifgk">Identifies the format as glyph keyed, must be set to 'ifgk'</span></td>
+    <td><span class="conform client" id="conform-conform-glyph-keyed-format-equals-ifgk">Identifies the format as glyph keyed, must be set to 'ifgk'</span></td>
   </tr>
   <tr>
     <td>uint32</td>
@@ -2531,14 +2533,14 @@ A glyph keyed patch contains a collection of data chunks that are each associate
     <td><dfn for="GlyphPatches">glyphIds</dfn>[glyphCount]</td>
     <td>
       An array of glyph indices included in the patch. Elements are uint24's if bit 0 (least significant bit) of
-      [=Glyph keyed patch/flags=] is set, otherwise elements are uint16's. <span class="conform" id="conform-glyph-keyed-glyph-ids-sort-ascending-unique">Must be in ascending sorted order and must not
+      [=Glyph keyed patch/flags=] is set, otherwise elements are uint16's. <span class="conform client" id="conform-glyph-keyed-glyph-ids-sort-ascending-unique">Must be in ascending sorted order and must not
       contain any duplicate values.</span>
     </td>
   </tr>
   <tr>
     <td>Tag</td>
     <td><dfn for="GlyphPatches">tables</dfn>[tableCount]</td>
-    <td>An array of [[open-type/otff#table-directory|tables]] (by tag) included in the patch. <span class="conform" id="conform-glyph-keyed-tables-sort-ascending-unique">Must be in ascending sorted
+    <td>An array of [[open-type/otff#table-directory|tables]] (by tag) included in the patch. <span class="conform client" id="conform-glyph-keyed-tables-sort-ascending-unique">Must be in ascending sorted
       order and must not contain any duplicate values.</span> For sorting tag values are interpreted as a 4 byte big endian
       unsigned integer and sorted by the integer value.</td>
   </tr>
@@ -2549,7 +2551,7 @@ A glyph keyed patch contains a collection of data chunks that are each associate
       An array of offsets of to glyph data for each table. The first [=GlyphPatches/glyphCount=] offsets corresponding to
       [=GlyphPatches/tables|tables[0]=], the next [=GlyphPatches/glyphCount=] offsets (if present) corresponding to
       [=GlyphPatches/tables|tables[1]=], and so on. All offsets are from the start of the [=GlyphPatches=] table.
-      <span class="conform" id="conform-glyph-keyed-glyph-data-offsets-sort-ascending">Offsets must be sorted in ascending order.</span>
+      <span class="conform client" id="conform-glyph-keyed-glyph-data-offsets-sort-ascending">Offsets must be sorted in ascending order.</span>
     </td>
   </tr>
   <tr>
@@ -2614,8 +2616,8 @@ The algorithm:
     *  The specific process for synthesizing the new table, depends on the specified format of the
         [[open-type/otff#table-directory|table]]. Any non-glyph associated data should be copied from the table in
         <var>base font subset</var>. Tables of the type [[open-type/glyf|glyf]],
-        [[open-type/gvar|gvar]], [[open-type/cff|CFF]], or [[open-type/cff2|CFF2]] are supported. <span class="conform" id="conform-table-entries-ignore-others">Entries for tables
-        of any other types must be ignored.</span> <span class="conform" id="conform-updating-glyf-updates-loca">When updating [[open-type/glyf|glyf]] the [[open-type/loca|loca]] table must be updated as
+        [[open-type/gvar|gvar]], [[open-type/cff|CFF]], or [[open-type/cff2|CFF2]] are supported. <span class="conform client" id="conform-table-entries-ignore-others">Entries for tables
+        of any other types must be ignored.</span> <span class="conform client" id="conform-updating-glyf-updates-loca">When updating [[open-type/glyf|glyf]] the [[open-type/loca|loca]] table must be updated as
         well.</span> No other tables in the font can be modified as a result of this step. Notably this means that a patch cannot add glyphs
         with indices beyond the numGlyphs specified in [[open-type/maxp|maxp]].
 
@@ -2649,13 +2651,13 @@ process of using an encoder, including whatever parameters an encoder requires o
 case.
 The [=incremental font=] and associated patches produced by a compliant encoder:
 
-1.  <span class="conform" id="conform-encoding-must-meet-extensions-format">Must meet all of the requirements in [[#font-format-extensions]] and [[#font-patch-formats]].</span>
+1.  <span class="conform encoder" id="conform-encoding-must-meet-extensions-format">Must meet all of the requirements in [[#font-format-extensions]] and [[#font-patch-formats]].</span>
 
-2.  <span class="conform" id="conform-encoding-must-be-consistent">Must be consistent, that is: for any possible [=font subset definition=] the result of invoking [$Extend an Incremental Font Subset$] 
+2.  <span class="conform encoder" id="conform-encoding-must-be-consistent">Must be consistent, that is: for any possible [=font subset definition=] the result of invoking [$Extend an Incremental Font Subset$] 
     with that subset definition and the [=incremental font=] must always be the same regardless of the particular order
     of patch selection chosen in step 8 of [$Extend an Incremental Font Subset$].</span>
 
-3.  <span class="conform" id="conform-encoding-must-respect-patch-invalidation-criteria">Must respect patch invalidation criteria.</span> <span class="conform" id="conform-encoding-only-alter-compatibility-ids">Any patch which is part of an IFT encoding when applied to a compatible [=font subset=]
+3.  <span class="conform encoder" id="conform-encoding-must-respect-patch-invalidation-criteria">Must respect patch invalidation criteria.</span> <span class="conform encoder" id="conform-encoding-only-alter-compatibility-ids">Any patch which is part of an IFT encoding when applied to a compatible [=font subset=]
      must only make changes to the [=patch map=] compatibility IDs which are compliant with the [[#font-patch-invalidations]] criteria
      for the invalidation mode declared by the associated [=patch map entries=].</span>
 
@@ -3071,8 +3073,8 @@ take privacy into account when encoding their own fonts or obtaining already-enc
 
   As required by [[!css-fonts-4]]:
 
-  "<span class="conform" id="conform-web-font-not-accessible-from-different-document">A Web Font must not be accessible in any other Document from the one which either is associated with
-  the @font-face rule or owns the FontFaceSet.</span> <span class="conform" id="conform-web-font-not-accessible-from-other-apps">Other applications on the device must not be able to access
+  "<span class="conform client" id="conform-web-font-not-accessible-from-different-document">A Web Font must not be accessible in any other Document from the one which either is associated with
+  the @font-face rule or owns the FontFaceSet.</span> <span class="conform client" id="conform-web-font-not-accessible-from-other-apps">Other applications on the device must not be able to access
   Web Fonts.</span>" - [[css-fonts-4#web-fonts]]
 
   Since IFT fonts are treated the same as regular fonts in CSS ([[#opt-in]]) these requirements apply and avoid information leaking across
@@ -3080,7 +3082,7 @@ take privacy into account when encoding their own fonts or obtaining already-enc
 
   Similar requirements apply to font palette values:
 
-  "<span class="conform" id="conform-palette-not-accesible-from-different-documents">An author-defined font color palette must only be available to the documents that reference it.</span> Using an author-defined color palette
+  "<span class="conform client" id="conform-palette-not-accesible-from-different-documents">An author-defined font color palette must only be available to the documents that reference it.</span> Using an author-defined color palette
   outside of the documents that reference it would constitute a security leak since the contents of one page would be able to
   affect other pages, something an attacker could use as an attack vector." - [[css-fonts-4#font-palette-values]]
 

--- a/Overview.html
+++ b/Overview.html
@@ -4,13 +4,16 @@
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <title>Incremental Font Transfer</title>
   <meta content="CR" name="w3c-status">
-  <meta content="Bikeshed version 4b8aed3f7, updated Thu Mar 6 12:35:01 2025 -0800" name="generator">
+  <meta content="Bikeshed version 3f621ba99, updated Mon Jul 28 15:38:36 2025 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="dfb01f9380b9e9612243d8c65e03f290b4741848" name="revision">
+  <meta content="c3b9c24802528dd428beb2cc2d4dcc74cb328474" name="revision">
   <meta content="dark light" name="color-scheme">
 <style>
-.conform:hover {background: #31668f; color: white}
-.conform:target {padding: 2px; border: 2px solid #AAA; background: #31668f; color: white }
+.conform:hover {background: #DFD}
+.conform:target {padding: 2px; border: 2px solid #ACA; background: #DFD }
+.client:before {content: "client: "; background: #9F9; padding:4px; border: thin solid green}
+.encoder:before {content: "encoder: "; background: #F99; padding:4px; border: thin solid maroon}
+
 
 table {
   width: 100%;
@@ -748,9 +751,13 @@ var[data-var-color="6"] { --var-vg: #FFBCF2; }
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
+</a>
+</p>
    <h1 class="p-name no-ref" id="title">Incremental Font Transfer</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CR">W3C Candidate Recommendation Snapshot</a>, <time class="dt-updated" datetime="2025-07-31">31 July 2025</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CR">W3C Candidate Recommendation Snapshot</a>,
+    <time class="dt-updated" datetime="2025-07-31">31 July 2025</time></p>
    <details open>
     <summary>More details about this document</summary>
     <div data-fill-with="spec-metadata">
@@ -776,7 +783,8 @@ var[data-var-color="6"] { --var-vg: #FFBCF2; }
     </div>
    </details>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2025 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/copyright/software-license/" rel="license" title="W3C Software and Document License">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2025 <a href="https://www.w3.org/">World Wide Web Consortium</a>. <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup> <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/copyright/software-license/" rel="license" title="W3C Software and Document License">permissive document license</a> rules apply.
+</p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -792,26 +800,55 @@ to complex scripts like Indic or Arabic.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
-   <p> <em>This section describes the status of this document at the time of its publication.
+   <p>
+	<em>This section describes the status of this document at the time of its publication.
 		A list of current W3C publications and the latest revision of this technical report
-		can be found in the <a href="https://www.w3.org/TR/">W3C standards and drafts index.</a></em> </p>
-   <p> This document was published by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a> as a Candidate Recommendation Snapshot using the <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation
+		can be found in the <a href="https://www.w3.org/TR/">W3C standards and drafts index.</a></em>
+
+</p>
+   <p>
+	This document was published by the <a href="https://www.w3.org/groups/wg/webfonts">Web Fonts Working Group</a>
+
+	as a Candidate Recommendation Snapshot using the <a href="https://www.w3.org/policies/process/20250818/#recs-and-notes">Recommendation
       track</a>. This document is intended to become a W3C Recommendation.
 	This document will remain a Candidate Recommendation at least until <time class="status-deadline" datetime="2025-10-31">31 October 2025</time> in order
-	to ensure the opportunity for wide review. </p>
-   <p> If you wish to make comments regarding this document, please <a href="https://github.com/w3c/PFE/issues/new">file an issue on the specification repository</a>. </p>
-   <p> Publication as a Candidate Recommendation does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
-      A Candidate Recommendation Snapshot has received <a href="https://www.w3.org/policies/process/20231103/#dfn-wide-review">wide review</a>, is intended to
-      gather implementation experience, and has commitments from Working Group members to <a href="https://www.w3.org/policies/patent-policy/#sec-Requirements">royalty-free licensing</a> for implementations. </p>
-   <p> There is currently no preliminary implementation report. A test suite is under development.</p>
-   <p> This document was produced by a group operating under
+	to ensure the opportunity for wide review.
+
+</p>
+   <p>
+	If you wish to make comments regarding this document, please <a href="https://github.com/w3c/PFE/issues/new">file an issue on the specification repository</a>.
+
+</p>
+   <p>
+	      Publication as a Candidate Recommendation does not imply endorsement by
+      <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
+      A Candidate Recommendation Snapshot has received <a href="https://www.w3.org/policies/process/20250818/#dfn-wide-review">wide review</a>, is intended to
+      gather implementation experience, and has commitments from Working Group members to <a href="https://www.w3.org/policies/patent-policy/#sec-Requirements">royalty-free licensing</a> for implementations.
+
+</p>
+   <p>
+     There is currently no preliminary implementation report. A test suite is under development.
+
+</p>
+   <p>
+	This document was produced by a group operating under
 	the <a href="https://www.w3.org/policies/patent-policy/20200915/">W3C Patent Policy</a>.
-	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/44556/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
+	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/44556/status" rel="disclosure">public list of any patent disclosures</a>
+	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/policies/process/20231103/" id="w3c_process_revision">03 November 2023 W3C Process Document</a>. </p>
-   <p> For changes since the last draft,
-	see the <a href="#changes">Changes</a> section. </p>
+	An individual who has actual knowledge of a patent that the individual believes contains <a href="https://www.w3.org/policies/patent-policy/20200915/#def-essential">Essential Claim(s)</a>
+	must disclose the information in accordance with <a href="https://www.w3.org/policies/patent-policy/20200915/#sec-Disclosure">section 6 of the W3C Patent Policy</a>.
+
+</p>
+   <p>
+	This document is governed by the <a href="https://www.w3.org/policies/process/20250818/" id="w3c_process_revision">18 August 2025 W3C Process Document</a>.
+
+</p>
+   <p>
+	For changes since the last draft,
+	see the <a href="#changes">Changes</a> section.
+
+</p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -908,9 +945,11 @@ to complex scripts like Indic or Arabic.</p>
      </ol>
     <li><a href="#sec"><span class="secno">9</span> <span class="content">Security Considerations</span></a>
     <li><a href="#changes"><span class="secno">10</span> <span class="content">Changes</span></a>
-    <li><a href="#feature-tag-list"><span class="secno"></span> <span class="content"> Appendix A: Default Feature Tags</span></a>
+    <li><a href="#feature-tag-list"><span class="secno"></span> <span class="content">
+Appendix A: Default Feature Tags</span></a>
     <li>
-     <a href="#extension-example"><span class="secno"></span> <span class="content"> Appendix B: Extension Algorithm Example Execution</span></a>
+     <a href="#extension-example"><span class="secno"></span> <span class="content">
+Appendix B: Extension Algorithm Example Execution</span></a>
      <ol class="toc">
       <li><a href="#appendix-b-example-1"><span class="secno"></span> <span class="content">Example 1: Table and Glyph Keyed Patches</span></a>
       <li><a href="#appendix-b-example-2"><span class="secno"></span> <span class="content">Example 2: Glyph Keyed Patches with Child Entries</span></a>
@@ -969,7 +1008,8 @@ partly in virtue of two additional <a href="https://learn.microsoft.com/en-us/ty
    <p>At a high level an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font">incremental font</a> is used like this:</p>
    <ol>
     <li data-md>
-     <p>The client downloads an initial font file, which contains some initial subset of data from the full version of the font along with <a href="#font-format-extensions">embedded data</a> describing the set of <a href="#font-patch-formats">patches</a> which can be used to extend 
+     <p>The client downloads an initial font file, which contains some initial subset of data from the full version of the font along with
+<a href="#font-format-extensions">embedded data</a> describing the set of <a href="#font-patch-formats">patches</a> which can be used to extend 
 the font.</p>
     <li data-md>
      <p>Based on the content to be rendered, the client <a href="#extending-font-subset">selects, downloads, and applies</a> patches to extend
@@ -1037,16 +1077,20 @@ original font and all of it’s layout rules.</p>
    <p>As discussed in the previous section the most basic implementation of incremental font transfer will
 tend to increase the total number of requests made vs traditional font loading. Since each augmentation
 will typically require at least one round trip time, performance can be negatively impacted if too many requests
-are made. Depending on which patch types are available and how much information is provided in the <a href="#font-format-extensions">patch mapping</a>, a client might preemptively request patches for code points that are not
+are made. Depending on which patch types are available and how much information is provided in the 
+<a href="#font-format-extensions">patch mapping</a>, a client might preemptively request patches for code points that are not
 currently needed, but expected to be needed in the future. Intelligent use of this feature by an
 implementation can help reduce the total number of requests being made. The evaluation report explored
-this by testing the performance of a basic character frequency based <a href="https://www.w3.org/TR/PFE-evaluation/#codepredict">code point prediction</a> scheme and found it improved overall performance.</p>
+this by testing the performance of a basic character frequency based <a href="https://www.w3.org/TR/PFE-evaluation/#codepredict">code point prediction</a>
+scheme and found it improved overall performance.</p>
    <h2 class="heading settled" data-level="2" id="opt-in"><span class="secno">2. </span><span class="content">Opt-In Mechanism</span><a class="self-link" href="#opt-in"></a></h2>
    <p>Web pages can choose to opt-in to incremental transfer for a font via the use of a CSS font tech
-keyword (<a href="https://www.w3.org/TR/css-fonts-4/#font-tech-definitions"><cite>CSS Fonts 4</cite> § 11.1 Font tech</a>) inside the ''@font-face'' block. The keyword <code>incremental</code> is used to indicate the referenced font contains IFT data and should
+keyword (<a href="https://www.w3.org/TR/css-fonts-4/#font-tech-definitions"><cite>CSS Fonts 4</cite> § 11.1 Font tech</a>) inside the ''@font-face'' block. The keyword
+<code>incremental</code> is used to indicate the referenced font contains IFT data and should
 only be loaded by a user agent which supports incremental font transfer.</p>
    <div class="example" id="example-e768eb0f">
-    <a class="self-link" href="#example-e768eb0f"></a> 
+    <a class="self-link" href="#example-e768eb0f"></a>
+
 <pre>@font-face {
     font-family: "MyCoolWebFont";
     src: url("MyCoolWebFont-Incremental.otf") tech(incremental);
@@ -1054,7 +1098,8 @@ only be loaded by a user agent which supports incremental font transfer.</p>
 </pre>
    </div>
    <div class="example" id="example-8a58c904">
-    <a class="self-link" href="#example-8a58c904"></a> 
+    <a class="self-link" href="#example-8a58c904"></a>
+
 <pre>@font-face {
     font-family: "MyCoolWebFont";
     src: url("MyCoolWebFont-Incremental.otf") tech(incremental);
@@ -1067,7 +1112,8 @@ unicode ranges should be set to match the coverage of the fully extended font. T
 if the font does not support any code points which are needed.</p>
    <p>An alternative approach is to use the <a data-link-type="biblio" href="#biblio-css-conditional-5" title="CSS Conditional Rules Module Level 5">CSS supports mechanism</a> which can make selections based on font tech:</p>
    <div class="example" id="example-439e65c2">
-    <a class="self-link" href="#example-439e65c2"></a> 
+    <a class="self-link" href="#example-439e65c2"></a>
+
 <pre>@when font-tech(incremental) {
   @font-face {
     font-family: "MyCoolWebFont";
@@ -1086,7 +1132,9 @@ if the font does not support any code points which are needed.</p>
 variety of ways fonts are used on web pages. Authors have control over which fonts they want to use
 this technology with, and which they do not.</p>
    <p class="note" role="note"><span class="marker">Note:</span> the IFT tech keyword can be used in conjunction with other font tech specifiers to perform
-font feature selection. For example a <code>@font-face</code> could include two URLs one with <code>tech(incremental, color-COLRv1)</code> and the other with <code>tech(incremental, color-COLRv0)</code>.</p>
+font feature selection. For example a <code>@font-face</code> could include two URLs one with
+<code>tech(incremental, color-COLRv1)</code> and the other with
+<code>tech(incremental, color-COLRv0)</code>.</p>
    <h3 class="heading settled" data-level="2.1" id="offline-usage"><span class="secno">2.1. </span><span class="content">Offline Usage</span><a class="self-link" href="#offline-usage"></a></h3>
    <p>In some cases a user agent may wish to save a web page for offline use. Saved pages may be viewed while there is no network connection
 and thus it won’t be possible to request any additional patches referenced by an incremental font. Since it won’t be possible extend
@@ -1105,17 +1153,22 @@ needed to render a subset of:</p>
      <p>and <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a>.</p>
    </ul>
    <p>supported by the original font. When a properly constructed font subset is used to render text using any combination of the
-subset code points, <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout features</a>, or <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a> it renders identically to the original font. This includes rendering with the use of any optional typographic
+subset code points, <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout features</a>, or <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#terminology">design-variation space</a>
+it renders identically to the original font. This includes rendering with the use of any optional typographic
 features that a renderer may choose to use from the original font, such as hinting instructions. Design variation spaces
 are specified using the user-axis scales (<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>).</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-subset-definition">font subset definition</dfn> describes the minimum data (code points, layout features,
 variation axis space) that a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset">font subset</a> supports.</p>
-   <p class="note" role="note"><span class="marker">Note:</span> For convenience the remainder of this document links to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">[open-type]</a> specification which is a copy of <a data-link-type="biblio" href="#biblio-iso14496-22" title="Information technology — Coding of audio-visual objects — Part 22: Open Font Format">[iso14496-22]</a>.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> For convenience the remainder of this document links to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">[open-type]</a> specification which is a copy of
+<a data-link-type="biblio" href="#biblio-iso14496-22" title="Information technology — Coding of audio-visual objects — Part 22: Open Font Format">[iso14496-22]</a>.</p>
    <h3 class="heading settled" data-level="3.2" id="font-patch-definitions"><span class="secno">3.2. </span><span class="content">Font Patch</span><a class="self-link" href="#font-patch-definitions"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="font-patch">font patch</dfn> is a file which encodes changes to be made to an IFT-encoded font. Patches are used to extend
 an existing <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①">font subset</a> and provide expanded coverage.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-format">patch format</dfn> is a specified encoding of changes to be applied relative to a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②">font subset</a>. A set of
-changes encoded according to the format is a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Each <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs an extended <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
+changes encoded according to the format is a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch">font patch</a>. Each <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format">patch format</a> has an associated 
+<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-application-algorithm">patch application algorithm</dfn> which takes a
+<a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset③">font subset</a> and a <a data-link-type="dfn" href="#font-patch" id="ref-for-font-patch①">font patch</a> encoded in the <a data-link-type="dfn" href="#patch-format" id="ref-for-patch-format①">patch format</a> as input and outputs an extended
+<a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset④">font subset</a>.</p>
    <h3 class="heading settled" data-level="3.3" id="patch-map-dfn"><span class="secno">3.3. </span><span class="content">Patch Map</span><a class="self-link" href="#patch-map-dfn"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="patch-map">patch map</dfn> is an <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">open type table</a> which encodes a collection of
 mappings from <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition">font subset definitions</a> to URLs which host <a href="#font-patch-formats">patches</a> that
@@ -1134,14 +1187,15 @@ matched. <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map
         <li data-md>
          <p><a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①">font subset definition</a>: defines the base coverage.</p>
         <li data-md>
-         <p>References to zero or more child <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①">Patch Map Entry</a>’s:<br> these child entries are used to extend the coverage.</p>
+         <p>References to zero or more child <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①">Patch Map Entry</a>’s:<br>
+ these child entries are used to extend the coverage.</p>
         <li data-md>
          <p>Child entry match mode, which can be either conjunctive or disjunctive.</p>
        </ul>
       <td>
        <ul>
         <li data-md>
-         <p>One or more Patch <a data-link-type="biblio" href="#biblio-whatwg-url" title="URL Standard">URL</a> strings</p>
+         <p>One or more Patch  <a data-link-type="biblio" href="#biblio-whatwg-url" title="URL Standard">URL</a> strings</p>
         <li data-md>
          <p><a href="#font-patch-formats">Patch Format</a></p>
         <li data-md>
@@ -1236,29 +1290,37 @@ not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-
      <p>If the compatibility ID in 'IFT ' is equal to the compatibility ID in 'IFTX' this is an error, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors①">Handle errors</a>.</p>
     <li data-md>
      <p>For each of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
-invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a> or <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a>. Concatenate the returned entry lists into a single list, <var>entry list</var>.</p>
+invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a> or <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a>. Concatenate the returned entry lists into a single list,
+<var>entry list</var>.</p>
     <li data-md>
-     <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection">Check entry intersection</a> with <var>entry</var> and <var>target subset definition</var> as inputs, if it returns false remove <var>entry</var> from <var>entry list</var>. Additionally remove
+     <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection">Check entry intersection</a> with <var>entry</var> and
+<var>target subset definition</var> as inputs, if it returns false remove <var>entry</var> from <var>entry list</var>. Additionally remove
 any entries in <var>entry list</var> which have a patch URL string which was loaded and applied previously during the execution of this algorithm.</p>
     <li data-md>
      <p>If <var>entry list</var> is empty, then the extension operation is finished, return <var>extended font subset</var>.</p>
     <li data-md>
-     <p>Group the entries from <var>entry list</var> into 3 lists based on the invalidation mode of the <a href="#font-patch-formats-summary">patch format</a> of each entry: <var>full invalidation entry list</var>, <var>partial invalidation entry list</var>, and <var>no invalidation entry list</var>.</p>
+     <p>Group the entries from <var>entry list</var> into 3 lists based on the invalidation mode of the <a href="#font-patch-formats-summary">patch format</a>
+of each entry: <var>full invalidation entry list</var>, <var>partial invalidation entry list</var>, and <var>no invalidation entry list</var>.</p>
     <li data-md>
      <p>Pick one <var>entry</var> with the following procedure:</p>
      <ul>
       <li data-md>
-       <p>If <var>full invalidation entry list</var> is not empty, then select exactly one of the contained entries. Follow the criteria in <a href="#invalidating-patch-selection">§ 4.4 Selecting Invalidating Patches</a> to select the single entry.</p>
+       <p>If <var>full invalidation entry list</var> is not empty, then select exactly one of the contained entries. Follow the criteria in
+<a href="#invalidating-patch-selection">§ 4.4 Selecting Invalidating Patches</a> to select the single entry.</p>
       <li data-md>
        <p>Otherwise if <var>partial invalidation entry list</var> is not empty then, select exactly one of the contained entries.
 Follow the criteria in <a href="#invalidating-patch-selection">§ 4.4 Selecting Invalidating Patches</a> to select the single entry.</p>
       <li data-md>
-       <p>Otherwise select the entry in <var>no invalidation entry list</var> which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map②">patch map</a>. For <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a> this is the entry with the lowest entry index. For <a href="#patch-map-format-2">§ 5.3.2 Patch Map Table: Format 2</a> this is the entry that appears first in the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array. If entries from both the IFT and
+       <p>Otherwise select the entry in <var>no invalidation entry list</var> which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map②">patch map</a>. For <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a> this is the entry with the lowest entry index. For <a href="#patch-map-format-2">§ 5.3.2 Patch Map Table: Format 2</a>
+this is the entry that appears first in the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array. If entries from both the IFT and
 IFTX tables are candidates then all entries in IFT are considered to come before those in IFTX.</p>
      </ul>
     <li data-md>
-     <p>Start a load of <var>patch file</var> (if not already previously started) by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>initial font URL</var> as the initial font URL and the first patch URL string in <var>entry</var> as the patch URL string. If there are any other URL strings in <var>entry</var>, then initiate loads for those using the same procedure. These may be used during future iterations of this algorithm.
-Additionally the client may optionally start loads using the same procedure for any entries in <var>entry list</var> which will not be <a href="#font-patch-invalidations">invalidated</a> by <var>entry</var>. The total number of patches that a client can load and apply during a single execution
+     <p>Start a load of <var>patch file</var> (if not already previously started) by invoking <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file">Load patch file</a> with the <var>initial font URL</var>
+as the initial font URL and the first patch URL string in <var>entry</var> as the patch URL string. If there are any other URL strings in
+<var>entry</var>, then initiate loads for those using the same procedure. These may be used during future iterations of this algorithm.
+Additionally the client may optionally start loads using the same procedure for any entries in <var>entry list</var> which will not be
+<a href="#font-patch-invalidations">invalidated</a> by <var>entry</var>. The total number of patches that a client can load and apply during a single execution
 of this algorithm is limited to:</p>
      <ul>
       <li data-md>
@@ -1266,9 +1328,12 @@ of this algorithm is limited to:</p>
       <li data-md>
        <p>At most 2000 patches of any type.</p>
      </ul>
-     <p>Can be loaded and applied during a single invocation of this algorithm. If either count has been exceeded this is an error invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors②">Handle errors</a>.</p>
+     <p>Can be loaded and applied during a single invocation of this algorithm. If either count has been exceeded this is an error invoke
+<a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors②">Handle errors</a>.</p>
     <li data-md>
-     <p>Once the load for <var>patch file</var> is finished, apply it using the appropriate application algorithm (matching the patches format in <var>entry</var>) from <a href="#font-patch-formats">§ 6 Font Patch Formats</a> to apply the <var>patch file</var> using the patch URL string and the compatibility id from <var>entry</var> to <var>extended font subset</var>. If the load for <var>patch file</var> resulted in an error, handle it according
+     <p>Once the load for <var>patch file</var> is finished, apply it using the appropriate application algorithm (matching the patches format in
+ <var>entry</var>) from <a href="#font-patch-formats">§ 6 Font Patch Formats</a> to apply the <var>patch file</var> using the patch URL string and the compatibility id from
+ <var>entry</var> to <var>extended font subset</var>. If the load for <var>patch file</var> resulted in an error, handle it according
  to <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors③">Handle errors</a>.</p>
     <li data-md>
      <p>Go to step 2.</p>
@@ -1284,7 +1349,9 @@ want to perform patch application of the remaining intersecting non-invalidating
 operation. Due to the nature of glyph keyed patches it’s straightforward to construct the end result of applying
 multiple patches sequentially in a single pass. Doing it this way avoids repeatedly re-synthesizing new
 glyf/loca/CFF/CFF2 tables for each individual patch and can significantly reduce the total amount of computation needed.</p>
-   <div class="example" id="example-2ebb408c"><a class="self-link" href="#example-2ebb408c"></a> An example of the execution of the extension algorithm can be found in <a href="#extension-example">Appendix B: Extension Algorithm Example Execution</a>. </div>
+   <div class="example" id="example-2ebb408c"><a class="self-link" href="#example-2ebb408c"></a>
+An example of the execution of the extension algorithm can be found in <a href="#extension-example">Appendix B: Extension Algorithm Example Execution</a>.
+</div>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-check-entry-intersection">Check entry intersection</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
@@ -1326,11 +1393,14 @@ glyf/loca/CFF/CFF2 tables for each individual patch and can significantly reduce
     <li data-md>
      <p>If there are no child entries in <var>mapping entry</var>, then return true for <var>intersects</var>.</p>
     <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> for each child entry referenced in <var>mapping entry</var> with <var>subset definition</var> as an input. If child entry match mode is conjunctive, then return true for <var>intersects</var> only if all invocations return true.
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection①">Check entry intersection</a> for each child entry referenced in <var>mapping entry</var> with <var>subset definition</var>
+as an input. If child entry match mode is conjunctive, then return true for <var>intersects</var> only if all invocations return true.
 Otherwise return true only if at least one invocation returns true.</p>
    </ol>
    <div class="example" id="example-8269bfc5">
-    <a class="self-link" href="#example-8269bfc5"></a> 
+    <a class="self-link" href="#example-8269bfc5"></a>
+
+
     <p>The table below represents a patch mapping and shows the expected result of an intersection check against various entries. In these examples
 when a set (ie. code points, feature tags, design space, child entries) is not specified it is assumed to be the empty set.</p>
     <table>
@@ -1432,7 +1502,8 @@ match mode: conjunctive,
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>patch URL string</var>: A <a data-link-type="biblio" href="#biblio-whatwg-url" title="URL Standard">URL</a> string (<a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded) identifying the patch file to load. It  may be a <a href="https://url.spec.whatwg.org/#relative-url-string">relative</a> URL.</p>
+     <p><var>patch URL string</var>: A <a data-link-type="biblio" href="#biblio-whatwg-url" title="URL Standard">URL</a> string (<a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded) identifying the patch file to load. It  may be a
+ <a href="https://url.spec.whatwg.org/#relative-url-string">relative</a> URL.</p>
     <li data-md>
      <p><var>initial font URL</var>: a <a href="https://url.spec.whatwg.org/#concept-url">URL</a> which identifies the location of the initial incremental
 font that <var>font subset</var> was derived from.</p>
@@ -1445,10 +1516,12 @@ font that <var>font subset</var> was derived from.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Parse <var>patch URL string</var> into a <a href="https://url.spec.whatwg.org/#concept-url">URL Record</a> using <a href="https://url.spec.whatwg.org/#url-parsing">URL Standard § url-parsing</a>. <var>initial font URL</var> is the <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> and encoding is UTF-8. Store the result
+     <p>Parse <var>patch URL string</var> into a <a href="https://url.spec.whatwg.org/#concept-url">URL Record</a> using <a href="https://url.spec.whatwg.org/#url-parsing">URL Standard § url-parsing</a>.
+ <var>initial font URL</var> is the <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> and encoding is UTF-8. Store the result
  in <var>target URL</var>. If URL parsing failed, then return an error.</p>
     <li data-md>
-     <p>Retrieve the contents of <var>target URL</var> using the fetching capabilities of the implementing user agent. For web browsers, <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a> should be used. When using <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a> the request is configured as follows:</p>
+     <p>Retrieve the contents of <var>target URL</var> using the fetching capabilities of the implementing user agent. For web browsers,
+ <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a> should be used. When using <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a> the request is configured as follows:</p>
      <ul>
       <li data-md>
        <p>Set <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-method" id="ref-for-concept-request-method">method</a> to GET.</p>
@@ -1479,17 +1552,19 @@ first referrer is set to the initial font’s URL, second URL resolution uses th
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-handle-errors">Handle errors</dfn></p>
    <p>If the extending the font subset process has failed with an error, then some of the data within the font may not be fully loaded and as
 a result rendering content which relies on the missing data may result in incorrect renderings. The client may choose to continue using
-the font, but should only use it for the rendering of code points, features, and design space that are fully loaded according to <a href="#ift-font-coverage">§ 4.6 Determining what Content a Font can Render</a>. Rendering of all other content should fallback to a different font following normal client fallback logic.</p>
-   <p>If the error occurred during <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file①">Load patch file</a>, then the client may continue trying to extend the font subset. In step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</a> within each invalidation grouping any patches which failed to load are excluded from selection.
+the font, but should only use it for the rendering of code points, features, and design space that are fully loaded according to
+<a href="#ift-font-coverage">§ 4.6 Determining what Content a Font can Render</a>. Rendering of all other content should fallback to a different font following normal client fallback logic.</p>
+   <p>If the error occurred during <a data-link-type="abstract-op" href="#abstract-opdef-load-patch-file" id="ref-for-abstract-opdef-load-patch-file①">Load patch file</a>, then the client may continue trying to extend the font subset. In step 8 of
+<a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</a> within each invalidation grouping any patches which failed to load are excluded from selection.
 If an invalidation group is non empty and being selected from, but only contains failed patches then extension has failed and cannot
 continue.</p>
-   <p><span class="conform" id="conform-stop-extend-after-errors">In the case of all other errors the client must not attempt to further extend the font subset.</span></p>
+   <p><span class="conform client" id="conform-stop-extend-after-errors">In the case of all other errors the client must not attempt to further extend the font subset.</span></p>
    <h3 class="heading settled" data-level="4.4" id="invalidating-patch-selection"><span class="secno">4.4. </span><span class="content">Selecting Invalidating Patches</span><a class="self-link" href="#invalidating-patch-selection"></a></h3>
    <p>During execution of the <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①">Extend an Incremental Font Subset</a> algorithm in some cases it’s necessary to select a single invalidating (full or partial)
 patch entry from a list of candidate entries. The selection criteria used has a direct impact on the total number of round trips that will be needed to
 perform the extension. Round trips are costly so for maximum performance patches should be selected in a way that minimizes the total number of needed
 round trips.</p>
-   <p><span class="conform" id="conform-required-selection-criteria">The following selection criteria minimizes round trips and must be used by the client when selecting a single partial or full invalidation patch in step 8
+   <p><span class="conform client" id="conform-required-selection-criteria">The following selection criteria minimizes round trips and must be used by the client when selecting a single partial or full invalidation patch in step 8
 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset②">Extend an Incremental Font Subset</a></span>:</p>
    <ol>
     <li data-md>
@@ -1531,7 +1606,8 @@ that font can render in it’s current state. This is of particular importance w
 of the text to use fallback fonts for.</p>
    <p>During fallback processing a client would typically check the font’s <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table to determine which code points are
 supported; However, in an IFT font due to the way <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches work the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table may contain mappings
-for code points which do not yet have the corresponding glyph data loaded. As a result the client should not rely solely on the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table to determine code point presence. Instead the following procedure can be used by a client to check what
+for code points which do not yet have the corresponding glyph data loaded. As a result the client should not rely solely on the
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table to determine code point presence. Instead the following procedure can be used by a client to check what
 parts of some content an incremental font can render:</p>
    <ul>
     <li data-md>
@@ -1633,7 +1709,9 @@ to the procedures in this section. So if an incremental font needs to be stored 
 store only the font binary produced by the most recent application of the extension algorithm. It is not necessary to retain the initial
 font or any versions produced by prior extensions.</p>
    <h2 class="heading settled" data-level="5" id="font-format-extensions"><span class="secno">5. </span><span class="content">Extensions to the Font Format</span><a class="self-link" href="#font-format-extensions"></a></h2>
-   <p>An <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but includes two new <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑤">patch maps</a>. <span class="conform" id="conform-require-ift-table">All incremental fonts must contain the 'IFT ' table.</span> The 'IFTX' table is optional. When both tables are
+   <p>An <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font⑧">incremental font</a> follows the existing <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">OpenType</a> format, but includes two new
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> identified by the 4-byte tags 'IFT ' and 'IFTX'. These new tables are both
+<a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑤">patch maps</a>. <span class="conform client" id="conform-require-ift-table">All incremental fonts must contain the 'IFT ' table.</span> The 'IFTX' table is optional. When both tables are
 present, the mapping of the font as a whole is the union of the mappings of the two tables. The two new tables are used only in this
 specification and are not being added to the <a data-link-type="biblio" href="#biblio-open-type" title="OpenType Specification">Open-Type</a> specification.</p>
    <p class="note" role="note"><span class="marker">Note:</span> allowing the mapping to be split between two distinct tables allows an incremental font to more easily make use of multiple
@@ -1658,7 +1736,8 @@ file, the compressed font needs to be decoded before attempting to extend it.</p
  guarantee the specific bytes that result from decoding a transformed glyf and loca table. <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches may be used
  in conjunction with a transformed glyf and loca table.</p>
     <li data-md>
-     <p>The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in <a href="https://www.w3.org/TR/WOFF2/#table_format"><cite>WOFF 2.0</cite> § 5 Compressed data format</a>.</p>
+     <p>The 'IFT ' and 'IFTX' tables can be processed and brotli encoded by a WOFF2 encoder following the standard process defined in
+<a href="https://www.w3.org/TR/WOFF2/#table_format"><cite>WOFF 2.0</cite> § 5 Compressed data format</a>.</p>
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> Given that WOFF2 compression outperforms WOFF even with glyf/loca transformations disabled it is generally recommended
 that IFT fonts are compressed using WOFF2, with glyf/loca transformations disabled when the encoding updates those tables using
@@ -1668,14 +1747,15 @@ table-keyed patches.</p>
 additional restrictions:</p>
    <ul>
     <li data-md>
-     <p><span class="conform" id="conform-charstrings-location">CFF and CFF2 tables in an incremental font must have the CharStrings INDEX data structure be last element of the
+     <p><span class="conform client" id="conform-charstrings-location">CFF and CFF2 tables in an incremental font must have the CharStrings INDEX data structure be last element of the
 table (followed only by 0 padding to a four-byte word boundary).</span></p>
     <li data-md>
-     <p><span class="conform" id="conform-cff-tables-no-overlap">CFF and CFF2 tables in an incremental font must not have any other data elements that overlap the CharStrings INDEX data
+     <p><span class="conform client" id="conform-cff-tables-no-overlap">CFF and CFF2 tables in an incremental font must not have any other data elements that overlap the CharStrings INDEX data
 structure.</span></p>
     <li data-md>
-     <p><span class="conform" id="conform-ift-table-contians-offset">The 'IFT ' <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑥">patch map</a> table must contain an offset
-(<a data-link-type="dfn" href="#format-1-patch-map-cffcharstringsoffset" id="ref-for-format-1-patch-map-cffcharstringsoffset">cffCharStringsOffset</a>, <a data-link-type="dfn" href="#format-1-patch-map-cff2charstringsoffset" id="ref-for-format-1-patch-map-cff2charstringsoffset">cff2CharStringsOffset</a> <a data-link-type="dfn" href="#format-2-patch-map-cffcharstringsoffset" id="ref-for-format-2-patch-map-cffcharstringsoffset">cffCharStringsOffset</a>, or <a data-link-type="dfn" href="#format-2-patch-map-cff2charstringsoffset" id="ref-for-format-2-patch-map-cff2charstringsoffset">cff2CharStringsOffset</a>)
+     <p><span class="conform client" id="conform-ift-table-contians-offset">The 'IFT ' <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑥">patch map</a> table must contain an offset
+(<a data-link-type="dfn" href="#format-1-patch-map-cffcharstringsoffset" id="ref-for-format-1-patch-map-cffcharstringsoffset">cffCharStringsOffset</a>, <a data-link-type="dfn" href="#format-1-patch-map-cff2charstringsoffset" id="ref-for-format-1-patch-map-cff2charstringsoffset">cff2CharStringsOffset</a>
+<a data-link-type="dfn" href="#format-2-patch-map-cffcharstringsoffset" id="ref-for-format-2-patch-map-cffcharstringsoffset">cffCharStringsOffset</a>, or <a data-link-type="dfn" href="#format-2-patch-map-cff2charstringsoffset" id="ref-for-format-2-patch-map-cff2charstringsoffset">cff2CharStringsOffset</a>)
 to the start of the CharStrings INDEX data for the CFF and/or CFF2 table.</span></p>
    </ul>
    <p>These three requirements allow for the glyph keyed patch application implementation on CFF and CFF2 tables to be significantly
@@ -1699,7 +1779,8 @@ not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-f
      <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
 is typically less compact than format 1.</p>
    </ul>
-   <p>Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a> algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
+   <p>Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The
+<a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a> algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
 encoded bytes are the source of truth at all times for the patch map. Patch application during subset extension will alter the encoded
 bytes of the patch map and as a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets
 the encoded bytes at the start of every iteration to pick up any changes made in the previous iteration.</p>
@@ -1724,12 +1805,15 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-flags">flags</dfn>
       <td>Flags to signal the presence of optional fields.
         If bit 0 (least significant bit) is set, then <a data-link-type="dfn" href="#format-1-patch-map-cffcharstringsoffset" id="ref-for-format-1-patch-map-cffcharstringsoffset①">cffCharStringsOffset</a> will be present.
-        If bit 1 (least significant bit) is set, then <a data-link-type="dfn" href="#format-1-patch-map-cff2charstringsoffset" id="ref-for-format-1-patch-map-cff2charstringsoffset①">cff2CharStringsOffset</a> will be present. 
+        If bit 1 (least significant bit) is set, then <a data-link-type="dfn" href="#format-1-patch-map-cff2charstringsoffset" id="ref-for-format-1-patch-map-cff2charstringsoffset①">cff2CharStringsOffset</a> will be present.
+    
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-compatibilityid">compatibilityId</dfn>[4]
-      <td> Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>). The encoder chooses this
-      value. The encoder should set it to a random value which has not previously been used while encoding the IFT font. 
+      <td>
+      Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>). The encoder chooses this
+      value. The encoder should set it to a random value which has not previously been used while encoding the IFT font.
+    
      <tr>
       <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-maxentryindex">maxEntryIndex</dfn>
@@ -1737,14 +1821,17 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</dfn>
-      <td><span class="conform" id="conform-format1-entry-index-maximum">The largest <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map">Glyph Map</a> entry index encoded in this table. Must be less than or equal to maxEntryIndex.</span>
+      <td><span class="conform client" id="conform-format1-entry-index-maximum">The largest <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map">Glyph Map</a> entry index encoded in this table. Must be less than or equal to maxEntryIndex.</span>
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-glyphcount">glyphCount</dfn>
       <td>
-       <span class="conform" id="conform-format1-glyph-count-matches">Number of glyphs that mappings are provided for.
-        Must match the number of glyphs in the the font file.</span> 
-       <p class="note" role="note"><span class="marker">Note:</span> the number of glyphs in the font is encoded in the font file. At the time of writing, this value is listed in the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a> table; however, future font format extensions may use alternate tables to encode the value for number of
+       <span class="conform client" id="conform-format1-glyph-count-matches">Number of glyphs that mappings are provided for.
+        Must match the number of glyphs in the the font file.</span>
+
+
+       <p class="note" role="note"><span class="marker">Note:</span> the number of glyphs in the font is encoded in the font file. At the time of writing, this value is listed in the
+        <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a> table; however, future font format extensions may use alternate tables to encode the value for number of
         glyphs.</p>
      <tr>
       <td>Offset32
@@ -1757,30 +1844,46 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</dfn>[(maxEntryIndex + 8)/8]
-      <td> A bit map which tracks which entries have been applied. If bit <code>i</code> is set that indicates the patch for entry <code>i</code> has been applied to this font. Bit 0 is the least significant bit of appliedEntriesBitMap[0], while bit 7 is
-      the most significant bit. Bit 8 is the least significant bit of appliedEntriesBitMap[1] and so on. 
+      <td>
+      A bit map which tracks which entries have been applied. If bit <code>i</code> is set that indicates the patch for entry
+      <code>i</code> has been applied to this font. Bit 0 is the least significant bit of appliedEntriesBitMap[0], while bit 7 is
+      the most significant bit. Bit 8 is the least significant bit of appliedEntriesBitMap[1] and so on.
+    
      <tr>
       <td>uint16
       <td>urlTemplateLength
-      <td> Length of the urlTemplate byte array. 
+      <td>
+      Length of the urlTemplate byte array.
+    
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
-      <td> A byte array containing a <a href="#url-templates">URL Template</a> which is used to produce URL strings associated with each entry. 
+      <td>
+      A byte array containing a <a href="#url-templates">URL Template</a> which is used to produce URL strings associated with each entry.
+    
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchformat">patchFormat</dfn>
-      <td> Specifies the format of the patches linked to by urlTemplate. <span class="conform" id="conform-format1-valid-format-number">Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.</span> 
+      <td>
+      Specifies the format of the patches linked to by urlTemplate.
+      <span class="conform client" id="conform-format1-valid-format-number">Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.</span>
+    
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-cffcharstringsoffset">cffCharStringsOffset</dfn>
-      <td> Only present if bit 0 (least significant) of <a data-link-type="dfn" href="#format-1-patch-map-flags" id="ref-for-format-1-patch-map-flags">flags</a> is set.
-      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table to the CharStrings INDEX data structure of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table. 
+      <td>
+      Only present if bit 0 (least significant) of <a data-link-type="dfn" href="#format-1-patch-map-flags" id="ref-for-format-1-patch-map-flags">flags</a> is set.
+      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table to the CharStrings INDEX data structure of the
+      <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table.
+    
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-cff2charstringsoffset">cff2CharStringsOffset</dfn>
-      <td> Only present if bit 1 of <a data-link-type="dfn" href="#format-1-patch-map-flags" id="ref-for-format-1-patch-map-flags①">flags</a> is set.
-      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF2</a> table to the CharStrings INDEX data structure of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table. 
+      <td>
+      Only present if bit 1 of <a data-link-type="dfn" href="#format-1-patch-map-flags" id="ref-for-format-1-patch-map-flags①">flags</a> is set.
+      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF2</a> table to the CharStrings INDEX data structure of the
+      <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table.
+    
    </table>
    <p class="note" role="note"><span class="marker">Note:</span> <a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> is designed to be compatible with the
       proposed <a href="https://github.com/harfbuzz/boring-expansion-spec/tree/main">future font format extension</a> to allow for more
@@ -1800,8 +1903,10 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-entryindex">entryIndex</dfn>[<a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount①">glyphCount</a> - firstMappedGlyph]
-      <td> The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - <a data-link-type="dfn" href="#glyph-map-firstmappedglyph" id="ref-for-glyph-map-firstmappedglyph">firstMappedGlyph</a>]. Array members
-      are uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex">maxEntryIndex</a> is less than 256, otherwise they are uint16. 
+      <td>
+      The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - <a data-link-type="dfn" href="#glyph-map-firstmappedglyph" id="ref-for-glyph-map-firstmappedglyph">firstMappedGlyph</a>]. Array members
+      are uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex">maxEntryIndex</a> is less than 256, otherwise they are uint16.
+    
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="feature-map">Feature Map</dfn> encoding:</p>
    <p>A feature map table associates combinations of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> and glyphs with an entry index.</p>
@@ -1818,16 +1923,21 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td><a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord">FeatureRecord</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Feature Map" data-dfn-type="dfn" data-noexport id="feature-map-featurerecords">featureRecords</dfn>[featureCount]
-      <td> Provides mappings for a specific <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tag</a>. <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords">featureRecords</a> are sorted by <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag">featureTag</a> in ascending order with any feature tag occurring at most once. For sorting tag values are interpreted
-      as a 4 byte big endian unsigned integer and sorted by the integer value. 
+      <td>
+      Provides mappings for a specific  <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tag</a>. <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords">featureRecords</a> are sorted by
+      <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag">featureTag</a> in ascending order with any feature tag occurring at most once. For sorting tag values are interpreted
+      as a 4 byte big endian unsigned integer and sorted by the integer value.
+    
      <tr>
       <td><a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord">EntryMapRecord</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Feature Map" data-dfn-type="dfn" data-noexport id="feature-map-entrymaprecords">entryMapRecords</dfn>[variable]
-      <td> Provides the key (entry index) for each feature mapping. The entryMapRecords array contains as many entries as the sum of
+      <td>
+      Provides the key (entry index) for each feature mapping. The entryMapRecords array contains as many entries as the sum of
       the <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount">entryMapCount</a> fields in the <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords①">featureRecords</a> array, with entryMapRecords[0] corresponding
       to the first entry of featureRecords[0], entryMapRecords[featureRecord[0].entryMapCount] corresponding to the first entry of
       featureRecords[1], entryMapRecords[featureRecords[0].entryMapCount + featureRecord[1].entryMapCount]] corresponding to the
-      first entry of featureRecords[2], and so on. 
+      first entry of featureRecords[2], and so on.
+    
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="featurerecord">FeatureRecord</dfn> encoding:</p>
    <table>
@@ -1843,13 +1953,17 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="FeatureRecord" data-dfn-type="dfn" data-noexport id="featurerecord-firstnewentryindex">firstNewEntryIndex</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex①">maxEntryIndex</a> is less than 256, otherwise uint16.
-      The first entry index this record maps too. 
+      <td>
+      uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex①">maxEntryIndex</a> is less than 256, otherwise uint16.
+      The first entry index this record maps too.
+    
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="FeatureRecord" data-dfn-type="dfn" data-noexport id="featurerecord-entrymapcount">entryMapCount</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex②">maxEntryIndex</a> is less than 256, otherwise uint16.
-      The number of <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord①">EntryMapRecord</a>s associated with this feature. 
+      <td>
+      uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex②">maxEntryIndex</a> is less than 256, otherwise uint16.
+      The number of <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord①">EntryMapRecord</a>s associated with this feature.
+    
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="entrymaprecord">EntryMapRecord</dfn> encoding:</p>
    <table>
@@ -1861,12 +1975,16 @@ the encoded bytes at the start of every iteration to pick up any changes made in
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-firstentryindex">firstEntryIndex</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex③">maxEntryIndex</a> is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
-      the set of <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map②">Glyph Map</a> entries which form the subset definitions for the entries created by this mapping. 
+      <td>
+      uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex③">maxEntryIndex</a> is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
+      the set of <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map②">Glyph Map</a> entries which form the subset definitions for the entries created by this mapping.
+    
      <tr>
       <td>uint8/uint16
       <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-lastentryindex">lastEntryIndex</dfn>
-      <td> uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex④">maxEntryIndex</a> is less than 256, otherwise uint16. 
+      <td>
+      uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex④">maxEntryIndex</a> is less than 256, otherwise uint16.
+    
    </table>
    <p>An entry map record matches any entry indices that are greater than or equal to firstEntryIndex and less than or equal to  lastEntryIndex.</p>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 1" data-level="5.3.1.1" id="interpreting-patch-map-format-1"><span class="secno">5.3.1.1. </span><span class="content">Interpreting Format 1</span><a class="self-link" href="#interpreting-patch-map-format-1"></a></h5>
@@ -1896,54 +2014,71 @@ the encoded bytes at the start of every iteration to pick up any changes made in
        <p>If <var>entry index</var> is 0 then, this is a special entry used to mark glyphs which are already in the initial font. Skip this
 index and do not build an entry for it.</p>
       <li data-md>
-       <p>If the <var>entry index</var> is larger than <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</a> this entry is invalid, skip this <var>entry index</var>.</p>
+       <p>If the <var>entry index</var> is larger than <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</a> this entry is invalid, skip this
+<var>entry index</var>.</p>
       <li data-md>
-       <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
+       <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a> is set to 1, skip this
+<var>entry index</var>.</p>
       <li data-md>
        <p>Collect the set of glyph indices that map to the <var>entry index</var>.</p>
       <li data-md>
-       <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
+       <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
 Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a> and <var>entry index</var> as inputs. If the template expansion results in an error, then return
+       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a>
+and <var>entry index</var> as inputs. If the template expansion results in an error, then return
 an error.</p>
       <li data-md>
        <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
       <li data-md>
        <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">entry</a> to <var>entry list</var> with a subset definition which contains only the Unicode code point
-set and maps to the generated URL string, the patch format specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
+set and maps to the generated URL string, the patch format specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat">patchFormat</a>, and
+<a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#format-1-patch-map-featuremapoffset" id="ref-for-format-1-patch-map-featuremapoffset">featureMapOffset</a> is not null then, for each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords②">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
+     <p>If <a data-link-type="dfn" href="#format-1-patch-map-featuremapoffset" id="ref-for-format-1-patch-map-featuremapoffset">featureMapOffset</a> is not null then, for each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in
+    <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords②">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
      <ul>
       <li data-md>
-       <p>Any <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord②">FeatureRecord’s</a> whose <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag①">featureTag</a> is less than or equal to a <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag②">featureTag</a> of any <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord③">FeatureRecord</a> which occurred earlier in the list are invalid. All associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord③">EntryMapRecord’s</a> are
+       <p>Any <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord②">FeatureRecord’s</a> whose <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag①">featureTag</a> is less than or equal to a <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag②">featureTag</a>
+of any <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord③">FeatureRecord</a>  which occurred earlier in the list are invalid. All associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord③">EntryMapRecord’s</a> are
 skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigned integer and ordered by the integer value.</p>
       <li data-md>
-       <p>Compute <var>mapped entry index</var>, the first <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord④">EntryMapRecord</a> associated with a <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord④">FeatureRecord</a> is <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex">FeatureRecord::firstNewEntryIndex</a>, the second <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex①">FeatureRecord::firstNewEntryIndex</a> + 1, and so on. The last will be <a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex②">FeatureRecord::firstNewEntryIndex</a> + <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount①">entryMapCount</a> - 1.</p>
+       <p>Compute <var>mapped entry index</var>, the first <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord④">EntryMapRecord</a> associated with a <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord④">FeatureRecord</a> is
+<a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex">FeatureRecord::firstNewEntryIndex</a>, the second
+<a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex①">FeatureRecord::firstNewEntryIndex</a> + 1, and so on. The last will be
+<a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex②">FeatureRecord::firstNewEntryIndex</a> + <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount①">entryMapCount</a> - 1.</p>
       <li data-md>
-       <p>If the computed <var>mapped entry index</var> is less than or equal to <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex①">maxGlyphMapEntryIndex</a> or larger than <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑤">maxEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑤">EntryMapRecord</a> is invalid, skip it.</p>
+       <p>If the computed <var>mapped entry index</var> is less than or equal to <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex①">maxGlyphMapEntryIndex</a> or larger than
+<a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑤">maxEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑤">EntryMapRecord</a> is invalid, skip it.</p>
       <li data-md>
-       <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
+       <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than
+<a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
       <li data-md>
-       <p>Convert <var>mapped entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template①">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a> and <var>mapped entry index</var> as inputs. If the template expansion results in an error, then return an error.</p>
+       <p>Convert <var>mapped entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template①">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a>
+and <var>mapped entry index</var> as inputs. If the template expansion results in an error, then return an error.</p>
       <li data-md>
        <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this entry.</p>
       <li data-md>
-       <p>Construct a set of Unicode code points. For each <var>entry index</var> between <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex①">EntryMapRecord::firstEntryIndex</a> (inclusive) and <a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex①">EntryMapRecord::lastEntryIndex</a> (inclusive):</p>
+       <p>Construct a set of Unicode code points. For each <var>entry index</var> between
+<a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex①">EntryMapRecord::firstEntryIndex</a> (inclusive) and
+<a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex①">EntryMapRecord::lastEntryIndex</a> (inclusive):</p>
        <ul>
         <li data-md>
          <p>If <var>entry index</var> is greater than <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex②">maxGlyphMapEntryIndex</a> then, this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑦">EntryMapRecord</a> is invalid
 skip it.</p>
         <li data-md>
-         <p>Add the set of Unicode code points associated with <var>entry index</var> that was computed in step 2 to the set. If the <var>entry index</var> was skipped because it was 0 or <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap②">appliedEntriesBitMap</a> compute the set of
+         <p>Add the set of Unicode code points associated with <var>entry index</var> that was computed in step 2 to the set. If the
+<var>entry index</var> was skipped because it was 0 or <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap②">appliedEntriesBitMap</a> compute the set of
 associated code points as if it wasn’t skipped.</p>
        </ul>
       <li data-md>
        <p>If the constructed set of Unicode code points is empty then, this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑧">EntryMapRecord</a> is invalid skip it.</p>
       <li data-md>
        <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> to <var>entry list</var> which  maps to the generated URL string, the patch format
-specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat①">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> in <var>entry list</var> which has the same patch URL string as the generated URL string then
+specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat①">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing
+<a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> in <var>entry list</var> which has the same patch URL string as the generated URL string then
 instead modify the existing entry. Add the constructed set of Unicode code points and <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag③">featureTag</a> to the new or
 existing entry’s subset definition.</p>
      </ul>
@@ -1966,17 +2101,21 @@ change the number of bytes.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format①">format</a> equal to 1 and is valid according to the requirements in <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format①">format</a> equal to 1 and is valid according to the requirements in
+ <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
     <li data-md>
      <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex①">entryIndex</a> of <var>patch map</var>:</p>
      <ul>
       <li data-md>
-       <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this <var>entry index</var>.</p>
+       <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this
+<var>entry index</var>.</p>
       <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template②">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a> and <var>entry index</var> as inputs. If the template expansion results in an error, then return
+       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template②">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a>
+and <var>entry index</var> as inputs. If the template expansion results in an error, then return
 an error.</p>
       <li data-md>
-       <p>If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
+       <p>If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in
+<a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
      </ul>
    </ol>
    <h4 class="heading settled" data-level="5.3.2" id="patch-map-format-2"><span class="secno">5.3.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
@@ -2000,16 +2139,22 @@ an error.</p>
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-flags">flags</dfn>
       <td>Flags to signal the presence of optional fields.
         If bit 0 (least significant bit) is set, then <a data-link-type="dfn" href="#format-2-patch-map-cffcharstringsoffset" id="ref-for-format-2-patch-map-cffcharstringsoffset①">cffCharStringsOffset</a> will be present.
-        If bit 1 (least significant bit) is set, then <a data-link-type="dfn" href="#format-2-patch-map-cff2charstringsoffset" id="ref-for-format-2-patch-map-cff2charstringsoffset①">cff2CharStringsOffset</a> will be present. 
+        If bit 1 (least significant bit) is set, then <a data-link-type="dfn" href="#format-2-patch-map-cff2charstringsoffset" id="ref-for-format-2-patch-map-cff2charstringsoffset①">cff2CharStringsOffset</a> will be present.
+    
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-compatibilityid">compatibilityId</dfn>[4]
-      <td> Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>). The encoder chooses this
-      value. The encoder should set it to a random value which has not previously been used while encoding the IFT font. 
+      <td>
+      Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>). The encoder chooses this
+      value. The encoder should set it to a random value which has not previously been used while encoding the IFT font.
+    
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchformat">defaultPatchFormat</dfn>
-      <td> Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry). <span class="conform" id="conform-format2-valid-format-number">Must be set to one of the format numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.</span> 
+      <td>
+      Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
+      <span class="conform client" id="conform-format2-valid-format-number">Must be set to one of the format numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.</span>
+    
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entrycount">entryCount</dfn>
@@ -2021,26 +2166,38 @@ an error.</p>
      <tr>
       <td>Offset32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entryidstringdata">entryIdStringData</dfn>
-      <td> Offset to a block of data containing the concatentation of all of the entry ID strings.
-      May be null (0). Offset is from the start of this table. 
+      <td>
+      Offset to a block of data containing the concatentation of all of the entry ID strings.
+      May be null (0). Offset is from the start of this table.
+    
      <tr>
       <td>uint16
       <td>urlTemplateLength
-      <td> Length of the urlTemplate byte array. 
+      <td>
+      Length of the urlTemplate byte array.
+    
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
-      <td> A byte array containing a <a href="#url-templates">URL Template</a> which is used to produce URL strings associated with each entry. 
+      <td>
+      A byte array containing a <a href="#url-templates">URL Template</a> which is used to produce URL strings associated with each entry.
+    
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-cffcharstringsoffset">cffCharStringsOffset</dfn>
-      <td> Only present if bit 0 (least significant) of <a data-link-type="dfn" href="#format-2-patch-map-flags" id="ref-for-format-2-patch-map-flags">flags</a> is set.
-      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table to the CharStrings INDEX data structure of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table. 
+      <td>
+      Only present if bit 0 (least significant) of <a data-link-type="dfn" href="#format-2-patch-map-flags" id="ref-for-format-2-patch-map-flags">flags</a> is set.
+      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table to the CharStrings INDEX data structure of the
+      <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table.
+    
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-cff2charstringsoffset">cff2CharStringsOffset</dfn>
-      <td> Only present if bit 1 of <a data-link-type="dfn" href="#format-2-patch-map-flags" id="ref-for-format-2-patch-map-flags①">flags</a> is set.
-      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF2</a> table to the CharStrings INDEX data structure of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table. 
+      <td>
+      Only present if bit 1 of <a data-link-type="dfn" href="#format-2-patch-map-flags" id="ref-for-format-2-patch-map-flags①">flags</a> is set.
+      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF2</a> table to the CharStrings INDEX data structure of the
+      <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table.
+    
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entries">Mapping Entries</dfn> encoding:</p>
    <table>
@@ -2065,71 +2222,100 @@ an error.</p>
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-formatflags">formatFlags</dfn>
-      <td> A bit field. Bit 0 (least significant bit) through bit 5 indicate the presence of optional fields. If bit 6 is set this entry is
-      ignored. Bit 7 is reserved for future use and set to 0. 
+      <td>
+      A bit field. Bit 0 (least significant bit) through bit 5 indicate the presence of optional fields. If bit 6 is set this entry is
+      ignored. Bit 7 is reserved for future use and set to 0.
+    
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featurecount">featureCount</dfn>
-      <td> Number of feature tags in the featureTags list. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags">formatFlags</a> bit 0 is set. 
+      <td>
+      Number of feature tags in the featureTags list. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags">formatFlags</a> bit 0 is set.
+    
      <tr>
       <td>Tag
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags</dfn>[featureCount]
-      <td> List of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set. 
+      <td>
+      List of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definition</a>. Only present if
+      <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set.
+    
      <tr>
       <td>uint16
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacecount">designSpaceCount</dfn>
-      <td> Number of elements in the design space list. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags②">formatFlags</a> bit 0 is set. 
+      <td>
+      Number of elements in the design space list. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags②">formatFlags</a> bit 0 is set.
+    
      <tr>
       <td><a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment">Design Space Segment</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments</dfn>[designSpaceCount]
-      <td> List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set. 
+      <td>
+      List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set.
+    
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-childentrymatchmodeandcount">childEntryMatchModeAndCount</dfn>
-      <td> This and the following field are used to add conditions to the intersection check for this entry that depend on whether prior entries intersect.
+      <td>
+      This and the following field are used to add conditions to the intersection check for this entry that depend on whether prior entries intersect.
       The most significant bit is used to indicate the matching mode. If the bit is set the condition is conjunctive otherwise it is disjunctive. The
       remaining 7 bits are interpreted as a unsigned integer and represent the number of entry indices in the childEntryIndices list. This field is only
-      present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags④">formatFlags</a> bit 1 is set. 
+      present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags④">formatFlags</a> bit 1 is set.
+    
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-childentryindices">childEntryIndices</dfn>[0b01111111 &amp; childEntryMatchModeAndCount]
-      <td> Each value is the index of an entry in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries②">entries</a> array whose intersection will be checked to determine this entries intersection.
-      Only entries that occurred prior to this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries③">entries</a> can be referenced. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set. 
+      <td>
+      Each value is the index of an entry in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries②">entries</a> array whose intersection will be checked to determine this entries intersection.
+      Only entries that occurred prior to this <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry①">Mapping Entry</a> in <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries③">entries</a> can be referenced. Only present if
+      <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑤">formatFlags</a> bit 1 is set.
+    
      <tr>
       <td>int24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryiddelta">entryIdDelta</dfn>[variable]
-      <td> List of signed deltas which calculate the IDs of the URL strings for this entry. If present, has at least one delta. If the least
+      <td>
+      List of signed deltas which calculate the IDs of the URL strings for this entry. If present, has at least one delta. If the least
       significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
-      cleared is encountered. The entry id for each delta is the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0).
+      cleared is encountered. The entry id for each delta is the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if
+      <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0).
       If not present and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata①">entryIdStringData</a> is null (0), then there is one id for this entry and the
-      delta is assumed to be 0. 
+      delta is assumed to be 0.
+    
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryidstringlength">entryIdStringLength</dfn>[variable]
-      <td> The number of bytes that each id string for this entry occupies in the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata②">entryIdStringData</a> data block.  If the most significant bit of a length value is set, then another length value follows. This repeats
+      <td>
+      The number of bytes that each id string for this entry occupies in the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata②">entryIdStringData</a>
+      data block.  If the most significant bit of a length value is set, then another length value follows. This repeats
       until a length value with the most significant bit cleared is encountered. The actual length value is stored in
-      the least significant 23 bits of each value. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑦">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a> is not null (0). If present has at least one length value. If not present
+      the least significant 23 bits of each value. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑦">formatFlags</a> bit 2 is set and
+      <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a> is not null (0). If present has at least one length value. If not present
       and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a> is not null (0), then the there is one id string which is set to the last
-      id string from the previous entry or an empty string for the first entry. 
+      id string from the previous entry or an empty string for the first entry.
+    
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchformat">patchFormat</dfn>
-      <td> Specifies the format of the patch linked to by this entry. Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.
+      <td>
+      Specifies the format of the patch linked to by this entry. Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.
       Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat">defaultPatchFormat</a>.
-      Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 3 is set. 
+      Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 3 is set.
+    
      <tr>
       <td>uint16/uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-bias">bias</dfn>
-      <td> Bias value which is added to all code point values in the code points set.
+      <td>
+      Bias value which is added to all code point values in the code points set.
       If format bit 4 is 0 and bit 5 is 1, then this is present and a uint16.
       If format bit 4 is 1 and bit 5 is 1, then this is present and a uint24.
-      Otherwise it is not present. 
+      Otherwise it is not present.
+    
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-codepoints">codePoints</dfn>[variable]
-      <td> Set of code points for this mapping. Encoded as a <a data-link-type="dfn" href="#sparse-bit-set" id="ref-for-sparse-bit-set">Sparse Bit Set</a>.
+      <td>
+      Set of code points for this mapping. Encoded as a <a data-link-type="dfn" href="#sparse-bit-set" id="ref-for-sparse-bit-set">Sparse Bit Set</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑨">formatFlags</a> bit 4 and/or 5 is set. The length is
-      determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 5.3.2.3 Sparse Bit Set</a>. 
+      determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 5.3.2.3 Sparse Bit Set</a>.
+    
    </table>
    <p>If an encoder is producing patches that will be stored on a file system and then served it’s recommended that only numeric entry IDs be
 used (via <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a>) as these will generally produce the smallest encoding of the format 2 patch map. String IDs
@@ -2145,15 +2331,23 @@ being requested.</p>
      <tr>
       <td>Tag
       <td><dfn class="dfn-paneled" data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-tag">tag</dfn>
-      <td> Axis tag value. 
+      <td>
+      Axis tag value.
+    
      <tr>
       <td>Fixed
       <td><dfn class="dfn-paneled" data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-start">start</dfn>
-      <td> Start (inclusive) of the segment. This value uses the user axis scale: <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
+      <td>
+      Start (inclusive) of the segment. This value uses the user axis scale:
+      <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>.
+    
      <tr>
       <td>Fixed
       <td><dfn class="dfn-paneled" data-dfn-for="Design Space Segment" data-dfn-type="dfn" data-noexport id="design-space-segment-end">end</dfn>
-      <td> End (inclusive) of the segment. <span class="conform" id="conform-design-space-segment-end-valid-value">Must be greater than or equal to start.</span> This value uses the user axis scale: <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>. 
+      <td>
+      End (inclusive) of the segment. <span class="conform client" id="conform-design-space-segment-end-valid-value">Must be greater than or equal to start.</span> This value uses the user axis scale:
+      <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>.
+    
    </table>
    <h5 class="heading settled algorithm" data-algorithm="Interpreting Format 2" data-level="5.3.2.1" id="interpreting-patch-map-format-2"><span class="secno">5.3.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
    <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑧">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
@@ -2171,7 +2365,8 @@ being requested.</p>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in <a href="#patch-map-format-2">§ 5.3.2 Patch Map Table: Format 2</a> (requirements are marked with a "must"). If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in
+ <a href="#patch-map-format-2">§ 5.3.2 Patch Map Table: Format 2</a> (requirements are marked with a "must"). If it is not return an error.</p>
     <li data-md>
      <p>If the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑤">entryIdStringData</a> offset is 0 then initialize <var>last entry id</var> to 0. Otherwise initialize
  it to an empty byte string. Set <var>current byte</var> to 0, and <var>current id string byte</var> to 0.</p>
@@ -2184,7 +2379,10 @@ being requested.</p>
        <p>pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
  the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑥">entryIdStringData</a>[<var>current id string byte</var>]
- to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero, <var>last entry id</var>, <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and <a data-link-type="dfn" href="#format-2-patch-map-urltemplate" id="ref-for-format-2-patch-map-urltemplate">urlTemplate</a>.</p>
+ to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero,
+ <var>last entry id</var>,
+ <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and
+ <a data-link-type="dfn" href="#format-2-patch-map-urltemplate" id="ref-for-format-2-patch-map-urltemplate">urlTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
@@ -2194,7 +2392,8 @@ being requested.</p>
       <li data-md>
        <p>Add the returned entry to <var>prior entry list</var>.</p>
       <li data-md>
-       <p>If the returned value of ignored is false, then set the compatibility ID of the returned entry to <a data-link-type="dfn" href="#format-2-patch-map-compatibilityid" id="ref-for-format-2-patch-map-compatibilityid">compatibilityId</a> and add the  entry to <var>entry list</var>.</p>
+       <p>If the returned value of ignored is false, then set the compatibility ID of the returned entry to
+ <a data-link-type="dfn" href="#format-2-patch-map-compatibilityid" id="ref-for-format-2-patch-map-compatibilityid">compatibilityId</a> and add the  entry to <var>entry list</var>.</p>
      </ul>
     <li data-md>
      <p>Return <var>entry list</var>.</p>
@@ -2245,11 +2444,14 @@ being requested.</p>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①①">formatFlags</a> bit 0 is set, then the feature tag and design space lists are present:</p>
      <ul>
       <li data-md>
-       <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var> and add the loaded tags to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a> in <var>entry</var>.</p>
+       <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var>
+and add the loaded tags to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a> in <var>entry</var>.</p>
       <li data-md>
-       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a> from <var>entry bytes</var> and add the design space segments to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> in <var>entry</var>. Each
+       <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a>
+from <var>entry bytes</var> and add the design space segments to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> in <var>entry</var>. Each
 segment defines an interval from <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start">start</a> to <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end">end</a> inclusive for the axis identified
-by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-space-segment-tag">tag</a>. If any segment has a <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start①">start</a> which is greater than <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end①">end</a> then, this encoding is invalid return an error.</p>
+by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-space-segment-tag">tag</a>. If any segment has a <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start①">start</a> which is greater than
+<a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end①">end</a> then, this encoding is invalid return an error.</p>
      </ul>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①②">formatFlags</a> bit 1 is set, then the copy indices list is present:</p>
@@ -2258,7 +2460,8 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
        <p>If the most significant bit of <a data-link-type="dfn" href="#mapping-entry-childentrymatchmodeandcount" id="ref-for-mapping-entry-childentrymatchmodeandcount">childEntryMatchModeAndCount</a> is set then set <var>entry</var>’s match mode to conjunctive,
  otherwise to disjunctive.</p>
       <li data-md>
-       <p>Read the child entry indices list specified by <a data-link-type="dfn" href="#mapping-entry-childentrymatchmodeandcount" id="ref-for-mapping-entry-childentrymatchmodeandcount①">childEntryMatchModeAndCount</a> and <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices">childEntryIndices</a> from <var>entry bytes</var>.</p>
+       <p>Read the child entry indices list specified by <a data-link-type="dfn" href="#mapping-entry-childentrymatchmodeandcount" id="ref-for-mapping-entry-childentrymatchmodeandcount①">childEntryMatchModeAndCount</a> and <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices">childEntryIndices</a> from
+ <var>entry bytes</var>.</p>
       <li data-md>
        <p>The child entry indices refer to previously loaded entries. 0 is the first <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry③">Mapping Entry</a> in <var>prior entry list</var>, 1 the second
  and so on. For each value in <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices①">childEntryIndices</a> locate the entry in <var>prior entry list</var> with a matching index.
@@ -2277,7 +2480,8 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
  If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template③">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template③">Expand URL Template</a> with <var>url template</var>
+ and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
         <li data-md>
@@ -2292,7 +2496,8 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
  Set <var>entry id</var> to the result. Increment <var>consumed id string bytes</var> by the number of bytes read.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template④">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template④">Expand URL Template</a> with <var>url template</var>
+ and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
         <li data-md>
@@ -2308,7 +2513,8 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
         <li data-md>
          <p>Set <var>entry id</var> to <var>entry id</var> + 1.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑤">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑤">Expand URL Template</a> with <var>url template</var>
+ and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
        </ul>
@@ -2316,13 +2522,15 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
        <p>Otherwise if <var>id string bytes</var> is present, then:</p>
        <ul>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑥">Expand URL Template</a> with <var>url template</var> and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑥">Expand URL Template</a> with <var>url template</var>
+ and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
        </ul>
      </ul>
     <li data-md>
-     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑤">formatFlags</a> bit 3 is set, then a patch format is present. Read the format specified by <a data-link-type="dfn" href="#mapping-entry-patchformat" id="ref-for-mapping-entry-patchformat">patchFormat</a> from <var>entry bytes</var> and set the patch format of <var>entry</var> to the read value.
+     <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑤">formatFlags</a> bit 3 is set, then a patch format is present. Read the format specified by
+ <a data-link-type="dfn" href="#mapping-entry-patchformat" id="ref-for-mapping-entry-patchformat">patchFormat</a> from <var>entry bytes</var> and set the patch format of <var>entry</var> to the read value.
  If <a data-link-type="dfn" href="#mapping-entry-patchformat" id="ref-for-mapping-entry-patchformat①">patchFormat</a> is not one of the values in <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> then, this encoding is invalid
  return an error.</p>
     <li data-md>
@@ -2344,7 +2552,8 @@ failed then, this encoding is invalid return an error.</p>
     <li data-md>
      <p>If <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⑨">formatFlags</a> bit 6 is set, then set <var>ignored</var> to true. Otherwise <var>ignored</var> is false.</p>
     <li data-md>
-     <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>, <var>consumed id string bytes</var>, and <var>ignored</var>.</p>
+     <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>,
+ <var>consumed id string bytes</var>, and <var>ignored</var>.</p>
    </ol>
    <h5 class="heading settled algorithm" data-algorithm="Remove Entries from Format 2" data-level="5.3.2.2" id="remove-entries-format-2"><span class="secno">5.3.2.2. </span><span class="content">Remove Entries from Format 2</span><a class="self-link" href="#remove-entries-format-2"></a></h5>
    <p>This algorithm is used to remove entries from a format 2 patch map. This removal modifies the bytes of the patch map but does not
@@ -2357,10 +2566,12 @@ change the number of bytes.</p>
     <li data-md>
      <p><var>patch URL string</var>: URL string for a patch which identifies the entries to be removed.</p>
    </ul>
-   <p>This algorithm is a modified version of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map①">Interpret Format 2 Patch Map</a>, invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map②">Interpret Format 2 Patch Map</a> with <var>patch map</var> as an input but with the following changes:</p>
+   <p>This algorithm is a modified version of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map①">Interpret Format 2 Patch Map</a>, invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map②">Interpret Format 2 Patch Map</a> with <var>patch map</var>
+as an input but with the following changes:</p>
    <ul>
     <li data-md>
-     <p>During step 8 and 9 of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry②">Interpret Format 2 Patch Map Entry</a>: compare the URL string generated for only the first delta/length value to <var>patch URL string</var> if they are equal then, set bit 6 of <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags②⓪">formatFlags</a> to 1. Stop the interpretation process
+     <p>During step 8 and 9 of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry②">Interpret Format 2 Patch Map Entry</a>: compare the URL string generated for only the first delta/length value to
+<var>patch URL string</var> if they are equal then, set bit 6 of  <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags②⓪">formatFlags</a> to 1. Stop the interpretation process
 at this point.</p>
     <li data-md>
      <p>The return value of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map③">Interpret Format 2 Patch Map</a> is not used.</p>
@@ -2383,7 +2594,8 @@ values stored in a sparse bit set are restricted to being <a data-link-type="bib
       <td>uint8
       <td>header
       <td>Bits 0 (least significant) and 1 encode the trees branch factor <i>B</i> via <a data-link-type="dfn" href="#branch-factor-encoding" id="ref-for-branch-factor-encoding">Branch Factor Encoding</a>. Bits 2 through 6 are a
-        5-bit unsigned integer which encodes the value of <i>H</i>. Bit 7 is set to 0 and reserved for future use. 
+        5-bit unsigned integer which encodes the value of <i>H</i>. Bit 7 is set to 0 and reserved for future use.
+    
      <tr>
       <td>uint8
       <td>treeData[variable]
@@ -2479,9 +2691,13 @@ into <var>S</var>. Go to step 5.</p>
      <p>Go to step 8.</p>
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> when encoding sparse bit sets the encoder can use any of the possible branching factors, but it is recommended to
-use 4 as that has <a href="https://github.com/w3c/PFE-analysis/blob/main/results/set_encoding_branch_factor.md">been shown</a> to give the smallest encodings for most unicode code point sets typically encountered.</p>
+use 4 as that has <a href="https://github.com/w3c/PFE-analysis/blob/main/results/set_encoding_branch_factor.md">been shown</a>
+to give the smallest encodings for most unicode code point sets typically encountered.</p>
    <div class="example" id="example-eb491b43">
-    <a class="self-link" href="#example-eb491b43"></a> The set {2, 33, 323} in a tree with a branching factor of 8 can be encoded as the bit string: 
+    <a class="self-link" href="#example-eb491b43"></a>
+  The set {2, 33, 323} in a tree with a branching factor of 8 can be encoded as the bit string:
+
+  
 <pre>bit string:
 |-- header --|- lvl 0 |---- level 1 ----|------- level 2 -----------|
 | B=8 H=3    |   n0   |   n1       n2   |   n3       n4       n5    |
@@ -2500,7 +2716,10 @@ Which then becomes the byte string:
 </pre>
    </div>
    <div class="example" id="example-e803ad63">
-    <a class="self-link" href="#example-e803ad63"></a> The empty set in a tree with a branching factor of 2 is encoded as the bit string: 
+    <a class="self-link" href="#example-e803ad63"></a>
+  The empty set in a tree with a branching factor of 2 is encoded as the bit string:
+
+  
 <pre>bit string:
 |-- header -- |
 | B=2 H=0     |
@@ -2513,7 +2732,10 @@ Which then becomes the byte string:
 </pre>
    </div>
    <div class="example" id="example-cc307778">
-    <a class="self-link" href="#example-cc307778"></a> The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as: 
+    <a class="self-link" href="#example-cc307778"></a>
+  The set {0, 1, 2, ..., 17} can be encoded with a branching factor of 4 as:
+
+  
 <pre>bit string:
 |-- header --| l0 |- lvl 1 -| l2  |
 | B=4 H=3    | n0 | n1 | n2 | n3  |
@@ -2593,27 +2815,39 @@ expansion is finished, return <var>URL string</var>.</p>
      <tr>
       <td>Insert id32
       <td>128 (0b10000000)
-      <td> Append the value of the <var>id32</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+      <td>
+      Append the value of the <var>id32</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
+    
      <tr>
       <td>Insert d1
       <td>129 (0b10000001)
-      <td> Append the value of the <var>d1</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+      <td>
+      Append the value of the <var>d1</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
+    
      <tr>
       <td>Insert d2
       <td>130 (0b10000010)
-      <td> Append the value of the <var>d2</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+      <td>
+      Append the value of the <var>d2</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
+    
      <tr>
       <td>Insert d3
       <td>131 (0b10000011)
-      <td> Append the value of the <var>d3</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+      <td>
+      Append the value of the <var>d3</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
+    
      <tr>
       <td>Insert d4
       <td>132 (0b10000100)
-      <td> Append the value of the <var>d4</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+      <td>
+      Append the value of the <var>d4</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
+    
      <tr>
       <td>Insert id64
       <td>133 (0b10000101)
-      <td> Append the value of the <var>id64</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>. 
+      <td>
+      Append the value of the <var>id64</var> variable from the proceeding <b>Expansion Variables</b> table to <var>URL string</var>.
+    
    </table>
    <p><b>Expansion Variables</b></p>
    <table>
@@ -2623,36 +2857,53 @@ expansion is finished, return <var>URL string</var>.</p>
       <th>Value
      <tr>
       <td><var>id32</var>
-      <td> The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a> string (using the digits 0-9, A-V) with padding
-      omitted. <span class="conform" id="conform-entry-id-must-be-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
-      but then all leading bytes that are equal to 0 are removed before encoding.</span> (For example, when the
-      integer is less than 256 only one byte is encoded.) If <var>entry ID</var> is 0 then one zero byte is encoded. When <var>entry ID</var> is a string the raw bytes are encoded as base32hex. 
+      <td>
+      The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a> string (using the digits 0-9, A-V) with padding
+      omitted.  <span class="conform client" id="conform-entry-id-must-be-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
+      but then all leading bytes that are equal to 0 are removed before encoding.</span>  (For example, when the
+      integer is less than 256 only one byte is encoded.) If <var>entry ID</var> is 0 then one zero byte is encoded. When
+      <var>entry ID</var> is a string the raw bytes are encoded as base32hex.
+    
      <tr>
       <td><var>d1</var>
-      <td> The last character of the string in the <var>id32</var> variable.
-      If <var>id32</var> variable is empty then, the value is the character _ (U+005F). 
+      <td>
+      The last character of the string in the <var>id32</var> variable.
+      If <var>id32</var> variable is empty then, the value is the character _ (U+005F).
+    
      <tr>
       <td><var>d2</var>
-      <td> The second to last character of the string in the <var>id32</var> variable.
-      If the <var>id32</var> variable has less than 2 characters then, the value is the character _ (U+005F). 
+      <td>
+      The second to last character of the string in the <var>id32</var> variable.
+      If the <var>id32</var> variable has less than 2 characters then, the value is the character _ (U+005F).
+    
      <tr>
       <td><var>d3</var>
-      <td> The third to last character of the string in the <var>id32</var> variable.
-      If the <var>id32</var> variable has less than 3 characters then, the value is the character _ (U+005F). 
+      <td>
+      The third to last character of the string in the <var>id32</var> variable.
+      If the <var>id32</var> variable has less than 3 characters then, the value is the character _ (U+005F).
+    
      <tr>
       <td><var>d4</var>
-      <td> The fourth to last character of the string in the <var>id32</var> variable.
-      If the <var>id32</var> variable has less than 4 characters then, the value is the character _ (U+005F). 
+      <td>
+      The fourth to last character of the string in the <var>id32</var> variable.
+      If the <var>id32</var> variable has less than 4 characters then, the value is the character _ (U+005F).
+    
      <tr>
       <td><var>id64</var>
-      <td> The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a> string (using the digits A-Z, a-z, 0-9, -
-      (minus) and _ (underline)) with padding included. <span class="conform" id="conform-equal-sign-encoded">Because the padding character is '=', it must
-      be URL-encoded as '%3D'.</span> <span class="conform" id="conform-entry-id-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big
-      endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding.</span> (For example, when the integer is less than 256 only one byte is encoded.) If the <var>entry ID</var> is 0 then one
-      zero byte is encoded. When the <var>entry ID</var> is a string its raw bytes are encoded as <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>. 
+      <td>
+      The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a> string (using the digits A-Z, a-z, 0-9, -
+      (minus) and _ (underline)) with padding included. <span class="conform client" id="conform-equal-sign-encoded">Because the padding character is '=', it must
+      be URL-encoded as '%3D'.</span>  <span class="conform client" id="conform-entry-id-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big
+      endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding.</span>
+      (For example, when the integer is less than 256 only one byte is encoded.) If the <var>entry ID</var> is 0 then one
+      zero byte is encoded. When the <var>entry ID</var> is a string its raw bytes are encoded as
+      <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>.
+    
    </table>
    <div class="example" id="example-305f10ca">
-    <a class="self-link" href="#example-305f10ca"></a> 
+    <a class="self-link" href="#example-305f10ca"></a>
+
+
     <p>Some example inputs and the corresponding expansions. Values in "Template Bytes" column are provided as C style byte arrays.</p>
     <table>
      <tbody>
@@ -2781,7 +3032,10 @@ encoding can make use of more than one patch format.</p>
       <td><a data-link-type="dfn" href="#no-invalidation" id="ref-for-no-invalidation">No Invalidation</a>
    </table>
    <h3 class="heading settled" data-level="6.2" id="table-keyed"><span class="secno">6.2. </span><span class="content">Table Keyed</span><a class="self-link" href="#table-keyed"></a></h3>
-   <p>A table keyed patch contains a collection of patches which are applied to the individual <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15#section-3.2">shared LZ77 dictionary</a>. A table keyed encoded patch consists of a short header followed
+   <p>A table keyed patch contains a collection of patches which are applied to the individual
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font tables</a> in the input font file. Each table patch is encoded with
+<a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a
+<a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15#section-3.2">shared LZ77 dictionary</a>. A table keyed encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
 or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="table-keyed-patch">Table keyed patch</dfn> encoding:</p>
@@ -2794,7 +3048,7 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
      <tr>
       <td>Tag
       <td>format
-      <td><span class="conform" id="conform-table-keyed-format-equals-iftk">Identifies the format as table keyed, must be set to 'iftk'</span>
+      <td><span class="conform client" id="conform-table-keyed-format-equals-iftk">Identifies the format as table keyed, must be set to 'iftk'</span>
      <tr>
       <td>uint32
       <td>reserved
@@ -2810,7 +3064,7 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
      <tr>
       <td>Offset32
       <td><dfn class="dfn-paneled" data-dfn-for="Table keyed patch" data-dfn-type="dfn" data-noexport id="table-keyed-patch-patches">patches</dfn>[patchesCount+1]
-      <td>Each entry is an offset from the start of this table to a <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch">TablePatch</a>. <span class="conform" id="conform-table-keyed-patches-sort-ascending">Offsets must be sorted in ascending order.</span>
+      <td>Each entry is an offset from the start of this table to a <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch">TablePatch</a>. <span class="conform client" id="conform-table-keyed-patches-sort-ascending">Offsets must be sorted in ascending order.</span>
    </table>
    <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches">patches</a> array gives the size
 of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">TablePatch</a>.</p>
@@ -2876,28 +3130,41 @@ can re-use the checksum from the entry in the source font. Otherwise a new check
      <p>For each entry in <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches①">patches</a>, with index <var>i</var>:</p>
      <ul>
       <li data-md>
-       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch③">TablePatch</a> associated with index <var>i</var>. The object starts at the offset <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches②">patches[i]</a> (inclusive) and ends at the offset <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
+       <p>Find the <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch③">TablePatch</a> associated with index <var>i</var>. The object starts at the offset
+<a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches②">patches[i]</a> (inclusive) and ends at the offset
+<a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches③">patches[i+1]</a> (exclusive). Both offsets are relative to the start of
 the <var>patch</var>.</p>
       <li data-md>
        <p>If an entry in <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches④">patches</a> was previously applied that has the same <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag">tag</a> as
 this entry, then ignore this entry and continue the iteration to the next one. Entries are processed in same order as they
 are listed in the <a data-link-type="dfn" href="#table-keyed-patch-patches" id="ref-for-table-keyed-patch-patches⑤">patches</a> array.</p>
       <li data-md>
-       <p>If bit 1 of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags">flags</a> is set, then do not copy or add a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag①">tag</a>. Continue to the next entry.</p>
+       <p>If bit 1 of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags">flags</a> is set, then do not copy or add a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to
+<var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag①">tag</a>. Continue to the next entry.</p>
       <li data-md>
-       <p>If bit 0 (least significant bit) of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags①">flags</a> is set, then decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream①">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10"><cite>Brotli Compressed Data Format</cite> § 10 Decoding Algorithm</a>. No shared dictionary is used. If the decoded data is larger than <a data-link-type="dfn" href="#tablepatch-maxuncompressedlength" id="ref-for-tablepatch-maxuncompressedlength">maxUncompressedLength</a> return an error. If there is any data in <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream②">brotliStream</a> which was not used by the decoding process return an error.
-Add a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag②">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream③">brotliStream</a>. Continue to the next entry.</p>
+       <p>If bit 0 (least significant bit) of <a data-link-type="dfn" href="#tablepatch-flags" id="ref-for-tablepatch-flags①">flags</a> is set, then decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream①">brotliStream</a> following
+<a href="https://www.rfc-editor.org/rfc/rfc7932#section-10"><cite>Brotli Compressed Data Format</cite> § 10 Decoding Algorithm</a>. No shared dictionary is used. If the decoded data is larger than <a data-link-type="dfn" href="#tablepatch-maxuncompressedlength" id="ref-for-tablepatch-maxuncompressedlength">maxUncompressedLength</a>
+return an error. If there is any data in <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream②">brotliStream</a> which was not used by the decoding process return an error.
+Add a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by
+<a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag②">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream③">brotliStream</a>. Continue to the next entry.</p>
       <li data-md>
-       <p>Otherwise, decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream④">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10"><cite>Brotli Compressed Data Format</cite> § 10 Decoding Algorithm</a> and using the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag③">tag</a> in <var>base font subset</var> as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15#section-3.2">shared LZ77 dictionary</a>. If no such table exists return an error. If the decoded data is
+       <p>Otherwise, decode <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream④">brotliStream</a> following <a href="https://www.rfc-editor.org/rfc/rfc7932#section-10"><cite>Brotli Compressed Data Format</cite> § 10 Decoding Algorithm</a> and using the
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag③">tag</a> in <var>base font subset</var>
+as a <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15#section-3.2">shared LZ77 dictionary</a>. If no such table exists return an error. If the decoded data is
 larger than <a data-link-type="dfn" href="#tablepatch-maxuncompressedlength" id="ref-for-tablepatch-maxuncompressedlength①">maxUncompressedLength</a> return an error. If there is any data in <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream⑤">brotliStream</a> which was
-not used by the decoding process return an error. Add a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to <var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag④">tag</a> with it’s contents set to the decoded <a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream⑥">brotliStream</a>.</p>
+not used by the decoding process return an error. Add a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> to
+<var>extended font subset</var> identified by <a data-link-type="dfn" href="#tablepatch-tag" id="ref-for-tablepatch-tag④">tag</a> with it’s contents set to the decoded
+<a data-link-type="dfn" href="#tablepatch-brotlistream" id="ref-for-tablepatch-brotlistream⑥">brotliStream</a>.</p>
      </ul>
     <li data-md>
      <p>For each <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> in <var>base font subset</var> which has a tag that was not found in any of
 the entries processed in step 5, add a copy of that table to <var>extended font subset</var>.</p>
    </ol>
    <h3 class="heading settled" data-level="6.3" id="glyph-keyed"><span class="secno">6.3. </span><span class="content">Glyph Keyed</span><a class="self-link" href="#glyph-keyed"></a></h3>
-   <p>A glyph keyed patch contains a collection of data chunks that are each associated with a glyph index and a <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font table</a>. The encoded data replaces any existing data for that glyph index in the referenced <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>. Glyph keyed patches can encode data for <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a>/<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/loca#">loca</a>, <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#">gvar</a>, <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff#">CFF</a>, and <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#">CFF2</a> tables.</p>
+   <p>A glyph keyed patch contains a collection of data chunks that are each associated with a glyph index and a
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">font table</a>. The encoded data replaces any existing data for that glyph index in the referenced
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>. Glyph keyed patches can encode data for <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a>/<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/loca#">loca</a>,
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#">gvar</a>, <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff#">CFF</a>, and <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#">CFF2</a> tables.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-keyed-patch">Glyph keyed patch</dfn> encoding:</p>
    <table>
     <tbody>
@@ -2908,7 +3175,7 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
      <tr>
       <td>Tag
       <td>format
-      <td><span class="conform" id="conform-conform-glyph-keyed-format-equals-ifgk">Identifies the format as glyph keyed, must be set to 'ifgk'</span>
+      <td><span class="conform client" id="conform-conform-glyph-keyed-format-equals-ifgk">Identifies the format as glyph keyed, must be set to 'ifgk'</span>
      <tr>
       <td>uint32
       <td>reserved
@@ -2944,26 +3211,38 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
      <tr>
       <td>uint8
       <td>tableCount
-      <td> The number of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> the patch has data for. 
+      <td>
+      The number of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> the patch has data for.
+    
      <tr>
       <td>uint16/uint24
       <td><dfn class="dfn-paneled" data-dfn-for="GlyphPatches" data-dfn-type="dfn" data-noexport id="glyphpatches-glyphids">glyphIds</dfn>[glyphCount]
-      <td> An array of glyph indices included in the patch. Elements are uint24’s if bit 0 (least significant bit) of <a data-link-type="dfn" href="#glyph-keyed-patch-flags" id="ref-for-glyph-keyed-patch-flags">flags</a> is set, otherwise elements are uint16’s. <span class="conform" id="conform-glyph-keyed-glyph-ids-sort-ascending-unique">Must be in ascending sorted order and must not
-      contain any duplicate values.</span> 
+      <td>
+      An array of glyph indices included in the patch. Elements are uint24’s if bit 0 (least significant bit) of
+      <a data-link-type="dfn" href="#glyph-keyed-patch-flags" id="ref-for-glyph-keyed-patch-flags">flags</a> is set, otherwise elements are uint16’s. <span class="conform client" id="conform-glyph-keyed-glyph-ids-sort-ascending-unique">Must be in ascending sorted order and must not
+      contain any duplicate values.</span>
+    
      <tr>
       <td>Tag
       <td><dfn class="dfn-paneled" data-dfn-for="GlyphPatches" data-dfn-type="dfn" data-noexport id="glyphpatches-tables">tables</dfn>[tableCount]
-      <td>An array of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> (by tag) included in the patch. <span class="conform" id="conform-glyph-keyed-tables-sort-ascending-unique">Must be in ascending sorted
+      <td>An array of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> (by tag) included in the patch. <span class="conform client" id="conform-glyph-keyed-tables-sort-ascending-unique">Must be in ascending sorted
       order and must not contain any duplicate values.</span> For sorting tag values are interpreted as a 4 byte big endian
       unsigned integer and sorted by the integer value.
      <tr>
       <td>Offset32
       <td><dfn class="dfn-paneled" data-dfn-for="GlyphPatches" data-dfn-type="dfn" data-noexport id="glyphpatches-glyphdataoffsets">glyphDataOffsets</dfn>[glyphCount * tableCount + 1]
-      <td> An array of offsets of to glyph data for each table. The first <a data-link-type="dfn" href="#glyphpatches-glyphcount" id="ref-for-glyphpatches-glyphcount">glyphCount</a> offsets corresponding to <a data-link-type="dfn" href="#glyphpatches-tables" id="ref-for-glyphpatches-tables">tables[0]</a>, the next <a data-link-type="dfn" href="#glyphpatches-glyphcount" id="ref-for-glyphpatches-glyphcount①">glyphCount</a> offsets (if present) corresponding to <a data-link-type="dfn" href="#glyphpatches-tables" id="ref-for-glyphpatches-tables①">tables[1]</a>, and so on. All offsets are from the start of the <a data-link-type="dfn" href="#glyphpatches" id="ref-for-glyphpatches①">GlyphPatches</a> table. <span class="conform" id="conform-glyph-keyed-glyph-data-offsets-sort-ascending">Offsets must be sorted in ascending order.</span> 
+      <td>
+      An array of offsets of to glyph data for each table. The first <a data-link-type="dfn" href="#glyphpatches-glyphcount" id="ref-for-glyphpatches-glyphcount">glyphCount</a> offsets corresponding to
+      <a data-link-type="dfn" href="#glyphpatches-tables" id="ref-for-glyphpatches-tables">tables[0]</a>, the next <a data-link-type="dfn" href="#glyphpatches-glyphcount" id="ref-for-glyphpatches-glyphcount①">glyphCount</a> offsets (if present) corresponding to
+      <a data-link-type="dfn" href="#glyphpatches-tables" id="ref-for-glyphpatches-tables①">tables[1]</a>, and so on. All offsets are from the start of the <a data-link-type="dfn" href="#glyphpatches" id="ref-for-glyphpatches①">GlyphPatches</a> table.
+      <span class="conform client" id="conform-glyph-keyed-glyph-data-offsets-sort-ascending">Offsets must be sorted in ascending order.</span>
+    
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="GlyphPatches" data-dfn-type="dfn" data-noexport id="glyphpatches-glyphdata">glyphData</dfn>[variable]
-      <td> The actual glyph data picked out by the offsets. 
+      <td>
+      The actual glyph data picked out by the offsets.
+    
    </table>
    <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets">glyphDataOffsets</a> array gives the size
 of that glyph data.</p>
@@ -3009,16 +3288,21 @@ a new table where the data for each glyph is replaced with the data correspondin
 from <a data-link-type="dfn" href="#glyphpatches-glyphdata" id="ref-for-glyphpatches-glyphdata">glyphData</a> if present, otherwise copied from the corresponding table in <var>base font subset</var> for
 that glyph index.</p>
       <li data-md>
-       <p>The patch glyph data for a glyph index is located by finding <a data-link-type="dfn" href="#glyphpatches-glyphids" id="ref-for-glyphpatches-glyphids①">glyphIds[j]</a> equal to the glyph index. The
+       <p>The patch glyph data for a glyph index is located by finding  <a data-link-type="dfn" href="#glyphpatches-glyphids" id="ref-for-glyphpatches-glyphids①">glyphIds[j]</a> equal to the glyph index. The
 offset to the associated glyph data is <a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets①">glyphDataOffsets[i * glyphCount + j]</a>. The length
-of the associated glyph data is <a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets②">glyphDataOffsets[i * glyphCount + j + 1]</a> minus <a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets③">glyphDataOffsets[i * glyphCount + j]</a>.</p>
+of the associated glyph data is <a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets②">glyphDataOffsets[i * glyphCount + j + 1]</a> minus
+<a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets③">glyphDataOffsets[i * glyphCount + j]</a>.</p>
       <li data-md>
-       <p>The specific process for synthesizing the new table, depends on the specified format of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>. Any non-glyph associated data should be copied from the table in <var>base font subset</var>. Tables of the type <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a>, <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#">gvar</a>, <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff#">CFF</a>, or <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#">CFF2</a> are supported. <span class="conform" id="conform-table-entries-ignore-others">Entries for tables
-of any other types must be ignored.</span> <span class="conform" id="conform-updating-glyf-updates-loca">When updating <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a> the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/loca#">loca</a> table must be updated as
+       <p>The specific process for synthesizing the new table, depends on the specified format of the
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a>. Any non-glyph associated data should be copied from the table in
+<var>base font subset</var>. Tables of the type <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a>,
+<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#">gvar</a>, <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff#">CFF</a>, or <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#">CFF2</a> are supported. <span class="conform client" id="conform-table-entries-ignore-others">Entries for tables
+of any other types must be ignored.</span> <span class="conform client" id="conform-updating-glyf-updates-loca">When updating <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a> the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/loca#">loca</a> table must be updated as
 well.</span> No other tables in the font can be modified as a result of this step. Notably this means that a patch cannot add glyphs
 with indices beyond the numGlyphs specified in <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a>.</p>
        <p><a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff#">CFF</a>, <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cff2#">CFF2</a>, and <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#">gvar</a> have variable sized offsets to per glyph data. If
-necessary when synthesizing a new table the offset sizes can be increased as needed. For <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a>/<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/loca#">loca</a> offset sizes cannot be changed because the offset size is specified in the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/head#">head</a> table. If during synthesis an offset
+necessary when synthesizing a new table the offset sizes can be increased as needed. For <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#">glyf</a>/<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/loca#">loca</a>
+offset sizes cannot be changed because the offset size is specified in the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/head#">head</a> table. If during synthesis an offset
 is generated which exceeds the maximum possible offset value (after increasing offset size if possible), then patch application has
 failed. Return an error.</p>
       <li data-md>
@@ -3029,7 +3313,8 @@ failed. Return an error.</p>
     <li data-md>
      <p>Locate the <a href="#patch-map-table">§ 5.3 Patch Map Table</a> which has the same <a data-link-type="dfn" href="#glyph-keyed-patch-compatibilityid" id="ref-for-glyph-keyed-patch-compatibilityid①">compatibilityId</a> as <var>compatibility id</var>. If it is a
 format 1 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-1-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a> with the patch map table and <var>patch URL string</var> as an
-input. Otherwise if it is a format 2 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-2-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a> with the patch map table and <var>patch URL string</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.</p>
+input. Otherwise if it is a format 2 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-2-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a> with the patch map table and
+<var>patch URL string</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.</p>
     <li data-md>
      <p>For each <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> in <var>base font subset</var> which has a tag that was not found in any of
 the entries processed in step 4 or 5, add a copy of that table to <var>extended font subset</var>.</p>
@@ -3045,21 +3330,26 @@ case.
 The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⓪">incremental font</a> and associated patches produced by a compliant encoder:</p>
    <ol>
     <li data-md>
-     <p><span class="conform" id="conform-encoding-must-meet-extensions-format">Must meet all of the requirements in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 6 Font Patch Formats</a>.</span></p>
+     <p><span class="conform encoder" id="conform-encoding-must-meet-extensions-format">Must meet all of the requirements in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 6 Font Patch Formats</a>.</span></p>
     <li data-md>
-     <p><span class="conform" id="conform-encoding-must-be-consistent">Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①⓪">Extend an Incremental Font Subset</a> with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
+     <p><span class="conform encoder" id="conform-encoding-must-be-consistent">Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①⓪">Extend an Incremental Font Subset</a>
+with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
 of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①①">Extend an Incremental Font Subset</a>.</span></p>
     <li data-md>
-     <p><span class="conform" id="conform-encoding-must-respect-patch-invalidation-criteria">Must respect patch invalidation criteria.</span> <span class="conform" id="conform-encoding-only-alter-compatibility-ids">Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①⓪">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
+     <p><span class="conform encoder" id="conform-encoding-must-respect-patch-invalidation-criteria">Must respect patch invalidation criteria.</span> <span class="conform encoder" id="conform-encoding-only-alter-compatibility-ids">Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a>
+ must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①⓪">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
  for the invalidation mode declared by the associated <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①①">patch map entries</a>.</span></p>
     <li data-md>
-     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> the associated <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
+     <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> the associated
+ <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
  should have all of the same <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> as the existing font (excluding the incremental IFT/IFTX
  tables) and each of those tables should be functionally equivalent to the corresponding table in the existing font. Note: the fully
  expanded may not always be an exact binary match with the existing font.</p>
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font throughout the augmentation process, that is:
- given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a> and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①②">Extend an Incremental Font Subset</a> with the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①④">incremental font</a> and the minimal subset definition covering that content should
+ given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a>
+ and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①②">Extend an Incremental Font Subset</a> with the
+ <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①④">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
    </ol>
    <p>When an encoder is used to transform an existing font file into and <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑤">incremental font</a> and a client is implemented according to the
@@ -3086,12 +3376,17 @@ it is still strongly encouraged to meet 5, which ensures consistent behavior of 
 guidance that encoder implementations may want to consider, and that can be important to reproducing the appearance and behavior of
 an existing font file when producing an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑥">incremental</a> version of that font. The guidance provided in this section
 is based on the experience of building an encoder implementation during development of this specification. It represents the  best
-understanding (at the time of writing) of how to generate a high performance encoding which meets requirements 1 through 4 of <a href="#encoding">§ 7 Encoding</a> and thus preserves all functionality/behavior of the original font being encoded.</p>
+understanding (at the time of writing) of how to generate a high performance encoding which meets requirements 1 through 4 of
+<a href="#encoding">§ 7 Encoding</a> and thus preserves all functionality/behavior of the original font being encoded.</p>
    <p><b>About <a href="#table-keyed">§ 6.2 Table Keyed</a> patches</b></p>
    <p>A <a href="#table-keyed">§ 6.2 Table Keyed</a> patch can change the contents of some font tables and not others. Each patched table typically needs to be
-relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#table-keyed">§ 6.2 Table Keyed</a> patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches and therefore be only <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation②">Partially Invalidating</a> (in that it will invalidate other <a href="#table-keyed">§ 6.2 Table Keyed</a> patches but not <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches). Additionally two sets of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches can be independent of each other if they do not
+relative to a specific table content, but other tables can have different contents. Therefore as long as a <a href="#table-keyed">§ 6.2 Table Keyed</a>
+patch does not alter the tables containing glyph data it can be compatible with <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches and therefore be only
+<a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation②">Partially Invalidating</a> (in that it will invalidate other <a href="#table-keyed">§ 6.2 Table Keyed</a> patches but not
+<a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches). Additionally two sets of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches can be independent of each other if they do not
 modify any of the same tables.  For example, one could use <a href="#table-keyed">§ 6.2 Table Keyed</a> patches for all
-content other than the glyph tables but then use another set of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches for those tables rather than <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches, and each of these could in theory be <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation③">Partially Invalidating</a>—leaving them
+content other than the glyph tables but then use another set of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches for those tables rather than
+<a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches, and each of these could in theory be <a data-link-type="dfn" href="#partial-invalidation" id="ref-for-partial-invalidation③">Partially Invalidating</a>—leaving them
 mutually dependent but independent of one another.</p>
    <p>An application of a <a href="#table-keyed">§ 6.2 Table Keyed</a> patch will typically alter the IFT or IFTX table it was was listed in to add a new set
 of patches to further extend the font. This means that the total set of <a href="#table-keyed">§ 6.2 Table Keyed</a> patches forms a graph,
@@ -3232,7 +3527,8 @@ to be representative of all possible encoder implementations. Notably it does no
 patches. Most encoders will likely be more complex and need to consider additional factors some of which are discussed in the remaining
 sections.</p>
    <p><b><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches</b></p>
-   <p>Specifically because they are parameterized by code points and feature tags but can be applied independently of one another, <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches have additional requirements and cannot be directly derived by using a subsetter implementation.  However,
+   <p>Specifically because they are parameterized by code points and feature tags but can be applied independently of one another,
+<a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches have additional requirements and cannot be directly derived by using a subsetter implementation.  However,
 such an implementation can help clarify what an encoder needs to do to maintain functional equivalence when producing this type
 of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑤">font subset definition</a>. We can define
 the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a> as the full set of glyphs included in the subset, which the
@@ -3289,7 +3585,8 @@ when loading the patches for two or more segments.  There are five main strategi
    <p>In some cases it might be desirable to avoid the overhead of applying patches to an initial file. For example, it could
 be desirable that the font loaded on a company home page already be able to render the content on that page. The main benefit
 of such a file is reduced rendering latency: the content can be rendered after a single round-trip.</p>
-   <p>There are two approaches to including data in the downloaded font file. One is to simply encode the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②⓪">incremental font</a> as a whole so that the data is in the initial file. Any such data will always be available in any patched version of the font.
+   <p>There are two approaches to including data in the downloaded font file. One is to simply encode the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font②⓪">incremental font</a>
+as a whole so that the data is in the initial file. Any such data will always be available in any patched version of the font.
 This can be helpful in cases when the same data would otherwise be needed in many different segments.</p>
    <p>The other approach is to download an already-patched font. That is, one can encode a font with little or no data in the "base"
 file but then apply patches to that file on the server side, so that the file downloaded already includes the data contained
@@ -3333,7 +3630,8 @@ which is being read. It is unclear how feasible this attack is, or the computati
 characters being requested are very unusual.</p>
    <p>More specifically, a IFT font includes a collection of unicode code point groups and requests will be made for groups that intersect
 content being rendered. This provides information to the hosting server that at least one code point in a group was needed, but does not
-contain information on which specific code points within a group were needed. This is functionally quite similar to the existing <a href="https://www.w3.org/TR/css-fonts-4/#unicode-range-desc"><cite>CSS Fonts 4</cite> § 4.5 Character range: the unicode-range descriptor</a> and has the same privacy implications. Discussion of the privacy implication of unicode-range can be
+contain information on which specific code points within a group were needed. This is functionally quite similar to the existing
+<a href="https://www.w3.org/TR/css-fonts-4/#unicode-range-desc"><cite>CSS Fonts 4</cite> § 4.5 Character range: the unicode-range descriptor</a> and has the same privacy implications. Discussion of the privacy implication of unicode-range can be
 found in the CSS Fonts 4 specification:</p>
    <ul>
     <li data-md>
@@ -3369,7 +3667,8 @@ communicates. Items that have a high frequency of occurrence communicate less in
 frequencies. The presence of a low frequency code point will narrow down the possible set of contents much further. At a
 high level, this means that larger, less granular conditions should be used for conditions that contain lower frequency
 items.</p>
-   <p><a href="https://github.com/w3c/PFE-analysis/blob/main/results/noise_simulations.md#conclusions">Simulations</a> conducted during the development of this specification found that minimum group sizes (for disjunctive conditions)
+   <p><a href="https://github.com/w3c/PFE-analysis/blob/main/results/noise_simulations.md#conclusions">Simulations</a>
+conducted during the development of this specification found that minimum group sizes (for disjunctive conditions)
 of 4 to 7 items produced good levels of ambiguity. Using minimum group sizes in encodings is also a good idea from a
 performance perspective, as patches that are too granular will introduce excessive amounts of overhead resulting in poor
 performance. Since low frequency items are infrequently needed, using a minimum group size for patches that contain them
@@ -3399,13 +3698,13 @@ the user making an encoding to make appropriate choices. Similarly, it is recomm
 take privacy into account when encoding their own fonts or obtaining already-encoded fonts from third parties.</p>
    <h3 class="heading settled" data-level="8.3" id="per-origin"><span class="secno">8.3. </span><span class="content">Per-origin restriction avoids fingerprinting</span><a class="self-link" href="#per-origin"></a></h3>
    <p>As required by <a data-link-type="biblio" href="#biblio-css-fonts-4" title="CSS Fonts Module Level 4">[css-fonts-4]</a>:</p>
-   <p>"<span class="conform" id="conform-web-font-not-accessible-from-different-document">A Web Font must not be accessible in any other Document from the one which either is associated with
-  the @font-face rule or owns the FontFaceSet.</span> <span class="conform" id="conform-web-font-not-accessible-from-other-apps">Other applications on the device must not be able to access
+   <p>"<span class="conform client" id="conform-web-font-not-accessible-from-different-document">A Web Font must not be accessible in any other Document from the one which either is associated with
+  the @font-face rule or owns the FontFaceSet.</span> <span class="conform client" id="conform-web-font-not-accessible-from-other-apps">Other applications on the device must not be able to access
   Web Fonts.</span>" - <a href="https://www.w3.org/TR/css-fonts-4/#web-fonts"><cite>CSS Fonts 4</cite> § 10.2 Web Fonts</a></p>
    <p>Since IFT fonts are treated the same as regular fonts in CSS (<a href="#opt-in">§ 2 Opt-In Mechanism</a>) these requirements apply and avoid information leaking across
   origins.</p>
    <p>Similar requirements apply to font palette values:</p>
-   <p>"<span class="conform" id="conform-palette-not-accesible-from-different-documents">An author-defined font color palette must only be available to the documents that reference it.</span> Using an author-defined color palette
+   <p>"<span class="conform client" id="conform-palette-not-accesible-from-different-documents">An author-defined font color palette must only be available to the documents that reference it.</span> Using an author-defined color palette
   outside of the documents that reference it would constitute a security leak since the contents of one page would be able to
   affect other pages, something an attacker could use as an attack vector." - <a href="https://www.w3.org/TR/css-fonts-4/#font-palette-values"><cite>CSS Fonts 4</cite> § 9.2 User-defined font color palettes: The @font-palette-values rule</a></p>
    <h2 class="heading settled" data-level="9" id="sec"><span class="secno">9. </span><span class="content">Security Considerations</span><a class="self-link" href="#sec"></a></h2>
@@ -3422,13 +3721,15 @@ number of requests:</p>
  access control headers.</p>
    </ol>
    <h2 class="heading settled" data-level="10" id="changes"><span class="secno">10. </span><span class="content">Changes</span><a class="self-link" href="#changes"></a></h2>
-   <p id="changes-20250715"><a href="https://www.w3.org/TR/2025/WD-IFT-20250715/">Working Draft of 15 July 2025</a> (see <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
+   <p id="changes-20250715"><a href="https://www.w3.org/TR/2025/WD-IFT-20250715/">Working Draft of 15 July 2025</a>
+  (see <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
    <ul>
     <li>Removed an unused item from references
     <li>Defined and exported the term "shaping unit"
    </ul>
    <p id="changes-20250220">Since the <a href="https://www.w3.org/TR/2025/WD-IFT-20250220/">Working 
-  Draft of 20 February 2025</a> (see <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
+  Draft of 20 February 2025</a> (see 
+  <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
    <ul>
     <li>Expanded privacy section to provide guidance for encoders.
     <li>Added examples of full absolute and host name relative URL expansion.
@@ -3463,7 +3764,8 @@ number of requests:</p>
     <li>Updated feature registry appendix to current version
    </ul>
    <p id="changes-20240709">Since the <a href="https://www.w3.org/TR/2024/WD-IFT-20240709/">Working 
-  Draft of 09 July 2024</a> (see <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
+  Draft of 09 July 2024</a> (see 
+  <a href="https://github.com/w3c/IFT/commits/main/Overview.bs">commit history</a>):</p>
    <ul>
     <li>Added an extension example to appendix B that utilizes child entries
     <li>Keep prior entries separate from the filtered list for output in format 2 interpretation.
@@ -3478,7 +3780,8 @@ number of requests:</p>
     <li>Explicit pre-fetching added to the extension algorithm.
     <li>Appendix B added which contains extension algorithm example executions.
    </ul>
-   <h2 class="heading settled" id="feature-tag-list"><span class="content"> Appendix A: Default Feature Tags</span><a class="self-link" href="#feature-tag-list"></a></h2>
+   <h2 class="heading settled" id="feature-tag-list"><span class="content">
+Appendix A: Default Feature Tags</span><a class="self-link" href="#feature-tag-list"></a></h2>
    <p><em>This appendix is not normative.</em> It provides a list of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">layout features</a> which are considered
 to be used by default in most shaper implementations. This list was assembled from:</p>
    <ul>
@@ -3487,7 +3790,8 @@ to be used by default in most shaper implementations. This list was assembled fr
     <li data-md>
      <p>Features which are listed as "default on" in <a data-link-type="biblio" href="#biblio-enabling-typography" title="Enabling Typography: towards a general model of OpenType Layout">[enabling-typography]</a></p>
     <li data-md>
-     <p>Features which are in default set in the <a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz subsetter</a>.</p>
+     <p>Features which are in default set in the
+<a href="https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-input.cc">harfbuzz subsetter</a>.</p>
    </ul>
    <p><b>Layout Features used by Default in Shapers</b></p>
    <table>
@@ -3691,7 +3995,8 @@ to be used by default in most shaper implementations. This list was assembled fr
       <td>vrtr
       <td>Vertical Alternates for Rotation
    </table>
-   <h2 class="heading settled" id="extension-example"><span class="content"> Appendix B: Extension Algorithm Example Execution</span><a class="self-link" href="#extension-example"></a></h2>
+   <h2 class="heading settled" id="extension-example"><span class="content">
+Appendix B: Extension Algorithm Example Execution</span><a class="self-link" href="#extension-example"></a></h2>
    <p><em>This appendix is not normative.</em> It provides examples of how a typical IFT font would be processed by the <a href="#extend-font-subset">§ 4.3 Incremental Font Extension Algorithm</a> algorithm.</p>
    <h3 class="heading settled" id="appendix-b-example-1"><span class="content">Example 1: Table and Glyph Keyed Patches</span><a class="self-link" href="#appendix-b-example-1"></a></h3>
    <p>In this example the IFT font contains a mix of both <a href="#table-keyed">§ 6.2 Table Keyed</a> and <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches.</p>
@@ -3711,26 +4016,34 @@ they are defaulted to an empty set.</p>
 <pre>code points: { 'a', 'b', ..., 'z' }
 </pre>
       <td>//foo.bar/01.tk
-      <td> 2, Table Keyed - Partial Invalidation 
+      <td>
+      2, Table Keyed - Partial Invalidation
+    
      <tr>
       <td>
 <pre>code points: { 'A', 'B', ..., 'Z' }
 </pre>
       <td>//foo.bar/02.tk
-      <td> 2, Table Keyed - Partial Invalidation 
+      <td>
+      2, Table Keyed - Partial Invalidation
+    
      <tr>
       <td>
 <pre>code points: { '0', '1', ..., '9' }
 </pre>
       <td>//foo.bar/03.tk
-      <td> 2, Table Keyed - Partial Invalidation 
+      <td>
+      2, Table Keyed - Partial Invalidation
+    
      <tr>
       <td>
 <pre>code points: { 'a', 'b', ..., 'z',
                'A', 'B', ..., 'Z' }
 </pre>
       <td>//foo.bar/04.tk
-      <td> 2, Table Keyed - Partial Invalidation 
+      <td>
+      2, Table Keyed - Partial Invalidation
+    
      <tr>
       <td>
 <pre>code points: { 'a', 'b', ..., 'z',
@@ -3738,9 +4051,13 @@ they are defaulted to an empty set.</p>
                '0', '1', ..., '9' }
 </pre>
       <td>//foo.bar/05.tk
-      <td> 2, Table Keyed - Partial Invalidation 
+      <td>
+      2, Table Keyed - Partial Invalidation
+    
    </table>
-    <br> 
+   
+<br>
+
    <table>
     <tbody>
      <tr>
@@ -3755,31 +4072,41 @@ they are defaulted to an empty set.</p>
 <pre>code points: { 'a', 'b', ..., 'm' }
 </pre>
       <td>//foo.bar/01.gk
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
      <tr>
       <td>
 <pre>code points: { 'n', 'o', ..., 'z' }
 </pre>
       <td>//foo.bar/02.gk
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
      <tr>
       <td>
 <pre>code points: { 'A', 'B', ..., 'M' }
 </pre>
       <td>//foo.bar/03.gk
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
      <tr>
       <td>
 <pre>code points: { 'N', 'O', ..., 'Z' }
 </pre>
       <td>//foo.bar/04.gk
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
      <tr>
       <td>
 <pre>code points: { '0', '1', ..., '9' }
 </pre>
       <td>//foo.bar/05.gk
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
    </table>
    <p><b>Optimized Extension Example</b></p>
    <p class="note" role="note"><span class="marker">Note:</span> this example execution is described as it would be implemented in an optimized client which aims to reduce the number of round trips needing to be
@@ -3848,7 +4175,9 @@ to add support for code points 'a' through 'Z'. Additionally the mapping in the 
 <pre>code points: { '0', '1', ..., '9' }
 </pre>
         <td>//foo.bar/08.tk
-        <td> 2, Table Keyed - Partial Invalidation 
+        <td>
+      2, Table Keyed - Partial Invalidation
+    
      </table>
      <p>Note the following changes:</p>
      <ul>
@@ -3928,7 +4257,9 @@ a subset definition they are defaulted to an empty set.</p>
   { 'a', 'b', ..., 'm' }
 </pre>
       <td>//foo.bar/01.gk
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
       <td>No
       <td>
      <tr>
@@ -3937,7 +4268,9 @@ a subset definition they are defaulted to an empty set.</p>
   { 'n', 'o', ..., 'z' }
 </pre>
       <td>//foo.bar/02.gk
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
       <td>No
       <td>
      <tr>
@@ -3945,7 +4278,9 @@ a subset definition they are defaulted to an empty set.</p>
 <pre>code points: { VS1 }
 </pre>
       <td>N/A
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
       <td>Yes
      <tr>
       <td>
@@ -3953,7 +4288,9 @@ a subset definition they are defaulted to an empty set.</p>
 match mode: conjunctive
 </pre>
       <td>//foo.bar/03.gk
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
       <td>No
       <td>Has alternate glyphs for {'a', ..., 'm'} that are activated by VS1
      <tr>
@@ -3962,7 +4299,9 @@ match mode: conjunctive
 match mode: conjunctive
 </pre>
       <td>//foo.bar/04.gk
-      <td> 3, Glyph Keyed 
+      <td>
+      3, Glyph Keyed
+    
       <td>No
       <td>Has alternate glyphs for {'n', ..., 'z'} that are activated by VS1
    </table>
@@ -4044,21 +4383,31 @@ content covered by the target subset definition.</p>
     in the normative parts of this document
     are to be interpreted as described in RFC 2119.
     However, for readability,
-    these words do not appear in all uppercase letters in this specification. </p>
+    these words do not appear in all uppercase letters in this specification.
+
+    </p>
    <p>All of the text of this specification is normative
-    except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">[RFC2119]</a> </p>
+    except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">[RFC2119]</a>
+
+    </p>
    <p>Examples in this specification are introduced with the words “for example”
     or are set apart from the normative text
     with <code>class="example"</code>,
-    like this: </p>
+    like this:
+
+    </p>
    <div class="example" id="w3c-example">
-    <a class="self-link" href="#w3c-example"></a> 
-    <p>This is an example of an informative example. </p>
+    <a class="self-link" href="#w3c-example"></a>
+        
+    <p>This is an example of an informative example.
+    </p>
    </div>
    <p>Informative notes begin with the word “Note”
     and are set apart from the normative text
     with <code>class="note"</code>,
-    like this: </p>
+    like this:
+
+    </p>
    <p class="note" role="note">Note, this is an informative note.</p>
    <section>
     <h3 class="no-ref no-num heading settled" id="w3c-conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#w3c-conformant-algorithms"></a></h3>
@@ -4067,14 +4416,17 @@ content covered by the target subset definition.</p>
     or "return false and abort these steps")
     are to be interpreted with the meaning of the key word
     ("must", "should", "may", etc)
-    used in introducing the algorithm. </p>
+    used in introducing the algorithm.
+
+    </p>
     <p>Conformance requirements phrased as algorithms or specific steps
     can be implemented in any manner,
     so long as the end result is equivalent.
     In particular, the algorithms defined in this specification
     are intended to be easy to understand
     and are not intended to be performant.
-    Implementers are encouraged to optimize. </p>
+    Implementers are encouraged to optimize.
+</p>
    </section>
   </div>
   <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>

--- a/conform.css
+++ b/conform.css
@@ -1,5 +1,0 @@
-.conform:hover {background: #DFD}
-.conform:target {padding: 2px; border: 2px solid #ACA; background: #DFD }
-.client:before {content: "client: "; background: #9F9; padding:4px; border: thin solid green}
-.encoder:before {content: "encoder: "; background: #F99; padding:4px; border: thin solid maroon}
-


### PR DESCRIPTION
Also move conform styles into the spec document since conform.css isn't being included.