### PR TITLE
Fix 'the the' / 'the there' typos in patch map descriptions

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1065,7 +1065,7 @@ the encoded bytes at the start of every iteration to pick up any changes made in
     <td>uint24</td>
     <td><dfn for="Format 1 Patch Map">glyphCount</dfn></td>
     <td><span class="conform client encoder" id="conform-format1-glyph-count-matches">Number of glyphs that mappings are provided for.
-        Must match the number of glyphs in the the font file.</span>
+        Must match the number of glyphs in the font file.</span>
 
         Note: the number of glyphs in the font is encoded in the font file. At the time of writing, this value is listed in the
         [[open-type/maxp|maxp]] table; however, future font format extensions may use alternate tables to encode the value for number of
@@ -1571,7 +1571,7 @@ The algorithm:
       until a length value with the most significant bit cleared is encountered. The actual length value is stored in
       the least significant 23 bits of each value. Only present if [=Mapping Entry/formatFlags=] bit 2 is set and
       [=Format 2 Patch Map/entryIdStringData=] is not null (0). If present has at least one length value. If not present
-      and [=Format 2 Patch Map/entryIdStringData=] is not null (0), then the there is one id string which is set to the last
+      and [=Format 2 Patch Map/entryIdStringData=] is not null (0), then there is one id string which is set to the last
       id string from the previous entry or an empty string for the first entry.
     </td>
   </tr>


### PR DESCRIPTION
## Summary

Fixes two minor duplicated-word typos in the patch map descriptions:

1. **§5.3.1 Format 1 Patch Map – `glyphCount` description**
   - Before: "Must match the number of glyphs in **the the** font file."
   - After:  "Must match the number of glyphs in **the** font file."

2. **§5.3.2 Format 2 Patch Map – `entryIdStringLength` description**
   - Before: "then **the there** is one id string …"
   - After:  "then **there** is one id string …"

Both are clear duplicated-word typos with no normative impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 13, 2026, 7:26 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2FIFT%2F0ae48014088a1c6147838432062b5e29919f0f73%2FOverview.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "3197:1",
        "messageType": "fatal",
        "text": "Couldn't find include file 'feature-registry.html'."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/IFT%23308.)._

</details>
