### PR TITLE
Remove Patch Map Format 1 from the specification.

### DIFF
--- a/Overview.bs
+++ b/Overview.bs
@@ -1016,7 +1016,7 @@ bytes at the start of every iteration to pick up any changes made in the previou
   <tr>
     <td>uint8</td>
     <td><dfn for="Patch Map Table">format</dfn></td>
-    <td>Set to 2, identifies the format of this table.</td>
+    <td>Set to 2, identifies the format of this table. Note: prior versions of the spec had a format 1 which has been removed, to maintain compatibility and provide a future extension point the format field has been retained with it's previous value of 2.</td>
   </tr>
   <tr>
     <td>uint24</td>

--- a/Overview.bs
+++ b/Overview.bs
@@ -460,7 +460,7 @@ The algorithm:
 3.  If the compatibility ID in 'IFT ' is equal to the compatibility ID in 'IFTX' this is an error, invoke [$Handle errors$].
 
 4.  For each of [[open-type/otff#table-directory|tables]] 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
-    invoking [$Interpret Format 1 Patch Map$] or [$Interpret Format 2 Patch Map$]. Concatenate the returned entry lists into a single list,
+    invoking [$Interpret Patch Map$]. Concatenate the returned entry lists into a single list,
     <var>entry list</var>.
     
 5.  For each <var>entry</var> in <var>entry list</var> invoke [$Check entry intersection$] with <var>entry</var> and
@@ -481,8 +481,7 @@ The algorithm:
         Follow the criteria in [[#invalidating-patch-selection]] to select the single entry.
 
     * Otherwise select the entry in <var>no invalidation entry list</var> which is listed first in the [=patch
-        map=]. For [[#patch-map-format-1]] this is the entry with the lowest entry index. For [[#patch-map-format-2]]
-        this is the entry that appears first in the [=Mapping Entries/entries=] array. If entries from both the IFT and
+        map=] (the entry that appears first in the [=Mapping Entries/entries=] array). If entries from both the IFT and
         IFTX tables are candidates then all entries in IFT are considered to come before those in IFTX.
 
 
@@ -783,8 +782,7 @@ of [$Extend an Incremental Font Subset$]</span>:
 4.  Find an entry whose intersection from step 2 is not a strict subset of any other intersection.
 
 5.  Locate any additional entries that are in the same [=patch map=] and have the same intersection as the entry found in step 3. From the this set of
-     entries (including the step 3 pick) the final selection is the entry which is listed first in the [=patch map=]. For [[#patch-map-format-1]] this is the
-     entry with the lowest entry index. For [[#patch-map-format-2]] this is the entry that appears first in the [=Mapping Entries/entries=] array.
+     entries (including the step 3 pick) the final selection is the entry which is listed first in the [=patch map=] (the entry that appears first in the [=Mapping Entries/entries=] array).
 
 Note: a fast and efficient way to find an entry which satisfies the criteria for step 3 is to sort the entries (descending) by the size of the code point
 set intersection, then the size of feature tag set intersection, and finally the size of the design space intersection. The first entry in this sorting is
@@ -982,8 +980,7 @@ additional restrictions:
     structure.</span>
 
 * <span class="conform encoder" id="conform-ift-table-contians-offset">The 'IFT ' [=patch map=] table must contain an offset
-    ([=Format 1 Patch Map/cffCharStringsOffset=], [=Format 1 Patch Map/cff2CharStringsOffset=]
-    [=Format 2 Patch Map/cffCharStringsOffset=], or [=Format 2 Patch Map/cff2CharStringsOffset=])
+    ([=Patch Map Table/cffCharStringsOffset=] or [=Patch Map Table/cff2CharStringsOffset=])
     to the start of the CharStrings INDEX data for the CFF and/or CFF2 table.</span>
 
 These three requirements allow for the glyph keyed patch application implementation on CFF and CFF2 tables to be significantly
@@ -1003,31 +1000,23 @@ to the specific needs of IFT.
 Patch Map Table {#patch-map-table}
 ----------------------------------
 
-A [=patch map=] is encoded in one of two formats:
+This section describes the encoding of the [=patch map=] and defines an algorithm for interpreting bytes encoded in this
+format to produce the list of entries it represents. The [$Extend an Incremental Font Subset$] algorithm invokes the
+interpretation algorithm and operates on the resulting entry list. The encoded bytes are the source of truth at all
+times for the patch map. Patch application during subset extension will alter the encoded bytes of the patch map and as
+a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets the encoded
+bytes at the start of every iteration to pick up any changes made in the previous iteration.
 
-*  Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URL strings. It does
-    not support [=font subset definitions=] with design space or entries with overlapping subset definitions.
+<dfn export id="patch-map-table-encoding">Patch Map Table</dfn> encoding:
 
-*  Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
-    is typically less compact than format 1.
-
-Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The
-[$Extend an Incremental Font Subset$] algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
-encoded bytes are the source of truth at all times for the patch map. Patch application during subset extension will alter the encoded
-bytes of the patch map and as a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets
-the encoded bytes at the start of every iteration to pick up any changes made in the previous iteration.
-
-### Patch Map Table: Format 1 ### {#patch-map-format-1}
-
-<dfn>Format 1 Patch Map</dfn> encoding:
 <table>
   <tr>
     <th>Type</th><th>Name</th><th>Description</th>
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">format</dfn></td>
-    <td>Set to 1, identifies this as format 1.</td>
+    <td><dfn for="Patch Map Table">format</dfn></td>
+    <td>Set to 2, identifies the format of this table.</td>
   </tr>
   <tr>
     <td>uint24</td>
@@ -1036,375 +1025,15 @@ the encoded bytes at the start of every iteration to pick up any changes made in
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">flags</dfn></td>
+    <td><dfn for="Patch Map Table">flags</dfn></td>
     <td>Flags to signal the presence of optional fields.
-        If bit 0 (least significant bit) is set, then [=Format 1 Patch Map/cffCharStringsOffset=] will be present.
-        If bit 1 (least significant bit) is set, then [=Format 1 Patch Map/cff2CharStringsOffset=] will be present.
-    </td>
-  </tr>
-
-  <tr>
-    <td>uint32</td>
-    <td><dfn for="Format 1 Patch Map">compatibilityId</dfn>[4]</td>
-    <td>
-      Unique ID used to identify patches that are compatible with this font (see [[#font-patch-invalidations]]). The encoder chooses this
-      value. The encoder should set it to a random value which has not previously been used while encoding the IFT font.
-    </td>
-  </tr>
-  <tr>
-    <td>uint16</td>
-    <td><dfn for="Format 1 Patch Map">maxEntryIndex</dfn></td>
-    <td>The largest entry index encoded in this table.</td>
-  </tr>
-  <tr>
-    <td>uint16</td>
-    <td><dfn for="Format 1 Patch Map">maxGlyphMapEntryIndex</dfn></td>
-    <td><span class="conform client encoder" id="conform-format1-entry-index-maximum">The largest [=Glyph Map=] entry index encoded in this table. Must be less than or equal to maxEntryIndex.</span></td>
-  </tr>
-  <tr>
-    <td>uint24</td>
-    <td><dfn for="Format 1 Patch Map">glyphCount</dfn></td>
-    <td><span class="conform client encoder" id="conform-format1-glyph-count-matches">Number of glyphs that mappings are provided for.
-        Must match the number of glyphs in the font file.</span>
-
-        Note: the number of glyphs in the font is encoded in the font file. At the time of writing, this value is listed in the
-        [[open-type/maxp|maxp]] table; however, future font format extensions may use alternate tables to encode the value for number of
-        glyphs.
-  </tr>
-  <tr>
-    <td>Offset32</td>
-    <td>glyphMapOffset</td>
-    <td>Offset to a [=Glyph Map=] sub table. Offset is from the start of this table.</td>
-  </tr>
-  <tr>
-    <td>Offset32</td>
-    <td><dfn for="Format 1 Patch Map">featureMapOffset</dfn></td>
-    <td>Offset to a [=Feature Map=] sub table. Offset is from the start of this table. May be null (0).</td>
-  </tr>
-  <tr>
-    <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">appliedEntriesBitMap</dfn>[(maxEntryIndex + 8)/8]</td>
-    <td>
-      A bit map which tracks which entries have been applied. If bit <code>i</code> is set that indicates the patch for entry
-      <code>i</code> has been applied to this font. Bit 0 is the least significant bit of appliedEntriesBitMap[0], while bit 7 is
-      the most significant bit. Bit 8 is the least significant bit of appliedEntriesBitMap[1] and so on.
-    </td>
-  </tr>
-  <tr>
-    <td>uint16</td>
-    <td>urlTemplateLength</td>
-    <td>
-      Length of the urlTemplate byte array.
-    </td>
-  </tr>
-  <tr>
-    <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
-    <td>
-      A byte array containing a [[#url-templates|URL Template]] which is used to produce URL strings associated with each entry.
-    </td>
-  </tr>
-  <tr>
-    <td>uint8</td>
-    <td><dfn for="Format 1 Patch Map">patchFormat</dfn></td>
-    <td>
-      Specifies the format of the patches linked to by urlTemplate.
-      <span class="conform client encoder" id="conform-format1-valid-format-number">Must be set to one of the format numbers from  the [[#font-patch-formats-summary]] table.</span>
+        If bit 0 (least significant bit) is set, then [=Patch Map Table/cffCharStringsOffset=] will be present.
+        If bit 1 (least significant bit) is set, then [=Patch Map Table/cff2CharStringsOffset=] will be present.
     </td>
   </tr>
   <tr>
     <td>uint32</td>
-    <td><dfn for="Format 1 Patch Map">cffCharStringsOffset</dfn></td>
-    <td>
-      Only present if bit 0 (least significant) of [=Format 1 Patch Map/flags=] is set.
-      Gives the offset from the start of the [[open-type/CFF|CFF]] table to the CharStrings INDEX data structure of the
-      [[open-type/CFF|CFF]] table.
-    </td>
-  </tr>
-  <tr>
-    <td>uint32</td>
-    <td><dfn for="Format 1 Patch Map">cff2CharStringsOffset</dfn></td>
-    <td>
-      Only present if bit 1 of [=Format 1 Patch Map/flags=] is set.
-      Gives the offset from the start of the [[open-type/CFF|CFF2]] table to the CharStrings INDEX data structure of the
-      [[open-type/CFF2|CFF2]] table.
-    </td>
-  </tr>
-</table>
-
-Note: [=Format 1 Patch Map/glyphCount=] is designed to be compatible with the
-      proposed <a href="https://github.com/harfbuzz/boring-expansion-spec/tree/main">future font format extension</a> to allow for more
-      than 65,535 glyphs.
-
-<dfn>Glyph Map</dfn> encoding:
-
-A glyph map table associates each glyph index in the font with an entry index.
-
-<table>
-  <tr>
-    <th>Type</th><th>Name</th><th>Description</th>
-  </tr>
-  <tr>
-    <td>uint16</td>
-    <td><dfn for="Glyph Map">firstMappedGlyph</dfn></td>
-    <td>All glyph indices less than firstMappedGlyph are implicitly mapped to entry index 0.</td>
-  </tr>
-  <tr>
-    <td>uint8/uint16</td>
-    <td><dfn for="Glyph Map">entryIndex</dfn>[[=Format 1 Patch Map/glyphCount=] - firstMappedGlyph]</td>
-    <td>
-      The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - [=Glyph Map/firstMappedGlyph=]]. Array members
-      are uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise they are uint16.
-    </td>
-  </tr>
-</table>
-
-
-<dfn>Feature Map</dfn> encoding:
-
-A feature map table associates combinations of [[open-type/featuretags|feature tags]] and glyphs with an entry index.
-
-<table>
-  <tr>
-    <th>Type</th><th>Name</th><th>Description</th>
-  </tr>
-  <tr>
-    <td>uint16</td>
-    <td>featureCount</td>
-    <td>Number of featureRecords.</td>
-  </tr>
-  <tr>
-    <td>[=FeatureRecord=]</td>
-    <td><dfn for="Feature Map">featureRecords</dfn>[featureCount]</td>
-    <td>
-      Provides mappings for a specific  [[open-type/featuretags|feature tag]]. [=Feature Map/featureRecords=] are sorted by
-      [=FeatureRecord/featureTag=] in ascending order with any feature tag occurring at most once. For sorting tag values are interpreted
-      as a 4 byte big endian unsigned integer and sorted by the integer value.
-    </td>
-  </tr>
-  <tr>
-    <td>[=EntryMapRecord=]</td>
-    <td><dfn for="Feature Map">entryMapRecords</dfn>[variable]</td>
-    <td>
-      Provides the key (entry index) for each feature mapping. The entryMapRecords array contains as many entries as the sum of
-      the [=FeatureRecord/entryMapCount=] fields in the [=Feature Map/featureRecords=] array, with entryMapRecords[0] corresponding
-      to the first entry of featureRecords[0], entryMapRecords[featureRecord[0].entryMapCount] corresponding to the first entry of
-      featureRecords[1], entryMapRecords[featureRecords[0].entryMapCount + featureRecord[1].entryMapCount]] corresponding to the
-      first entry of featureRecords[2], and so on.
-    </td>
-  </tr>
-</table>
-
-
-
-<dfn>FeatureRecord</dfn> encoding:
-
-<table>
-  <tr>
-    <th>Type</th><th>Name</th><th>Description</th>
-  </tr>
-  <tr>
-    <td>Tag</td>
-    <td><dfn for="FeatureRecord">featureTag</dfn></td>
-    <td>The [[open-type/featuretags|feature tag]] this mapping is for.</td>
-  </tr>
-  <tr>
-    <td>uint8/uint16</td>
-    <td><dfn for="FeatureRecord">firstNewEntryIndex</dfn></td>
-    <td>
-      uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise uint16.
-      The first entry index this record maps too.
-    </td>
-  </tr>
-  <tr>
-    <td>uint8/uint16</td>
-    <td><dfn for="FeatureRecord">entryMapCount</dfn></td>
-    <td>
-      uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise uint16.
-      The number of [=EntryMapRecord=]s associated with this feature.
-    </td>
-  </tr>
-</table>
-
-<dfn>EntryMapRecord</dfn> encoding:
-
-<table>
-  <tr>
-    <th>Type</th><th>Name</th><th>Description</th>
-  </tr>
-  <tr>
-    <td>uint8/uint16</td>
-    <td><dfn for="EntryMapRecord">firstEntryIndex</dfn></td>
-    <td>
-      uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
-      the set of [=Glyph Map=] entries which form the subset definitions for the entries created by this mapping.
-    </td>
-  </tr>
-    <tr>
-    <td>uint8/uint16</td>
-    <td><dfn for="EntryMapRecord">lastEntryIndex</dfn></td>
-    <td>
-      uint8 if [=Format 1 Patch Map/maxEntryIndex=] is less than 256, otherwise uint16.
-    </td>
-  </tr>
-</table>
-
-An entry map record matches any entry indices that are greater than or equal to firstEntryIndex and less than or equal to  lastEntryIndex.
-
-<h5 algorithm id="interpreting-patch-map-format-1" class="conform client">Interpreting Format 1</h5>
-
-This algorithm is used to convert a format 1 patch map into a list of [=patch map entries=].
-
-<dfn abstract-op>Interpret Format 1 Patch Map</dfn>
-
-The inputs to this algorithm are:
-
-* <var>patch map</var>: a [=Format 1 Patch Map=] encoded patch map.
-
-* <var>font subset</var>: the [=font subset=] which contains <var>patch map</var>.
-
-The algorithm outputs:
-
-* <var>entry list</var>: a list of [=patch map entries=].
-
-The algorithm:
-
-1.  Check that the <var>patch map</var> data is: complete and not truncated, has [=Format 1 Patch Map/format=] equal to 1, and is valid
-     according to the requirements in [[#patch-map-format-1]] (requirements are marked with a "must"). If it is not return an error.
-
-2.  For each unique <var>entry index</var> in [=Glyph Map/entryIndex=]:
-
-    *  If <var>entry index</var> is 0 then, this is a special entry used to mark glyphs which are already in the initial font. Skip this
-        index and do not build an entry for it.
-
-    *  If the <var>entry index</var> is larger than [=Format 1 Patch Map/maxGlyphMapEntryIndex=] this entry is invalid, skip this
-        <var>entry index</var>.
-
-    *  If the bit for <var>entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this
-        <var>entry index</var>.
-
-    *  Collect the set of glyph indices that map to the <var>entry index</var>.
-
-    *  Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the
-        [[open-type/cmap|cmap]] table of <var>font subset</var>. Ignore any glyph indices that are not mapped by [[open-type/cmap|cmap]].
-        Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.
-
-    *  Convert <var>entry index</var> into a URL string by invoking [$Expand URL Template$] with [=Format 1 Patch Map/urlTemplate=]
-        and <var>entry index</var> as inputs. If the template expansion results in an error, then return
-        an error.
-
-    *  If the Unicode code point set is empty then, skip this <var>entry index</var>.
-
-    *  Add an [=patch map entries|entry=] to <var>entry list</var> with a subset definition which contains only the Unicode code point
-        set and maps to the generated URL string, the patch format specified by [=Format 1 Patch Map/patchFormat=], and
-        [=Format 1 Patch Map/compatibilityId=].
-
-3.  If [=Format 1 Patch Map/featureMapOffset=] is not null then, for each [=FeatureRecord=] and associated [=EntryMapRecord=] in
-        [=Feature Map/featureRecords=] and [=Feature Map/entryMapRecords=]:
-
-    *  Any [=FeatureRecord|FeatureRecord's=] whose [=FeatureRecord/featureTag=] is less than or equal to a [=FeatureRecord/featureTag=]
-        of any [=FeatureRecord=]  which occurred earlier in the list are invalid. All associated [=EntryMapRecord|EntryMapRecord's=] are
-        skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigned integer and ordered by the integer value.
-
-    *  Compute <var>mapped entry index</var>, the first [=EntryMapRecord=] associated with a [=FeatureRecord=] is
-        [=FeatureRecord/firstNewEntryIndex|FeatureRecord::firstNewEntryIndex=], the second
-        [=FeatureRecord/firstNewEntryIndex|FeatureRecord::firstNewEntryIndex=] + 1, and so on. The last will be
-        [=FeatureRecord/firstNewEntryIndex|FeatureRecord::firstNewEntryIndex=] + [=FeatureRecord/entryMapCount=] - 1.
-
-    *  If the computed <var>mapped entry index</var> is less than or equal to [=Format 1 Patch Map/maxGlyphMapEntryIndex=] or larger than
-        [=Format 1 Patch Map/maxEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
-
-    *  If [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] is greater than
-        [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] this [=EntryMapRecord=] is invalid, skip it.
-
-    *  Convert <var>mapped entry index</var> into a URL string by invoking [$Expand URL Template$] with [=Format 1 Patch Map/urlTemplate=]
-        and <var>mapped entry index</var> as inputs. If the template expansion results in an error, then return an error.
-
-    *  If the bit for <var>mapped entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this entry.
-
-    *  Construct a set of Unicode code points. For each <var>entry index</var> between
-        [=EntryMapRecord/firstEntryIndex|EntryMapRecord::firstEntryIndex=] (inclusive) and
-        [=EntryMapRecord/lastEntryIndex|EntryMapRecord::lastEntryIndex=] (inclusive):
-
-        *  If <var>entry index</var> is greater than [=Format 1 Patch Map/maxGlyphMapEntryIndex=] then, this [=EntryMapRecord=] is invalid
-            skip it.
-
-        *  Add the set of Unicode code points associated with <var>entry index</var> that was computed in step 2 to the set. If the
-            <var>entry index</var> was skipped because it was 0 or [=Format 1 Patch Map/appliedEntriesBitMap=] compute the set of
-            associated code points as if it wasn't skipped.
-
-    *  If the constructed set of Unicode code points is empty then, this [=EntryMapRecord=] is invalid skip it.
-
-    *  Add an [=patch map entries|entry=] to <var>entry list</var> which  maps to the generated URL string, the patch format
-        specified by [=Format 1 Patch Map/patchFormat=], and [=Format 1 Patch Map/compatibilityId=]; or if there is an existing
-        [=patch map entries|entry=] in <var>entry list</var> which has the same patch URL string as the generated URL string then
-        instead modify the existing entry. Add the constructed set of Unicode code points and [=FeatureRecord/featureTag=] to the new or
-        existing entry's subset definition.
-
-4.  Return <var>entry list</var>.
-
-Note: while an encoding is not required to include entries for all entry indices in [0, [=Format 1 Patch Map/maxEntryIndex=]], it is
-recommended that it do so for maximum compactness.
-
-<h5 algorithm id="remove-entries-format-1" class="conform client">Remove Entries from Format 1</h5>
-
-This algorithm is used to remove entries from a format 1 patch map. This removal modifies the bytes of the patch map but does not
-change the number of bytes.
-
-<dfn abstract-op>Remove Entries from Format 1 Patch Map</dfn>
-
-The inputs to this algorithm are:
-
-* <var>patch map</var>: a [=Format 1 Patch Map=] encoded patch map. May be modified by this procedure.
-
-* <var>patch URL string</var>: URL string for a patch which identifies the entries to be removed.
-
-The algorithm:
-
-1.  Check that the <var>patch map</var> has [=Format 1 Patch Map/format=] equal to 1 and is valid according to the requirements in
-     [[#patch-map-format-1]]. If it is not return an error.
-
-2.  For each unique <var>entry index</var> in [=Glyph Map/entryIndex=] of <var>patch map</var>:
-
-    *  If the bit for <var>entry index</var> in [=Format 1 Patch Map/appliedEntriesBitMap=] is set to 1, skip this
-        <var>entry index</var>.
-
-    *  Convert <var>entry index</var> into a URL string by invoking [$Expand URL Template$] with [=Format 1 Patch Map/urlTemplate=]
-        and <var>entry index</var> as inputs. If the template expansion results in an error, then return
-        an error.
-
-    *  If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in
-        [=Format 1 Patch Map/appliedEntriesBitMap=] to 1.
-
-### Patch Map Table: Format 2 ### {#patch-map-format-2}
-
-<dfn>Format 2 Patch Map</dfn> encoding:
-
-<table>
-  <tr>
-    <th>Type</th><th>Name</th><th>Description</th>
-  </tr>
-  <tr>
-    <td>uint8</td>
-    <td><dfn for="Format 2 Patch Map">format</dfn></td>
-    <td>Set to 2, identifies this as format 2.</td>
-  </tr>
-  <tr>
-    <td>uint24</td>
-    <td>reserved</td>
-    <td>Not used, set to 0.</td>
-  </tr>
-  <tr>
-    <td>uint8</td>
-    <td><dfn for="Format 2 Patch Map">flags</dfn></td>
-    <td>Flags to signal the presence of optional fields.
-        If bit 0 (least significant bit) is set, then [=Format 2 Patch Map/cffCharStringsOffset=] will be present.
-        If bit 1 (least significant bit) is set, then [=Format 2 Patch Map/cff2CharStringsOffset=] will be present.
-    </td>
-  </tr>
-  <tr>
-    <td>uint32</td>
-    <td><dfn for="Format 2 Patch Map">compatibilityId</dfn>[4]</td>
+    <td><dfn for="Patch Map Table">compatibilityId</dfn>[4]</td>
     <td>
       Unique ID used to identify patches that are compatible with this font (see [[#font-patch-invalidations]]). The encoder chooses this
       value. The encoder should set it to a random value which has not previously been used while encoding the IFT font.
@@ -1412,25 +1041,25 @@ The algorithm:
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 2 Patch Map">defaultPatchFormat</dfn></td>
+    <td><dfn for="Patch Map Table">defaultPatchFormat</dfn></td>
     <td>
       Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
-      <span class="conform client encoder" id="conform-format2-valid-format-number">Must be set to one of the format numbers from the [[#font-patch-formats-summary]] table.</span>
+      <span class="conform client encoder" id="conform-patchmap-valid-format-number">Must be set to one of the format numbers from the [[#font-patch-formats-summary]] table.</span>
     </td>
   </tr>
   <tr>
     <td>uint24</td>
-    <td><dfn for="Format 2 Patch Map">entryCount</dfn></td>
+    <td><dfn for="Patch Map Table">entryCount</dfn></td>
     <td>Number of entries encoded in this table.</td>
   </tr>
   <tr>
     <td>Offset32</td>
-    <td><dfn for="Format 2 Patch Map">entries</dfn></td>
+    <td><dfn for="Patch Map Table">entries</dfn></td>
     <td>Offset to a [=Mapping Entries=] sub table. Offset is from the start of this table.</td>
   </tr>
   <tr>
     <td>Offset32</td>
-    <td><dfn for="Format 2 Patch Map">entryIdStringData</dfn></td>
+    <td><dfn for="Patch Map Table">entryIdStringData</dfn></td>
     <td>
       Offset to a block of data containing the concatentation of all of the entry ID strings.
       May be null (0). Offset is from the start of this table.
@@ -1445,25 +1074,25 @@ The algorithm:
   </tr>
   <tr>
     <td>uint8</td>
-    <td><dfn for="Format 2 Patch Map">urlTemplate</dfn>[urlTemplateLength]</td>
+    <td><dfn for="Patch Map Table">urlTemplate</dfn>[urlTemplateLength]</td>
     <td>
       A byte array containing a [[#url-templates|URL Template]] which is used to produce URL strings associated with each entry.
     </td>
   </tr>
   <tr>
     <td>uint32</td>
-    <td><dfn for="Format 2 Patch Map">cffCharStringsOffset</dfn></td>
+    <td><dfn for="Patch Map Table">cffCharStringsOffset</dfn></td>
     <td>
-      Only present if bit 0 (least significant) of [=Format 2 Patch Map/flags=] is set.
+      Only present if bit 0 (least significant) of [=Patch Map Table/flags=] is set.
       Gives the offset from the start of the [[open-type/CFF|CFF]] table to the CharStrings INDEX data structure of the
       [[open-type/CFF|CFF]] table.
     </td>
   </tr>
   <tr>
     <td>uint32</td>
-    <td><dfn for="Format 2 Patch Map">cff2CharStringsOffset</dfn></td>
+    <td><dfn for="Patch Map Table">cff2CharStringsOffset</dfn></td>
     <td>
-      Only present if bit 1 of [=Format 2 Patch Map/flags=] is set.
+      Only present if bit 1 of [=Patch Map Table/flags=] is set.
       Gives the offset from the start of the [[open-type/CFF|CFF2]] table to the CharStrings INDEX data structure of the
       [[open-type/CFF2|CFF2]] table.
     </td>
@@ -1479,8 +1108,8 @@ The algorithm:
   <tr>
     <td>uint8</td>
     <td><dfn for="Mapping Entries">entries</dfn>[variable]</td>
-    <td>Byte array containing the encoded bytes of [=Format 2 Patch Map/entryCount=] [=Mapping Entry=]'s. Each entry has a variable
-        length, which is determined following [$Interpret Format 2 Patch Map Entry$].</td>
+    <td>Byte array containing the encoded bytes of [=Patch Map Table/entryCount=] [=Mapping Entry=]'s. Each entry has a variable
+        length, which is determined following [$Interpret Patch Map Entry$].</td>
   </tr>
 </table>
 
@@ -1557,8 +1186,8 @@ The algorithm:
       List of signed deltas which calculate the IDs of the URL strings for this entry. If present, has at least one delta. If the least
       significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
       cleared is encountered. The entry id for each delta is the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if
-      [=Mapping Entry/formatFlags=] bit 2 is set and [=Format 2 Patch Map/entryIdStringData=] is null (0).
-      If not present and [=Format 2 Patch Map/entryIdStringData=] is null (0), then there is one id for this entry and the
+      [=Mapping Entry/formatFlags=] bit 2 is set and [=Patch Map Table/entryIdStringData=] is null (0).
+      If not present and [=Patch Map Table/entryIdStringData=] is null (0), then there is one id for this entry and the
       delta is assumed to be 0.
     </td>
   </tr>
@@ -1566,12 +1195,12 @@ The algorithm:
     <td>uint24</td>
     <td><dfn for="Mapping Entry">entryIdStringLength</dfn>[variable]</td>
     <td>
-      The number of bytes that each id string for this entry occupies in the [=Format 2 Patch Map/entryIdStringData=]
+      The number of bytes that each id string for this entry occupies in the [=Patch Map Table/entryIdStringData=]
       data block.  If the most significant bit of a length value is set, then another length value follows. This repeats
       until a length value with the most significant bit cleared is encountered. The actual length value is stored in
       the least significant 23 bits of each value. Only present if [=Mapping Entry/formatFlags=] bit 2 is set and
-      [=Format 2 Patch Map/entryIdStringData=] is not null (0). If present has at least one length value. If not present
-      and [=Format 2 Patch Map/entryIdStringData=] is not null (0), then there is one id string which is set to the last
+      [=Patch Map Table/entryIdStringData=] is not null (0). If present has at least one length value. If not present
+      and [=Patch Map Table/entryIdStringData=] is not null (0), then there is one id string which is set to the last
       id string from the previous entry or an empty string for the first entry.
     </td>
   </tr>
@@ -1581,7 +1210,7 @@ The algorithm:
     <td><dfn for="Mapping Entry">patchFormat</dfn></td>
     <td>
       Specifies the format of the patch linked to by this entry. Uses the ID numbers from the [[#font-patch-formats-summary]] table.
-      Overrides [=Format 2 Patch Map/defaultPatchFormat=].
+      Overrides [=Patch Map Table/defaultPatchFormat=].
       Only present if [=Mapping Entry/formatFlags=] bit 3 is set.
     </td>
   </tr>
@@ -1608,7 +1237,7 @@ The algorithm:
 </table>
 
 If an encoder is producing patches that will be stored on a file system and then served it's recommended that only numeric entry IDs be
-used (via [=Mapping Entry/entryIdDelta=]) as these will generally produce the smallest encoding of the format 2 patch map. String IDs
+used (via [=Mapping Entry/entryIdDelta=]) as these will generally produce the smallest encoding of the patch map. String IDs
 are useful in cases where patches are not being stored in advance and the ID strings can be then used to encode information about the patch
 being requested.
 
@@ -1645,15 +1274,15 @@ being requested.
   </tr>
 </table>
 
-<h5 algorithm id="interpreting-patch-map-format-2" class="conform client">Interpreting Format 2</h5>
+<h4 algorithm id="interpreting-patch-map" class="conform client">Interpreting a Patch Map</h4>
 
-This algorithm is used to convert a format 2 [=patch map=] into a list of [=patch map entries=].
+This algorithm is used to convert a [=patch map=] into a list of [=patch map entries=].
 
-<dfn abstract-op>Interpret Format 2 Patch Map</dfn>
+<dfn abstract-op>Interpret Patch Map</dfn>
 
 The inputs to this algorithm are:
 
-* <var>patch map</var>: a [=Format 2 Patch Map=] encoded [=patch map=].
+* <var>patch map</var>: a [=Patch Map Table=].
 
 The algorithm outputs:
 
@@ -1661,23 +1290,23 @@ The algorithm outputs:
 
 The algorithm:
 
-1.  Check that the <var>patch map</var> has [=Format 2 Patch Map/format=] equal to 2 and is valid according to the requirements in
-     [[#patch-map-format-2]] (requirements are marked with a "must"). If it is not return an error.
+1.  Check that the <var>patch map</var> has [=Patch Map Table/format=] equal to 2 and is valid according to the requirements in
+     [[#patch-map-table]] (requirements are marked with a "must"). If it is not return an error.
 
-2.  If the [=Format 2 Patch Map/entryIdStringData=] offset is 0 then initialize <var>last entry id</var> to 0. Otherwise initialize
+2.  If the [=Patch Map Table/entryIdStringData=] offset is 0 then initialize <var>last entry id</var> to 0. Otherwise initialize
      it to an empty byte string. Set <var>current byte</var> to 0, and <var>current id string byte</var> to 0.
 
 3.  Initialize <var>entry list</var> and <var>prior entry list</var> to empty lists.
 
-4.  Invoke [$Interpret Format 2 Patch Map Entry$], [=Format 2 Patch Map/entryCount=] times. For each invocation:
+4.  Invoke [$Interpret Patch Map Entry$], [=Patch Map Table/entryCount=] times. For each invocation:
 
-     *  pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entries=][<var>current byte</var>] to
+     *  pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from [=Patch Map Table/entries=][<var>current byte</var>] to
          the end of <var>patch map</var>,
-         the bytes from <var>patch map</var> starting from [=Format 2 Patch Map/entryIdStringData=][<var>current id string byte</var>]
-         to the end of <var>patch map</var> if [=Format 2 Patch Map/entryIdStringData=] is non zero,
+         the bytes from <var>patch map</var> starting from [=Patch Map Table/entryIdStringData=][<var>current id string byte</var>]
+         to the end of <var>patch map</var> if [=Patch Map Table/entryIdStringData=] is non zero,
          <var>last entry id</var>,
-         [=Format 2 Patch Map/defaultPatchFormat=], and
-         [=Format 2 Patch Map/urlTemplate=].
+         [=Patch Map Table/defaultPatchFormat=], and
+         [=Patch Map Table/urlTemplate=].
 
      *  Set <var>last entry id</var> to the returned entry id.
 
@@ -1688,11 +1317,11 @@ The algorithm:
      *  Add the returned entry to <var>prior entry list</var>.
 
      *  If the returned value of ignored is false, then set the compatibility ID of the returned entry to
-         [=Format 2 Patch Map/compatibilityId=] and add the  entry to <var>entry list</var>.
+         [=Patch Map Table/compatibilityId=] and add the  entry to <var>entry list</var>.
 
 5.  Return <var>entry list</var>.
 
-<dfn abstract-op>Interpret Format 2 Patch Map Entry</dfn>
+<dfn abstract-op>Interpret Patch Map Entry</dfn>
 
 The inputs to this algorithm are:
 
@@ -1829,36 +1458,36 @@ The algorithm:
 13. Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>,
      <var>consumed id string bytes</var>, and <var>ignored</var>.
 
-<h5 algorithm id="remove-entries-format-2" class="conform client">Remove Entries from Format 2</h5>
+<h4 algorithm id="remove-entries-patch-map" class="conform client">Remove Entries from a Patch Map</h4>
 
-This algorithm is used to remove entries from a format 2 patch map. This removal modifies the bytes of the patch map but does not
+This algorithm is used to remove entries from a patch map. This removal modifies the bytes of the patch map but does not
 change the number of bytes.
 
-<dfn abstract-op>Remove Entries from Format 2 Patch Map</dfn>
+<dfn abstract-op>Remove Entries from a Patch Map</dfn>
 
 The inputs to this algorithm are:
 
-* <var>patch map</var>: a [=Format 2 Patch Map=] encoded patch map. May be modified by this procedure.
+* <var>patch map</var>: a [=Patch Map Table=]. May be modified by this procedure.
 
 * <var>patch URL string</var>: URL string for a patch which identifies the entries to be removed.
 
-This algorithm is a modified version of [$Interpret Format 2 Patch Map$], invoke [$Interpret Format 2 Patch Map$] with <var>patch map</var>
+This algorithm is a modified version of [$Interpret Patch Map$], invoke [$Interpret Patch Map$] with <var>patch map</var>
 as an input but with the following changes:
 
-*  During step 8 and 9 of [$Interpret Format 2 Patch Map Entry$]: compare the URL string generated for only the first delta/length value to
+*  During step 8 and 9 of [$Interpret Patch Map Entry$]: compare the URL string generated for only the first delta/length value to
     <var>patch URL string</var> if they are equal then, set bit 6 of  [=Mapping Entry/formatFlags=] to 1. Stop the interpretation process
     at this point.
 
-*  The return value of [$Interpret Format 2 Patch Map$] is not used.
+*  The return value of [$Interpret Patch Map$] is not used.
 
-<h5 algorithm id="sparse-bit-set-decoding" class="conform client">Sparse Bit Set</h5>
+<h4 algorithm id="sparse-bit-set-decoding" class="conform client">Sparse Bit Set</h4>
 
 A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
 each node has a fixed number of children that recursively sub-divides an interval into equal partitions. A tree of height <i>H</i> with
 branching factor <i>B</i> can store set membership for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree
 is encoded into an array of bytes for transport.
 
-In the context of a [=Format 2 Patch Map=] a sparse bit set is used to store a set of [[!unicode|Unicode]] code points. As such integer
+In the context of a [=Patch Map Table=] a sparse bit set is used to store a set of [[!unicode|Unicode]] code points. As such integer
 values stored in a sparse bit set are restricted to being [[!unicode|Unicode]] code point values in the range 0 to 0x10FFFF.
 
 <dfn>Sparse Bit Set</dfn> encoding:
@@ -2630,10 +2259,8 @@ The algorithm:
 
     *  Insert the synthesized table into <var>extended font subset</var>.
 
-5. Locate the [[#patch-map-table]] which has the same [=Glyph keyed patch/compatibilityId=] as <var>compatibility id</var>. If it is a
-    format 1 patch map then, invoke [$Remove Entries from Format 1 Patch Map$] with the patch map table and <var>patch URL string</var> as an
-    input. Otherwise if it is a format 2 patch map then, invoke [$Remove Entries from Format 2 Patch Map$] with the patch map table and
-    <var>patch URL string</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.
+5. Locate the [[#patch-map-table]] which has the same [=Glyph keyed patch/compatibilityId=] as <var>compatibility id</var>. Invoke
+    [$Remove Entries from a Patch Map$] with the patch map table and <var>patch URL string</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.
 
 6. For each [[open-type/otff#table-directory|table]] in <var>base font subset</var> which has a tag that was not found in any of
     the entries processed in step 4 or 5, add a copy of that table to <var>extended font subset</var>.
@@ -2914,7 +2541,7 @@ when loading the patches for two or more segments.  There are five main strategi
 
 2.  The common glyphs can be placed in their own patch and then mapping entries set up to trigger the load of that common patch along side
      any of the segments that will need it. For example if 'c' is a common segment needed by segments 'a' and 'b' then, you could
-     have the following mapping entries (via a format 2 mapping table):
+     have the following mapping entries:
      *  subset definition a → segment a
      *  subset definition b → segment b
      *  subset definition a union subset definition b → segment c
@@ -2922,7 +2549,7 @@ when loading the patches for two or more segments.  There are five main strategi
 3.  In some cases, such as with [[open-type/cmap#format-14-unicode-variation-sequences|Unicode variation selectors]], there will be a
      modifier code point which triggers a glyph substitution when paired with many other code points. Given the large number of alternate
      glyphs it's desirable to keep them in their own patches which are only loaded when both the modifier code point and appropriate base
-     code point(s) are present. This can be achieved by using a [[#patch-map-format-2|Format 2 Patch Map]] and multiple entry matching
+     code point(s) are present. This can be achieved by using multiple entry matching
      via [=Mapping Entry/childEntryIndices=]. See [[#appendix-b-example-2]] for an example of how this can be set up.
 
 4.  Alternatively, the glyph can be included in more than one of the patches that correspond to those segments at the cost of duplicating

--- a/Overview.html
+++ b/Overview.html
@@ -7,7 +7,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
   <meta content="Bikeshed version d113b2e81, updated Tue Jun 9 14:57:55 2026 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="bcd565a144784be2c43831f4828a873cc1cd38aa" name="revision">
+  <meta content="5472f611c695df164b2936aa33e0bedf58972434" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -787,7 +787,7 @@ var[data-var-color="6"] { --var-vg: #FFBCF2; }
 </p>
    <h1 class="no-ref p-name" id="title">Incremental Font Transfer</h1>
    <p id="w3c-state"><a href="https://www.w3.org/standards/types/#ED">Editor’s Draft</a>,
-    <time class="dt-updated" datetime="2026-07-27">27 July 2026</time></p>
+    <time class="dt-updated" datetime="2026-07-31">31 July 2026</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1772,7 +1772,7 @@ bytes at the start of every iteration to pick up any changes made in the previou
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-format">format</dfn>
-      <td>Set to 2, identifies the format of this table.
+      <td>Set to 2, identifies the format of this table. Note: prior versions of the spec had a format 1 which has been removed, to maintain compatibility and provide a future extension point the format field has been retained with it’s previous value of 2.
      <tr>
       <td>uint24
       <td>reserved

--- a/Overview.html
+++ b/Overview.html
@@ -5,9 +5,9 @@
   <title>Incremental Font Transfer</title>
   <meta content="ED" name="w3c-status">
   <link href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED" rel="stylesheet">
-  <meta content="Bikeshed version cfb78d9c0, updated Tue Jun 2 16:21:00 2026 -0700" name="generator">
+  <meta content="Bikeshed version d113b2e81, updated Tue Jun 9 14:57:55 2026 -0700" name="generator">
   <link href="https://www.w3.org/TR/IFT/" rel="canonical">
-  <meta content="01fe3666daea4c35e0f015dcb11d9c4b4e202ee8" name="revision">
+  <meta content="bcd565a144784be2c43831f4828a873cc1cd38aa" name="revision">
   <meta content="dark light" name="color-scheme">
   <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
 <style>
@@ -787,7 +787,7 @@ var[data-var-color="6"] { --var-vg: #FFBCF2; }
 </p>
    <h1 class="no-ref p-name" id="title">Incremental Font Transfer</h1>
    <p id="w3c-state"><a href="https://www.w3.org/standards/types/#ED">Editor’s Draft</a>,
-    <time class="dt-updated" datetime="2026-06-01">1 June 2026</time></p>
+    <time class="dt-updated" datetime="2026-07-27">27 July 2026</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -899,20 +899,10 @@ to complex scripts like Indic or Arabic.</p>
       <li>
        <a href="#patch-map-table"><span class="secno">5.3</span> <span class="content">Patch Map Table</span></a>
        <ol class="toc">
-        <li>
-         <a href="#patch-map-format-1"><span class="secno">5.3.1</span> <span class="content">Patch Map Table: Format 1</span></a>
-         <ol class="toc">
-          <li><a href="#interpreting-patch-map-format-1"><span class="secno">5.3.1.1</span> <span class="content">Interpreting Format 1</span></a>
-          <li><a href="#remove-entries-format-1"><span class="secno">5.3.1.2</span> <span class="content">Remove Entries from Format 1</span></a>
-         </ol>
-        <li>
-         <a href="#patch-map-format-2"><span class="secno">5.3.2</span> <span class="content">Patch Map Table: Format 2</span></a>
-         <ol class="toc">
-          <li><a href="#interpreting-patch-map-format-2"><span class="secno">5.3.2.1</span> <span class="content">Interpreting Format 2</span></a>
-          <li><a href="#remove-entries-format-2"><span class="secno">5.3.2.2</span> <span class="content">Remove Entries from Format 2</span></a>
-          <li><a href="#sparse-bit-set-decoding"><span class="secno">5.3.2.3</span> <span class="content">Sparse Bit Set</span></a>
-         </ol>
-        <li><a href="#url-templates"><span class="secno">5.3.3</span> <span class="content">URL Templates</span></a>
+        <li><a href="#interpreting-patch-map"><span class="secno">5.3.1</span> <span class="content">Interpreting a Patch Map</span></a>
+        <li><a href="#remove-entries-patch-map"><span class="secno">5.3.2</span> <span class="content">Remove Entries from a Patch Map</span></a>
+        <li><a href="#sparse-bit-set-decoding"><span class="secno">5.3.3</span> <span class="content">Sparse Bit Set</span></a>
+        <li><a href="#url-templates"><span class="secno">5.3.4</span> <span class="content">URL Templates</span></a>
        </ol>
      </ol>
     <li>
@@ -1289,7 +1279,7 @@ not an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-
      <p>If the compatibility ID in 'IFT ' is equal to the compatibility ID in 'IFTX' this is an error, invoke <a data-link-type="abstract-op" href="#abstract-opdef-handle-errors" id="ref-for-abstract-opdef-handle-errors①">Handle errors</a>.</p>
     <li data-md>
      <p>For each of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">tables</a> 'IFT ' and 'IFTX' (if present): convert the table into a list of entries by
-invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-1-patch-map" id="ref-for-abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a> or <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a>. Concatenate the returned entry lists into a single list,
+invoking <a data-link-type="abstract-op" href="#abstract-opdef-interpret-patch-map" id="ref-for-abstract-opdef-interpret-patch-map">Interpret Patch Map</a>. Concatenate the returned entry lists into a single list,
 <var>entry list</var>.</p>
     <li data-md>
      <p>For each <var>entry</var> in <var>entry list</var> invoke <a data-link-type="abstract-op" href="#abstract-opdef-check-entry-intersection" id="ref-for-abstract-opdef-check-entry-intersection">Check entry intersection</a> with <var>entry</var> and
@@ -1310,8 +1300,7 @@ of each entry: <var>full invalidation entry list</var>, <var>partial invalidatio
        <p>Otherwise if <var>partial invalidation entry list</var> is not empty then, select exactly one of the contained entries.
 Follow the criteria in <a href="#invalidating-patch-selection">§ 4.4 Selecting Invalidating Patches</a> to select the single entry.</p>
       <li data-md>
-       <p>Otherwise select the entry in <var>no invalidation entry list</var> which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map②">patch map</a>. For <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a> this is the entry with the lowest entry index. For <a href="#patch-map-format-2">§ 5.3.2 Patch Map Table: Format 2</a>
-this is the entry that appears first in the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array. If entries from both the IFT and
+       <p>Otherwise select the entry in <var>no invalidation entry list</var> which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map②">patch map</a> (the entry that appears first in the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries">entries</a> array). If entries from both the IFT and
 IFTX tables are candidates then all entries in IFT are considered to come before those in IFTX.</p>
      </ul>
     <li data-md>
@@ -1579,8 +1568,7 @@ candidate entries.</p>
      <p>Find an entry whose intersection from step 2 is not a strict subset of any other intersection.</p>
     <li data-md>
      <p>Locate any additional entries that are in the same <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map③">patch map</a> and have the same intersection as the entry found in step 3. From the this set of
- entries (including the step 3 pick) the final selection is the entry which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map④">patch map</a>. For <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a> this is the
- entry with the lowest entry index. For <a href="#patch-map-format-2">§ 5.3.2 Patch Map Table: Format 2</a> this is the entry that appears first in the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a> array.</p>
+ entries (including the step 3 pick) the final selection is the entry which is listed first in the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map④">patch map</a> (the entry that appears first in the <a data-link-type="dfn" href="#mapping-entries-entries" id="ref-for-mapping-entries-entries①">entries</a> array).</p>
    </ol>
    <p class="note" role="note"><span class="marker">Note:</span> a fast and efficient way to find an entry which satisfies the criteria for step 3 is to sort the entries (descending) by the size of the code point
 set intersection, then the size of feature tag set intersection, and finally the size of the design space intersection. The first entry in this sorting is
@@ -1753,8 +1741,7 @@ table (followed only by 0 padding to a four-byte word boundary).</span></p>
 structure.</span></p>
     <li data-md>
      <p><span class="conform encoder" id="conform-ift-table-contians-offset">The 'IFT ' <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑥">patch map</a> table must contain an offset
-(<a data-link-type="dfn" href="#format-1-patch-map-cffcharstringsoffset" id="ref-for-format-1-patch-map-cffcharstringsoffset">cffCharStringsOffset</a>, <a data-link-type="dfn" href="#format-1-patch-map-cff2charstringsoffset" id="ref-for-format-1-patch-map-cff2charstringsoffset">cff2CharStringsOffset</a>
-<a data-link-type="dfn" href="#format-2-patch-map-cffcharstringsoffset" id="ref-for-format-2-patch-map-cffcharstringsoffset">cffCharStringsOffset</a>, or <a data-link-type="dfn" href="#format-2-patch-map-cff2charstringsoffset" id="ref-for-format-2-patch-map-cff2charstringsoffset">cff2CharStringsOffset</a>)
+(<a data-link-type="dfn" href="#patch-map-table-cffcharstringsoffset" id="ref-for-patch-map-table-cffcharstringsoffset">cffCharStringsOffset</a> or <a data-link-type="dfn" href="#patch-map-table-cff2charstringsoffset" id="ref-for-patch-map-table-cff2charstringsoffset">cff2CharStringsOffset</a>)
 to the start of the CharStrings INDEX data for the CFF and/or CFF2 table.</span></p>
    </ul>
    <p>These three requirements allow for the glyph keyed patch application implementation on CFF and CFF2 tables to be significantly
@@ -1769,22 +1756,13 @@ non-subroutinized font more effectively than its subroutinized equivalent (at th
 uncompressed file).  Therefore, it is recommended that subroutinzation either be avoided, used moderately, or customized
 to the specific needs of IFT.</p>
    <h3 class="heading settled" data-level="5.3" id="patch-map-table"><span class="secno">5.3. </span><span class="content">Patch Map Table</span><a class="self-link" href="#patch-map-table"></a></h3>
-   <p>A <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑦">patch map</a> is encoded in one of two formats:</p>
-   <ul>
-    <li data-md>
-     <p>Format 1: a limited, but more compact encoding. It encodes a one-to-one mapping from glyph id to patch URL strings. It does
-not support <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑥">font subset definitions</a> with design space or entries with overlapping subset definitions.</p>
-    <li data-md>
-     <p>Format 2: can encode arbitrary mappings including ones with design space or overlapping subset definitions. However, it
-is typically less compact than format 1.</p>
-   </ul>
-   <p>Each format defines an algorithm for interpreting bytes encoded with that format to produce the list of entries it represents. The
-<a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a> algorithm invokes the interpretation algorithms and operates on the resulting entry list. The
-encoded bytes are the source of truth at all times for the patch map. Patch application during subset extension will alter the encoded
-bytes of the patch map and as a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets
-the encoded bytes at the start of every iteration to pick up any changes made in the previous iteration.</p>
-   <h4 class="heading settled" data-level="5.3.1" id="patch-map-format-1"><span class="secno">5.3.1. </span><span class="content">Patch Map Table: Format 1</span><a class="self-link" href="#patch-map-format-1"></a></h4>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="format-1-patch-map">Format 1 Patch Map</dfn> encoding:</p>
+   <p>This section describes the encoding of the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑦">patch map</a> and defines an algorithm for interpreting bytes encoded in this
+format to produce the list of entries it represents. The <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset⑨">Extend an Incremental Font Subset</a> algorithm invokes the
+interpretation algorithm and operates on the resulting entry list. The encoded bytes are the source of truth at all
+times for the patch map. Patch application during subset extension will alter the encoded bytes of the patch map and as
+a result the entry list derived from the encoded bytes will change. The extension algorithm reinterprets the encoded
+bytes at the start of every iteration to pick up any changes made in the previous iteration.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="patch-map-table-encoding">Patch Map Table</dfn> encoding:</p>
    <table>
     <tbody>
      <tr>
@@ -1793,378 +1771,44 @@ the encoded bytes at the start of every iteration to pick up any changes made in
       <th>Description
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-format">format</dfn>
-      <td>Set to 1, identifies this as format 1.
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-format">format</dfn>
+      <td>Set to 2, identifies the format of this table.
      <tr>
       <td>uint24
       <td>reserved
       <td>Not used, set to 0.
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-flags">flags</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-flags">flags</dfn>
       <td>Flags to signal the presence of optional fields.
-        If bit 0 (least significant bit) is set, then <a data-link-type="dfn" href="#format-1-patch-map-cffcharstringsoffset" id="ref-for-format-1-patch-map-cffcharstringsoffset①">cffCharStringsOffset</a> will be present.
-        If bit 1 (least significant bit) is set, then <a data-link-type="dfn" href="#format-1-patch-map-cff2charstringsoffset" id="ref-for-format-1-patch-map-cff2charstringsoffset①">cff2CharStringsOffset</a> will be present.
+        If bit 0 (least significant bit) is set, then <a data-link-type="dfn" href="#patch-map-table-cffcharstringsoffset" id="ref-for-patch-map-table-cffcharstringsoffset①">cffCharStringsOffset</a> will be present.
+        If bit 1 (least significant bit) is set, then <a data-link-type="dfn" href="#patch-map-table-cff2charstringsoffset" id="ref-for-patch-map-table-cff2charstringsoffset①">cff2CharStringsOffset</a> will be present.
     
      <tr>
       <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-compatibilityid">compatibilityId</dfn>[4]
-      <td>
-      Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>). The encoder chooses this
-      value. The encoder should set it to a random value which has not previously been used while encoding the IFT font.
-    
-     <tr>
-      <td>uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-maxentryindex">maxEntryIndex</dfn>
-      <td>The largest entry index encoded in this table.
-     <tr>
-      <td>uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</dfn>
-      <td><span class="client conform encoder" id="conform-format1-entry-index-maximum">The largest <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map">Glyph Map</a> entry index encoded in this table. Must be less than or equal to maxEntryIndex.</span>
-     <tr>
-      <td>uint24
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-glyphcount">glyphCount</dfn>
-      <td>
-       <span class="client conform encoder" id="conform-format1-glyph-count-matches">Number of glyphs that mappings are provided for.
-        Must match the number of glyphs in the font file.</span>
-
-
-       <p class="note" role="note"><span class="marker">Note:</span> the number of glyphs in the font is encoded in the font file. At the time of writing, this value is listed in the
-        <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/maxp#">maxp</a> table; however, future font format extensions may use alternate tables to encode the value for number of
-        glyphs.</p>
-     <tr>
-      <td>Offset32
-      <td>glyphMapOffset
-      <td>Offset to a <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map①">Glyph Map</a> sub table. Offset is from the start of this table.
-     <tr>
-      <td>Offset32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-featuremapoffset">featureMapOffset</dfn>
-      <td>Offset to a <a data-link-type="dfn" href="#feature-map" id="ref-for-feature-map">Feature Map</a> sub table. Offset is from the start of this table. May be null (0).
-     <tr>
-      <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</dfn>[(maxEntryIndex + 8)/8]
-      <td>
-      A bit map which tracks which entries have been applied. If bit <code>i</code> is set that indicates the patch for entry
-      <code>i</code> has been applied to this font. Bit 0 is the least significant bit of appliedEntriesBitMap[0], while bit 7 is
-      the most significant bit. Bit 8 is the least significant bit of appliedEntriesBitMap[1] and so on.
-    
-     <tr>
-      <td>uint16
-      <td>urlTemplateLength
-      <td>
-      Length of the urlTemplate byte array.
-    
-     <tr>
-      <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
-      <td>
-      A byte array containing a <a href="#url-templates">URL Template</a> which is used to produce URL strings associated with each entry.
-    
-     <tr>
-      <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-patchformat">patchFormat</dfn>
-      <td>
-      Specifies the format of the patches linked to by urlTemplate.
-      <span class="client conform encoder" id="conform-format1-valid-format-number">Must be set to one of the format numbers from  the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.</span>
-    
-     <tr>
-      <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-cffcharstringsoffset">cffCharStringsOffset</dfn>
-      <td>
-      Only present if bit 0 (least significant) of <a data-link-type="dfn" href="#format-1-patch-map-flags" id="ref-for-format-1-patch-map-flags">flags</a> is set.
-      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table to the CharStrings INDEX data structure of the
-      <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table.
-    
-     <tr>
-      <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 1 Patch Map" data-dfn-type="dfn" data-noexport id="format-1-patch-map-cff2charstringsoffset">cff2CharStringsOffset</dfn>
-      <td>
-      Only present if bit 1 of <a data-link-type="dfn" href="#format-1-patch-map-flags" id="ref-for-format-1-patch-map-flags①">flags</a> is set.
-      Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF2</a> table to the CharStrings INDEX data structure of the
-      <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table.
-    
-   </table>
-   <p class="note" role="note"><span class="marker">Note:</span> <a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount">glyphCount</a> is designed to be compatible with the
-      proposed <a href="https://github.com/harfbuzz/boring-expansion-spec/tree/main">future font format extension</a> to allow for more
-      than 65,535 glyphs.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-map">Glyph Map</dfn> encoding:</p>
-   <p>A glyph map table associates each glyph index in the font with an entry index.</p>
-   <table>
-    <tbody>
-     <tr>
-      <th>Type
-      <th>Name
-      <th>Description
-     <tr>
-      <td>uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-firstmappedglyph">firstMappedGlyph</dfn>
-      <td>All glyph indices less than firstMappedGlyph are implicitly mapped to entry index 0.
-     <tr>
-      <td>uint8/uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="Glyph Map" data-dfn-type="dfn" data-noexport id="glyph-map-entryindex">entryIndex</dfn>[<a data-link-type="dfn" href="#format-1-patch-map-glyphcount" id="ref-for-format-1-patch-map-glyphcount①">glyphCount</a> - firstMappedGlyph]
-      <td>
-      The entry index for glyph <code>i</code> is stored in entryIndex[<code>i</code> - <a data-link-type="dfn" href="#glyph-map-firstmappedglyph" id="ref-for-glyph-map-firstmappedglyph">firstMappedGlyph</a>]. Array members
-      are uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex">maxEntryIndex</a> is less than 256, otherwise they are uint16.
-    
-   </table>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="feature-map">Feature Map</dfn> encoding:</p>
-   <p>A feature map table associates combinations of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> and glyphs with an entry index.</p>
-   <table>
-    <tbody>
-     <tr>
-      <th>Type
-      <th>Name
-      <th>Description
-     <tr>
-      <td>uint16
-      <td>featureCount
-      <td>Number of featureRecords.
-     <tr>
-      <td><a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord">FeatureRecord</a>
-      <td><dfn class="dfn-paneled" data-dfn-for="Feature Map" data-dfn-type="dfn" data-noexport id="feature-map-featurerecords">featureRecords</dfn>[featureCount]
-      <td>
-      Provides mappings for a specific  <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tag</a>. <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords">featureRecords</a> are sorted by
-      <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag">featureTag</a> in ascending order with any feature tag occurring at most once. For sorting tag values are interpreted
-      as a 4 byte big endian unsigned integer and sorted by the integer value.
-    
-     <tr>
-      <td><a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord">EntryMapRecord</a>
-      <td><dfn class="dfn-paneled" data-dfn-for="Feature Map" data-dfn-type="dfn" data-noexport id="feature-map-entrymaprecords">entryMapRecords</dfn>[variable]
-      <td>
-      Provides the key (entry index) for each feature mapping. The entryMapRecords array contains as many entries as the sum of
-      the <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount">entryMapCount</a> fields in the <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords①">featureRecords</a> array, with entryMapRecords[0] corresponding
-      to the first entry of featureRecords[0], entryMapRecords[featureRecord[0].entryMapCount] corresponding to the first entry of
-      featureRecords[1], entryMapRecords[featureRecords[0].entryMapCount + featureRecord[1].entryMapCount]] corresponding to the
-      first entry of featureRecords[2], and so on.
-    
-   </table>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="featurerecord">FeatureRecord</dfn> encoding:</p>
-   <table>
-    <tbody>
-     <tr>
-      <th>Type
-      <th>Name
-      <th>Description
-     <tr>
-      <td>Tag
-      <td><dfn class="dfn-paneled" data-dfn-for="FeatureRecord" data-dfn-type="dfn" data-noexport id="featurerecord-featuretag">featureTag</dfn>
-      <td>The <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tag</a> this mapping is for.
-     <tr>
-      <td>uint8/uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="FeatureRecord" data-dfn-type="dfn" data-noexport id="featurerecord-firstnewentryindex">firstNewEntryIndex</dfn>
-      <td>
-      uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex①">maxEntryIndex</a> is less than 256, otherwise uint16.
-      The first entry index this record maps too.
-    
-     <tr>
-      <td>uint8/uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="FeatureRecord" data-dfn-type="dfn" data-noexport id="featurerecord-entrymapcount">entryMapCount</dfn>
-      <td>
-      uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex②">maxEntryIndex</a> is less than 256, otherwise uint16.
-      The number of <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord①">EntryMapRecord</a>s associated with this feature.
-    
-   </table>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="entrymaprecord">EntryMapRecord</dfn> encoding:</p>
-   <table>
-    <tbody>
-     <tr>
-      <th>Type
-      <th>Name
-      <th>Description
-     <tr>
-      <td>uint8/uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-firstentryindex">firstEntryIndex</dfn>
-      <td>
-      uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex③">maxEntryIndex</a> is less than 256, otherwise uint16. firstEntryIndex and lastEntryIndex specify
-      the set of <a data-link-type="dfn" href="#glyph-map" id="ref-for-glyph-map②">Glyph Map</a> entries which form the subset definitions for the entries created by this mapping.
-    
-     <tr>
-      <td>uint8/uint16
-      <td><dfn class="dfn-paneled" data-dfn-for="EntryMapRecord" data-dfn-type="dfn" data-noexport id="entrymaprecord-lastentryindex">lastEntryIndex</dfn>
-      <td>
-      uint8 if <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex④">maxEntryIndex</a> is less than 256, otherwise uint16.
-    
-   </table>
-   <p>An entry map record matches any entry indices that are greater than or equal to firstEntryIndex and less than or equal to  lastEntryIndex.</p>
-   <h5 class="algorithm client conform heading settled" data-algorithm="Interpreting Format 1" data-level="5.3.1.1" id="interpreting-patch-map-format-1"><span class="secno">5.3.1.1. </span><span class="content">Interpreting Format 1</span><a class="self-link" href="#interpreting-patch-map-format-1"></a></h5>
-   <p>This algorithm is used to convert a format 1 patch map into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries③">patch map entries</a>.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</dfn></p>
-   <p>The inputs to this algorithm are:</p>
-   <ul>
-    <li data-md>
-     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-1-patch-map" id="ref-for-format-1-patch-map">Format 1 Patch Map</a> encoded patch map.</p>
-    <li data-md>
-     <p><var>font subset</var>: the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subset</a> which contains <var>patch map</var>.</p>
-   </ul>
-   <p>The algorithm outputs:</p>
-   <ul>
-    <li data-md>
-     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a>.</p>
-   </ul>
-   <p>The algorithm:</p>
-   <ol>
-    <li data-md>
-     <p>Check that the <var>patch map</var> data is: complete and not truncated, has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format">format</a> equal to 1, and is valid
- according to the requirements in <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a> (requirements are marked with a "must"). If it is not return an error.</p>
-    <li data-md>
-     <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex">entryIndex</a>:</p>
-     <ul>
-      <li data-md>
-       <p>If <var>entry index</var> is 0 then, this is a special entry used to mark glyphs which are already in the initial font. Skip this
-index and do not build an entry for it.</p>
-      <li data-md>
-       <p>If the <var>entry index</var> is larger than <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</a> this entry is invalid, skip this
-<var>entry index</var>.</p>
-      <li data-md>
-       <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a> is set to 1, skip this
-<var>entry index</var>.</p>
-      <li data-md>
-       <p>Collect the set of glyph indices that map to the <var>entry index</var>.</p>
-      <li data-md>
-       <p>Convert the set of glyph indices to a set of Unicode code points using the code point to glyph mapping in the
-<a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a> table of <var>font subset</var>. Ignore any glyph indices that are not mapped by <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#">cmap</a>.
-Multiple code points may map to the same glyph id. All code points associated with a glyph should be included.</p>
-      <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate">urlTemplate</a>
-and <var>entry index</var> as inputs. If the template expansion results in an error, then return
-an error.</p>
-      <li data-md>
-       <p>If the Unicode code point set is empty then, skip this <var>entry index</var>.</p>
-      <li data-md>
-       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">entry</a> to <var>entry list</var> with a subset definition which contains only the Unicode code point
-set and maps to the generated URL string, the patch format specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat">patchFormat</a>, and
-<a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid">compatibilityId</a>.</p>
-     </ul>
-    <li data-md>
-     <p>If <a data-link-type="dfn" href="#format-1-patch-map-featuremapoffset" id="ref-for-format-1-patch-map-featuremapoffset">featureMapOffset</a> is not null then, for each <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord①">FeatureRecord</a> and associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord②">EntryMapRecord</a> in
-    <a data-link-type="dfn" href="#feature-map-featurerecords" id="ref-for-feature-map-featurerecords②">featureRecords</a> and <a data-link-type="dfn" href="#feature-map-entrymaprecords" id="ref-for-feature-map-entrymaprecords">entryMapRecords</a>:</p>
-     <ul>
-      <li data-md>
-       <p>Any <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord②">FeatureRecord’s</a> whose <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag①">featureTag</a> is less than or equal to a <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag②">featureTag</a>
-of any <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord③">FeatureRecord</a>  which occurred earlier in the list are invalid. All associated <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord③">EntryMapRecord’s</a> are
-skipped. For ordering, tag values are interpreted as a 4 byte big endian unsigned integer and ordered by the integer value.</p>
-      <li data-md>
-       <p>Compute <var>mapped entry index</var>, the first <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord④">EntryMapRecord</a> associated with a <a data-link-type="dfn" href="#featurerecord" id="ref-for-featurerecord④">FeatureRecord</a> is
-<a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex">FeatureRecord::firstNewEntryIndex</a>, the second
-<a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex①">FeatureRecord::firstNewEntryIndex</a> + 1, and so on. The last will be
-<a data-link-type="dfn" href="#featurerecord-firstnewentryindex" id="ref-for-featurerecord-firstnewentryindex②">FeatureRecord::firstNewEntryIndex</a> + <a data-link-type="dfn" href="#featurerecord-entrymapcount" id="ref-for-featurerecord-entrymapcount①">entryMapCount</a> - 1.</p>
-      <li data-md>
-       <p>If the computed <var>mapped entry index</var> is less than or equal to <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex①">maxGlyphMapEntryIndex</a> or larger than
-<a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑤">maxEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑤">EntryMapRecord</a> is invalid, skip it.</p>
-      <li data-md>
-       <p>If <a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex">EntryMapRecord::firstEntryIndex</a> is greater than
-<a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex">EntryMapRecord::lastEntryIndex</a> this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑥">EntryMapRecord</a> is invalid, skip it.</p>
-      <li data-md>
-       <p>Convert <var>mapped entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template①">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate①">urlTemplate</a>
-and <var>mapped entry index</var> as inputs. If the template expansion results in an error, then return an error.</p>
-      <li data-md>
-       <p>If the bit for <var>mapped entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap①">appliedEntriesBitMap</a> is set to 1, skip this entry.</p>
-      <li data-md>
-       <p>Construct a set of Unicode code points. For each <var>entry index</var> between
-<a data-link-type="dfn" href="#entrymaprecord-firstentryindex" id="ref-for-entrymaprecord-firstentryindex①">EntryMapRecord::firstEntryIndex</a> (inclusive) and
-<a data-link-type="dfn" href="#entrymaprecord-lastentryindex" id="ref-for-entrymaprecord-lastentryindex①">EntryMapRecord::lastEntryIndex</a> (inclusive):</p>
-       <ul>
-        <li data-md>
-         <p>If <var>entry index</var> is greater than <a data-link-type="dfn" href="#format-1-patch-map-maxglyphmapentryindex" id="ref-for-format-1-patch-map-maxglyphmapentryindex②">maxGlyphMapEntryIndex</a> then, this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑦">EntryMapRecord</a> is invalid
-skip it.</p>
-        <li data-md>
-         <p>Add the set of Unicode code points associated with <var>entry index</var> that was computed in step 2 to the set. If the
-<var>entry index</var> was skipped because it was 0 or <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap②">appliedEntriesBitMap</a> compute the set of
-associated code points as if it wasn’t skipped.</p>
-       </ul>
-      <li data-md>
-       <p>If the constructed set of Unicode code points is empty then, this <a data-link-type="dfn" href="#entrymaprecord" id="ref-for-entrymaprecord⑧">EntryMapRecord</a> is invalid skip it.</p>
-      <li data-md>
-       <p>Add an <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">entry</a> to <var>entry list</var> which  maps to the generated URL string, the patch format
-specified by <a data-link-type="dfn" href="#format-1-patch-map-patchformat" id="ref-for-format-1-patch-map-patchformat①">patchFormat</a>, and <a data-link-type="dfn" href="#format-1-patch-map-compatibilityid" id="ref-for-format-1-patch-map-compatibilityid①">compatibilityId</a>; or if there is an existing
-<a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑦">entry</a> in <var>entry list</var> which has the same patch URL string as the generated URL string then
-instead modify the existing entry. Add the constructed set of Unicode code points and <a data-link-type="dfn" href="#featurerecord-featuretag" id="ref-for-featurerecord-featuretag③">featureTag</a> to the new or
-existing entry’s subset definition.</p>
-     </ul>
-    <li data-md>
-     <p>Return <var>entry list</var>.</p>
-   </ol>
-   <p class="note" role="note"><span class="marker">Note:</span> while an encoding is not required to include entries for all entry indices in [0, <a data-link-type="dfn" href="#format-1-patch-map-maxentryindex" id="ref-for-format-1-patch-map-maxentryindex⑥">maxEntryIndex</a>], it is
-recommended that it do so for maximum compactness.</p>
-   <h5 class="algorithm client conform heading settled" data-algorithm="Remove Entries from Format 1" data-level="5.3.1.2" id="remove-entries-format-1"><span class="secno">5.3.1.2. </span><span class="content">Remove Entries from Format 1</span><a class="self-link" href="#remove-entries-format-1"></a></h5>
-   <p>This algorithm is used to remove entries from a format 1 patch map. This removal modifies the bytes of the patch map but does not
-change the number of bytes.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</dfn></p>
-   <p>The inputs to this algorithm are:</p>
-   <ul>
-    <li data-md>
-     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-1-patch-map" id="ref-for-format-1-patch-map①">Format 1 Patch Map</a> encoded patch map. May be modified by this procedure.</p>
-    <li data-md>
-     <p><var>patch URL string</var>: URL string for a patch which identifies the entries to be removed.</p>
-   </ul>
-   <p>The algorithm:</p>
-   <ol>
-    <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-1-patch-map-format" id="ref-for-format-1-patch-map-format①">format</a> equal to 1 and is valid according to the requirements in
- <a href="#patch-map-format-1">§ 5.3.1 Patch Map Table: Format 1</a>. If it is not return an error.</p>
-    <li data-md>
-     <p>For each unique <var>entry index</var> in <a data-link-type="dfn" href="#glyph-map-entryindex" id="ref-for-glyph-map-entryindex①">entryIndex</a> of <var>patch map</var>:</p>
-     <ul>
-      <li data-md>
-       <p>If the bit for <var>entry index</var> in <a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap③">appliedEntriesBitMap</a> is set to 1, skip this
-<var>entry index</var>.</p>
-      <li data-md>
-       <p>Convert <var>entry index</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template②">Expand URL Template</a> with <a data-link-type="dfn" href="#format-1-patch-map-urltemplate" id="ref-for-format-1-patch-map-urltemplate②">urlTemplate</a>
-and <var>entry index</var> as inputs. If the template expansion results in an error, then return
-an error.</p>
-      <li data-md>
-       <p>If the generated URL string is equal to <var>patch URL string</var> then set the bit for <var>entry index</var> in
-<a data-link-type="dfn" href="#format-1-patch-map-appliedentriesbitmap" id="ref-for-format-1-patch-map-appliedentriesbitmap④">appliedEntriesBitMap</a> to 1.</p>
-     </ul>
-   </ol>
-   <h4 class="heading settled" data-level="5.3.2" id="patch-map-format-2"><span class="secno">5.3.2. </span><span class="content">Patch Map Table: Format 2</span><a class="self-link" href="#patch-map-format-2"></a></h4>
-   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="format-2-patch-map">Format 2 Patch Map</dfn> encoding:</p>
-   <table>
-    <tbody>
-     <tr>
-      <th>Type
-      <th>Name
-      <th>Description
-     <tr>
-      <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-format">format</dfn>
-      <td>Set to 2, identifies this as format 2.
-     <tr>
-      <td>uint24
-      <td>reserved
-      <td>Not used, set to 0.
-     <tr>
-      <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-flags">flags</dfn>
-      <td>Flags to signal the presence of optional fields.
-        If bit 0 (least significant bit) is set, then <a data-link-type="dfn" href="#format-2-patch-map-cffcharstringsoffset" id="ref-for-format-2-patch-map-cffcharstringsoffset①">cffCharStringsOffset</a> will be present.
-        If bit 1 (least significant bit) is set, then <a data-link-type="dfn" href="#format-2-patch-map-cff2charstringsoffset" id="ref-for-format-2-patch-map-cff2charstringsoffset①">cff2CharStringsOffset</a> will be present.
-    
-     <tr>
-      <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-compatibilityid">compatibilityId</dfn>[4]
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-compatibilityid">compatibilityId</dfn>[4]
       <td>
       Unique ID used to identify patches that are compatible with this font (see <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>). The encoder chooses this
       value. The encoder should set it to a random value which has not previously been used while encoding the IFT font.
     
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-defaultpatchformat">defaultPatchFormat</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-defaultpatchformat">defaultPatchFormat</dfn>
       <td>
       Specifies the format of the patches linked to by urlTemplate (unless overridden by an entry).
-      <span class="client conform encoder" id="conform-format2-valid-format-number">Must be set to one of the format numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.</span>
+      <span class="client conform encoder" id="conform-patchmap-valid-format-number">Must be set to one of the format numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.</span>
     
      <tr>
       <td>uint24
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entrycount">entryCount</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-entrycount">entryCount</dfn>
       <td>Number of entries encoded in this table.
      <tr>
       <td>Offset32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entries">entries</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-entries">entries</dfn>
       <td>Offset to a <a data-link-type="dfn" href="#mapping-entries" id="ref-for-mapping-entries">Mapping Entries</a> sub table. Offset is from the start of this table.
      <tr>
       <td>Offset32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-entryidstringdata">entryIdStringData</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-entryidstringdata">entryIdStringData</dfn>
       <td>
       Offset to a block of data containing the concatentation of all of the entry ID strings.
       May be null (0). Offset is from the start of this table.
@@ -2177,23 +1821,23 @@ an error.</p>
     
      <tr>
       <td>uint8
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-urltemplate">urlTemplate</dfn>[urlTemplateLength]
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-urltemplate">urlTemplate</dfn>[urlTemplateLength]
       <td>
       A byte array containing a <a href="#url-templates">URL Template</a> which is used to produce URL strings associated with each entry.
     
      <tr>
       <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-cffcharstringsoffset">cffCharStringsOffset</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-cffcharstringsoffset">cffCharStringsOffset</dfn>
       <td>
-      Only present if bit 0 (least significant) of <a data-link-type="dfn" href="#format-2-patch-map-flags" id="ref-for-format-2-patch-map-flags">flags</a> is set.
+      Only present if bit 0 (least significant) of <a data-link-type="dfn" href="#patch-map-table-flags" id="ref-for-patch-map-table-flags">flags</a> is set.
       Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table to the CharStrings INDEX data structure of the
       <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF</a> table.
     
      <tr>
       <td>uint32
-      <td><dfn class="dfn-paneled" data-dfn-for="Format 2 Patch Map" data-dfn-type="dfn" data-noexport id="format-2-patch-map-cff2charstringsoffset">cff2CharStringsOffset</dfn>
+      <td><dfn class="dfn-paneled" data-dfn-for="Patch Map Table" data-dfn-type="dfn" data-noexport id="patch-map-table-cff2charstringsoffset">cff2CharStringsOffset</dfn>
       <td>
-      Only present if bit 1 of <a data-link-type="dfn" href="#format-2-patch-map-flags" id="ref-for-format-2-patch-map-flags①">flags</a> is set.
+      Only present if bit 1 of <a data-link-type="dfn" href="#patch-map-table-flags" id="ref-for-patch-map-table-flags①">flags</a> is set.
       Gives the offset from the start of the <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF#">CFF2</a> table to the CharStrings INDEX data structure of the
       <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/CFF2#">CFF2</a> table.
     
@@ -2208,8 +1852,8 @@ an error.</p>
      <tr>
       <td>uint8
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entries" data-dfn-type="dfn" data-noexport id="mapping-entries-entries">entries</dfn>[variable]
-      <td>Byte array containing the encoded bytes of <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount">entryCount</a> <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry">Mapping Entry</a>’s. Each entry has a variable
-        length, which is determined following <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a>.
+      <td>Byte array containing the encoded bytes of <a data-link-type="dfn" href="#patch-map-table-entrycount" id="ref-for-patch-map-table-entrycount">entryCount</a> <a data-link-type="dfn" href="#mapping-entry" id="ref-for-mapping-entry">Mapping Entry</a>’s. Each entry has a variable
+        length, which is determined following <a data-link-type="abstract-op" href="#abstract-opdef-interpret-patch-map-entry" id="ref-for-abstract-opdef-interpret-patch-map-entry">Interpret Patch Map Entry</a>.
    </table>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mapping-entry">Mapping Entry</dfn> encoding:</p>
    <table>
@@ -2235,7 +1879,7 @@ an error.</p>
       <td>Tag
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-featuretags">featureTags</dfn>[featureCount]
       <td>
-      List of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definition</a>. Only present if
+      List of <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/featuretags#">feature tags</a> in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑥">font subset definition</a>. Only present if
       <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①">formatFlags</a> bit 0 is set.
     
      <tr>
@@ -2248,7 +1892,7 @@ an error.</p>
       <td><a data-link-type="dfn" href="#design-space-segment" id="ref-for-design-space-segment">Design Space Segment</a>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-designspacesegments">designSpaceSegments</dfn>[designSpaceCount]
       <td>
-      List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set.
+      List of design space segments in the entry’s <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑦">font subset definition</a>. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags③">formatFlags</a> bit 0 is set.
     
      <tr>
       <td>uint8
@@ -2274,20 +1918,20 @@ an error.</p>
       List of signed deltas which calculate the IDs of the URL strings for this entry. If present, has at least one delta. If the least
       significant bit of a delta is set, then one more delta follows. This repeats until a delta with the least significant bit
       cleared is encountered. The entry id for each delta is the last calculated entry id + 1 + floor(entryIdDelta / 2). Only present if
-      <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata">entryIdStringData</a> is null (0).
-      If not present and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata①">entryIdStringData</a> is null (0), then there is one id for this entry and the
+      <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑥">formatFlags</a> bit 2 is set and <a data-link-type="dfn" href="#patch-map-table-entryidstringdata" id="ref-for-patch-map-table-entryidstringdata">entryIdStringData</a> is null (0).
+      If not present and <a data-link-type="dfn" href="#patch-map-table-entryidstringdata" id="ref-for-patch-map-table-entryidstringdata①">entryIdStringData</a> is null (0), then there is one id for this entry and the
       delta is assumed to be 0.
     
      <tr>
       <td>uint24
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-entryidstringlength">entryIdStringLength</dfn>[variable]
       <td>
-      The number of bytes that each id string for this entry occupies in the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata②">entryIdStringData</a>
+      The number of bytes that each id string for this entry occupies in the <a data-link-type="dfn" href="#patch-map-table-entryidstringdata" id="ref-for-patch-map-table-entryidstringdata②">entryIdStringData</a>
       data block.  If the most significant bit of a length value is set, then another length value follows. This repeats
       until a length value with the most significant bit cleared is encountered. The actual length value is stored in
       the least significant 23 bits of each value. Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑦">formatFlags</a> bit 2 is set and
-      <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata③">entryIdStringData</a> is not null (0). If present has at least one length value. If not present
-      and <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata④">entryIdStringData</a> is not null (0), then there is one id string which is set to the last
+      <a data-link-type="dfn" href="#patch-map-table-entryidstringdata" id="ref-for-patch-map-table-entryidstringdata③">entryIdStringData</a> is not null (0). If present has at least one length value. If not present
+      and <a data-link-type="dfn" href="#patch-map-table-entryidstringdata" id="ref-for-patch-map-table-entryidstringdata④">entryIdStringData</a> is not null (0), then there is one id string which is set to the last
       id string from the previous entry or an empty string for the first entry.
     
      <tr>
@@ -2295,7 +1939,7 @@ an error.</p>
       <td><dfn class="dfn-paneled" data-dfn-for="Mapping Entry" data-dfn-type="dfn" data-noexport id="mapping-entry-patchformat">patchFormat</dfn>
       <td>
       Specifies the format of the patch linked to by this entry. Uses the ID numbers from the <a href="#font-patch-formats-summary">§ 6.1 Formats Summary</a> table.
-      Overrides <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat">defaultPatchFormat</a>.
+      Overrides <a data-link-type="dfn" href="#patch-map-table-defaultpatchformat" id="ref-for-patch-map-table-defaultpatchformat">defaultPatchFormat</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑧">formatFlags</a> bit 3 is set.
     
      <tr>
@@ -2313,11 +1957,11 @@ an error.</p>
       <td>
       Set of code points for this mapping. Encoded as a <a data-link-type="dfn" href="#sparse-bit-set" id="ref-for-sparse-bit-set">Sparse Bit Set</a>.
       Only present if <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags⑨">formatFlags</a> bit 4 and/or 5 is set. The length is
-      determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 5.3.2.3 Sparse Bit Set</a>.
+      determined by following the decoding procedures in <a href="#sparse-bit-set-decoding">§ 5.3.3 Sparse Bit Set</a>.
     
    </table>
    <p>If an encoder is producing patches that will be stored on a file system and then served it’s recommended that only numeric entry IDs be
-used (via <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a>) as these will generally produce the smallest encoding of the format 2 patch map. String IDs
+used (via <a data-link-type="dfn" href="#mapping-entry-entryiddelta" id="ref-for-mapping-entry-entryiddelta">entryIdDelta</a>) as these will generally produce the smallest encoding of the patch map. String IDs
 are useful in cases where patches are not being stored in advance and the ID strings can be then used to encode information about the patch
 being requested.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="design-space-segment">Design Space Segment</dfn> encoding:</p>
@@ -2348,40 +1992,40 @@ being requested.</p>
       <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#coordinate-scales-and-normalization">OpenType Specification § otvaroverview#coordinate-scales-and-normalization</a>.
     
    </table>
-   <h5 class="algorithm client conform heading settled" data-algorithm="Interpreting Format 2" data-level="5.3.2.1" id="interpreting-patch-map-format-2"><span class="secno">5.3.2.1. </span><span class="content">Interpreting Format 2</span><a class="self-link" href="#interpreting-patch-map-format-2"></a></h5>
-   <p>This algorithm is used to convert a format 2 <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑧">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑧">patch map entries</a>.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</dfn></p>
+   <h4 class="algorithm client conform heading settled" data-algorithm="Interpreting a Patch Map" data-level="5.3.1" id="interpreting-patch-map"><span class="secno">5.3.1. </span><span class="content">Interpreting a Patch Map</span><a class="self-link" href="#interpreting-patch-map"></a></h4>
+   <p>This algorithm is used to convert a <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑧">patch map</a> into a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries③">patch map entries</a>.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-patch-map">Interpret Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map">Format 2 Patch Map</a> encoded <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑨">patch map</a>.</p>
+     <p><var>patch map</var>: a <a data-link-type="dfn" href="#patch-map-table-encoding" id="ref-for-patch-map-table-encoding">Patch Map Table</a>.</p>
    </ul>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑨">patch map entries</a>.</p>
+     <p><var>entry list</var>: a list of <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries④">patch map entries</a>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
     <li data-md>
-     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#format-2-patch-map-format" id="ref-for-format-2-patch-map-format">format</a> equal to 2 and is valid according to the requirements in
- <a href="#patch-map-format-2">§ 5.3.2 Patch Map Table: Format 2</a> (requirements are marked with a "must"). If it is not return an error.</p>
+     <p>Check that the <var>patch map</var> has <a data-link-type="dfn" href="#patch-map-table-format" id="ref-for-patch-map-table-format">format</a> equal to 2 and is valid according to the requirements in
+ <a href="#patch-map-table">§ 5.3 Patch Map Table</a> (requirements are marked with a "must"). If it is not return an error.</p>
     <li data-md>
-     <p>If the <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑤">entryIdStringData</a> offset is 0 then initialize <var>last entry id</var> to 0. Otherwise initialize
+     <p>If the <a data-link-type="dfn" href="#patch-map-table-entryidstringdata" id="ref-for-patch-map-table-entryidstringdata⑤">entryIdStringData</a> offset is 0 then initialize <var>last entry id</var> to 0. Otherwise initialize
  it to an empty byte string. Set <var>current byte</var> to 0, and <var>current id string byte</var> to 0.</p>
     <li data-md>
      <p>Initialize <var>entry list</var> and <var>prior entry list</var> to empty lists.</p>
     <li data-md>
-     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry①">Interpret Format 2 Patch Map Entry</a>, <a data-link-type="dfn" href="#format-2-patch-map-entrycount" id="ref-for-format-2-patch-map-entrycount①">entryCount</a> times. For each invocation:</p>
+     <p>Invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-patch-map-entry" id="ref-for-abstract-opdef-interpret-patch-map-entry①">Interpret Patch Map Entry</a>, <a data-link-type="dfn" href="#patch-map-table-entrycount" id="ref-for-patch-map-table-entrycount①">entryCount</a> times. For each invocation:</p>
      <ul>
       <li data-md>
-       <p>pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entries" id="ref-for-format-2-patch-map-entries">entries</a>[<var>current byte</var>] to
+       <p>pass in <var>prior entry list</var>, the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#patch-map-table-entries" id="ref-for-patch-map-table-entries">entries</a>[<var>current byte</var>] to
  the end of <var>patch map</var>,
- the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑥">entryIdStringData</a>[<var>current id string byte</var>]
- to the end of <var>patch map</var> if <a data-link-type="dfn" href="#format-2-patch-map-entryidstringdata" id="ref-for-format-2-patch-map-entryidstringdata⑦">entryIdStringData</a> is non zero,
+ the bytes from <var>patch map</var> starting from <a data-link-type="dfn" href="#patch-map-table-entryidstringdata" id="ref-for-patch-map-table-entryidstringdata⑥">entryIdStringData</a>[<var>current id string byte</var>]
+ to the end of <var>patch map</var> if <a data-link-type="dfn" href="#patch-map-table-entryidstringdata" id="ref-for-patch-map-table-entryidstringdata⑦">entryIdStringData</a> is non zero,
  <var>last entry id</var>,
- <a data-link-type="dfn" href="#format-2-patch-map-defaultpatchformat" id="ref-for-format-2-patch-map-defaultpatchformat①">defaultPatchFormat</a>, and
- <a data-link-type="dfn" href="#format-2-patch-map-urltemplate" id="ref-for-format-2-patch-map-urltemplate">urlTemplate</a>.</p>
+ <a data-link-type="dfn" href="#patch-map-table-defaultpatchformat" id="ref-for-patch-map-table-defaultpatchformat①">defaultPatchFormat</a>, and
+ <a data-link-type="dfn" href="#patch-map-table-urltemplate" id="ref-for-patch-map-table-urltemplate">urlTemplate</a>.</p>
       <li data-md>
        <p>Set <var>last entry id</var> to the returned entry id.</p>
       <li data-md>
@@ -2392,12 +2036,12 @@ being requested.</p>
        <p>Add the returned entry to <var>prior entry list</var>.</p>
       <li data-md>
        <p>If the returned value of ignored is false, then set the compatibility ID of the returned entry to
- <a data-link-type="dfn" href="#format-2-patch-map-compatibilityid" id="ref-for-format-2-patch-map-compatibilityid">compatibilityId</a> and add the  entry to <var>entry list</var>.</p>
+ <a data-link-type="dfn" href="#patch-map-table-compatibilityid" id="ref-for-patch-map-table-compatibilityid">compatibilityId</a> and add the  entry to <var>entry list</var>.</p>
      </ul>
     <li data-md>
      <p>Return <var>entry list</var>.</p>
    </ol>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</dfn></p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-interpret-patch-map-entry">Interpret Patch Map Entry</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
@@ -2418,7 +2062,7 @@ being requested.</p>
     <li data-md>
      <p><var>entry id</var>: the last generated numeric or string id of this entry.</p>
     <li data-md>
-     <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①⓪">entry</a>.</p>
+     <p><var>entry</var>: a single <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑤">entry</a>.</p>
     <li data-md>
      <p><var>consumed bytes</var>: the number of bytes used to encode the entry.</p>
     <li data-md>
@@ -2436,7 +2080,7 @@ being requested.</p>
     <li data-md>
      <p>Set the patch format of <var>entry</var> to <var>default patch format</var>.</p>
     <li data-md>
-     <p>Add a single <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a> to <var>entry</var> with all sets initialized to be empty.</p>
+     <p>Add a single <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑧">font subset definition</a> to <var>entry</var> with all sets initialized to be empty.</p>
     <li data-md>
      <p>Read <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags①⓪">formatFlags</a> from <var>entry bytes</var>.</p>
     <li data-md>
@@ -2444,10 +2088,10 @@ being requested.</p>
      <ul>
       <li data-md>
        <p>Read the feature tag list specified by <a data-link-type="dfn" href="#mapping-entry-featurecount" id="ref-for-mapping-entry-featurecount">featureCount</a> and <a data-link-type="dfn" href="#mapping-entry-featuretags" id="ref-for-mapping-entry-featuretags">featureTags</a> from <var>entry bytes</var>
-and add the loaded tags to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a> in <var>entry</var>.</p>
+and add the loaded tags to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition⑨">font subset definition</a> in <var>entry</var>.</p>
       <li data-md>
        <p>Read the design space segment list specified by <a data-link-type="dfn" href="#mapping-entry-designspacecount" id="ref-for-mapping-entry-designspacecount">designSpaceCount</a> and <a data-link-type="dfn" href="#mapping-entry-designspacesegments" id="ref-for-mapping-entry-designspacesegments">designSpaceSegments</a>
-from <var>entry bytes</var> and add the design space segments to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> in <var>entry</var>. Each
+from <var>entry bytes</var> and add the design space segments to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⓪">font subset definition</a> in <var>entry</var>. Each
 segment defines an interval from <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start">start</a> to <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end">end</a> inclusive for the axis identified
 by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-space-segment-tag">tag</a>. If any segment has a <a data-link-type="dfn" href="#design-space-segment-start" id="ref-for-design-space-segment-start①">start</a> which is greater than
 <a data-link-type="dfn" href="#design-space-segment-end" id="ref-for-design-space-segment-end①">end</a> then, this encoding is invalid return an error.</p>
@@ -2479,7 +2123,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Set <var>entry id</var> to <code><var>entry id</var> + 1 + floor(delta value / 2)</code>.
  If <var>entry id</var> is negative or greater than 4,294,967,295 then, this encoding is invalid return an error.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template③">Expand URL Template</a> with <var>url template</var>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template">Expand URL Template</a> with <var>url template</var>
  and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
@@ -2495,7 +2139,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
          <p>Interpret the least significant 23 bits as an unsigned integer and read that many bytes from <var>id string bytes</var>.
  Set <var>entry id</var> to the result. Increment <var>consumed id string bytes</var> by the number of bytes read.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template④">Expand URL Template</a> with <var>url template</var>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template①">Expand URL Template</a> with <var>url template</var>
  and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
@@ -2512,7 +2156,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
         <li data-md>
          <p>Set <var>entry id</var> to <var>entry id</var> + 1.</p>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑤">Expand URL Template</a> with <var>url template</var>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template②">Expand URL Template</a> with <var>url template</var>
  and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
@@ -2521,7 +2165,7 @@ by <a data-link-type="dfn" href="#design-space-segment-tag" id="ref-for-design-s
        <p>Otherwise if <var>id string bytes</var> is present, then:</p>
        <ul>
         <li data-md>
-         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template⑥">Expand URL Template</a> with <var>url template</var>
+         <p>Convert <var>entry id</var> into a URL string by invoking <a data-link-type="abstract-op" href="#abstract-opdef-expand-url-template" id="ref-for-abstract-opdef-expand-url-template③">Expand URL Template</a> with <var>url template</var>
  and <var>entry id</var> as inputs. If the template expansion results in an error, then return an error.</p>
         <li data-md>
          <p>Add the generated patch URL string to <var>entry</var>.</p>
@@ -2544,8 +2188,8 @@ from <var>entry bytes</var>.</p>
       <li data-md>
        <p>Otherwise the bias is 0.</p>
       <li data-md>
-       <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codePoints</a> from <var>entry bytes</var> with bias following <a href="#sparse-bit-set-decoding">§ 5.3.2.3 Sparse Bit Set</a>.
-Add the resulting code point set to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①②">font subset definition</a> in <var>entry</var>. If the sparse bit set decoding
+       <p>Read the sparse bit set <a data-link-type="dfn" href="#mapping-entry-codepoints" id="ref-for-mapping-entry-codepoints">codePoints</a> from <var>entry bytes</var> with bias following <a href="#sparse-bit-set-decoding">§ 5.3.3 Sparse Bit Set</a>.
+Add the resulting code point set to the first <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①①">font subset definition</a> in <var>entry</var>. If the sparse bit set decoding
 failed then, this encoding is invalid return an error.</p>
      </ul>
     <li data-md>
@@ -2554,33 +2198,33 @@ failed then, this encoding is invalid return an error.</p>
      <p>Return <var>entry id</var>, <var>entry</var>, <var>consumed bytes</var>,
  <var>consumed id string bytes</var>, and <var>ignored</var>.</p>
    </ol>
-   <h5 class="algorithm client conform heading settled" data-algorithm="Remove Entries from Format 2" data-level="5.3.2.2" id="remove-entries-format-2"><span class="secno">5.3.2.2. </span><span class="content">Remove Entries from Format 2</span><a class="self-link" href="#remove-entries-format-2"></a></h5>
-   <p>This algorithm is used to remove entries from a format 2 patch map. This removal modifies the bytes of the patch map but does not
+   <h4 class="algorithm client conform heading settled" data-algorithm="Remove Entries from a Patch Map" data-level="5.3.2" id="remove-entries-patch-map"><span class="secno">5.3.2. </span><span class="content">Remove Entries from a Patch Map</span><a class="self-link" href="#remove-entries-patch-map"></a></h4>
+   <p>This algorithm is used to remove entries from a patch map. This removal modifies the bytes of the patch map but does not
 change the number of bytes.</p>
-   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</dfn></p>
+   <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-remove-entries-from-a-patch-map">Remove Entries from a Patch Map</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>patch map</var>: a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map①">Format 2 Patch Map</a> encoded patch map. May be modified by this procedure.</p>
+     <p><var>patch map</var>: a <a data-link-type="dfn" href="#patch-map-table-encoding" id="ref-for-patch-map-table-encoding①">Patch Map Table</a>. May be modified by this procedure.</p>
     <li data-md>
      <p><var>patch URL string</var>: URL string for a patch which identifies the entries to be removed.</p>
    </ul>
-   <p>This algorithm is a modified version of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map①">Interpret Format 2 Patch Map</a>, invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map②">Interpret Format 2 Patch Map</a> with <var>patch map</var>
+   <p>This algorithm is a modified version of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-patch-map" id="ref-for-abstract-opdef-interpret-patch-map①">Interpret Patch Map</a>, invoke <a data-link-type="abstract-op" href="#abstract-opdef-interpret-patch-map" id="ref-for-abstract-opdef-interpret-patch-map②">Interpret Patch Map</a> with <var>patch map</var>
 as an input but with the following changes:</p>
    <ul>
     <li data-md>
-     <p>During step 8 and 9 of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map-entry" id="ref-for-abstract-opdef-interpret-format-2-patch-map-entry②">Interpret Format 2 Patch Map Entry</a>: compare the URL string generated for only the first delta/length value to
+     <p>During step 8 and 9 of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-patch-map-entry" id="ref-for-abstract-opdef-interpret-patch-map-entry②">Interpret Patch Map Entry</a>: compare the URL string generated for only the first delta/length value to
 <var>patch URL string</var> if they are equal then, set bit 6 of  <a data-link-type="dfn" href="#mapping-entry-formatflags" id="ref-for-mapping-entry-formatflags②⓪">formatFlags</a> to 1. Stop the interpretation process
 at this point.</p>
     <li data-md>
-     <p>The return value of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-format-2-patch-map" id="ref-for-abstract-opdef-interpret-format-2-patch-map③">Interpret Format 2 Patch Map</a> is not used.</p>
+     <p>The return value of <a data-link-type="abstract-op" href="#abstract-opdef-interpret-patch-map" id="ref-for-abstract-opdef-interpret-patch-map③">Interpret Patch Map</a> is not used.</p>
    </ul>
-   <h5 class="algorithm client conform heading settled" data-algorithm="Sparse Bit Set" data-level="5.3.2.3" id="sparse-bit-set-decoding"><span class="secno">5.3.2.3. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h5>
+   <h4 class="algorithm client conform heading settled" data-algorithm="Sparse Bit Set" data-level="5.3.3" id="sparse-bit-set-decoding"><span class="secno">5.3.3. </span><span class="content">Sparse Bit Set</span><a class="self-link" href="#sparse-bit-set-decoding"></a></h4>
    <p>A sparse bit set is a data structure which compactly stores a set of distinct unsigned integers. The set is represented as a tree where
 each node has a fixed number of children that recursively sub-divides an interval into equal partitions. A tree of height <i>H</i> with
 branching factor <i>B</i> can store set membership for integers in the interval [0 to <i>B</i><sup><i>H</i></sup>-1] inclusive. The tree
 is encoded into an array of bytes for transport.</p>
-   <p>In the context of a <a data-link-type="dfn" href="#format-2-patch-map" id="ref-for-format-2-patch-map②">Format 2 Patch Map</a> a sparse bit set is used to store a set of <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">Unicode</a> code points. As such integer
+   <p>In the context of a <a data-link-type="dfn" href="#patch-map-table-encoding" id="ref-for-patch-map-table-encoding②">Patch Map Table</a> a sparse bit set is used to store a set of <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">Unicode</a> code points. As such integer
 values stored in a sparse bit set are restricted to being <a data-link-type="biblio" href="#biblio-unicode" title="The Unicode Standard">Unicode</a> code point values in the range 0 to 0x10FFFF.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sparse-bit-set">Sparse Bit Set</dfn> encoding:</p>
    <table>
@@ -2748,7 +2392,7 @@ byte string:
 ]
 </pre>
    </div>
-   <h4 class="algorithm client conform heading settled" data-algorithm="URL Templates" data-level="5.3.3" id="url-templates"><span class="secno">5.3.3. </span><span class="content">URL Templates</span><a class="self-link" href="#url-templates"></a></h4>
+   <h4 class="algorithm client conform heading settled" data-algorithm="URL Templates" data-level="5.3.4" id="url-templates"><span class="secno">5.3.4. </span><span class="content">URL Templates</span><a class="self-link" href="#url-templates"></a></h4>
    <p>URL templates are used to compress the URL strings associated with each patch map entry. Each patch mapping table
 provides a URL template and then the URL string for each entry is produced by expanding the common template using
 each entry’s ID as an input. The output of template expansion is a <a data-link-type="biblio" href="#biblio-utf-8" title="UTF-8, a transformation format of ISO 10646">[UTF-8]</a> encoded string.</p>
@@ -2787,7 +2431,7 @@ expansion is finished, return <var>URL string</var>.</p>
        <p>Read the next <var>number of literals</var> bytes from <var>url template bytes</var> into <var>literal bytes</var>.
  If there are not enough remaining bytes in <var>url template bytes</var>, then return an error.</p>
       <li data-md>
-       <p>Check that <var>literal bytes</var> is a valid UTF-8 encoded string according to <a href="https://www.rfc-editor.org/rfc/rfc3629#section-4">UTF-8, a transformation format of ISO 10646 § section-4</a>.
+       <p>Check that <var>literal bytes</var> is a valid UTF-8 encoded string according to <a href="https://www.rfc-editor.org/info/rfc3629/#section-4">UTF-8, a transformation format of ISO 10646 § section-4</a>.
  If it is not, then return an error.</p>
       <li data-md>
        <p>Append <var>literal bytes</var> to the end of <var>URL string</var>.</p>
@@ -2857,7 +2501,7 @@ expansion is finished, return <var>URL string</var>.</p>
      <tr>
       <td><var>id32</var>
       <td>
-      The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a> string (using the digits 0-9, A-V) with padding
+      The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/info/rfc4648/#section-7">base32hex</a> string (using the digits 0-9, A-V) with padding
       omitted.  <span class="client conform" id="conform-entry-id-must-be-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big endian 32 bit unsigned integer,
       but then all leading bytes that are equal to 0 are removed before encoding.</span>  (For example, when the
       integer is less than 256 only one byte is encoded.) If <var>entry ID</var> is 0 then one zero byte is encoded. When
@@ -2890,13 +2534,13 @@ expansion is finished, return <var>URL string</var>.</p>
      <tr>
       <td><var>id64</var>
       <td>
-      The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a> string (using the digits A-Z, a-z, 0-9, -
+      The input <var>entry ID</var> encoded as a <a href="https://www.rfc-editor.org/info/rfc4648/#section-5">base64url</a> string (using the digits A-Z, a-z, 0-9, -
       (minus) and _ (underline)) with padding included. <span class="client conform" id="conform-equal-sign-encoded">Because the padding character is '=', it must
       be URL-encoded as '%3D'.</span>  <span class="client conform" id="conform-entry-id-converted">When <var>entry ID</var> is an unsigned integer it must first be converted to a big
       endian 32 bit unsigned integer, but then all leading bytes that are equal to 0 are removed before encoding.</span>
       (For example, when the integer is less than 256 only one byte is encoded.) If the <var>entry ID</var> is 0 then one
       zero byte is encoded. When the <var>entry ID</var> is a string its raw bytes are encoded as
-      <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>.
+      <a href="https://www.rfc-editor.org/info/rfc4648/#section-5">base64url</a>.
     
    </table>
    <div class="example" id="example-305f10ca">
@@ -2998,14 +2642,14 @@ expansion is finished, return <var>URL string</var>.</p>
     </table>
    </div>
    <h2 class="heading settled" data-level="6" id="font-patch-formats"><span class="secno">6. </span><span class="content">Font Patch Formats</span><a class="self-link" href="#font-patch-formats"></a></h2>
-   <p>In incremental font transfer <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subsets</a> are extended by applying patches.
+   <p>In incremental font transfer <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⓪">font subsets</a> are extended by applying patches.
 This specification defines two patch formats, each appropriate to its own set of augmentation scenarios. A single
 encoding can make use of more than one patch format.</p>
    <h3 class="heading settled" data-level="6.1" id="font-patch-formats-summary"><span class="secno">6.1. </span><span class="content">Formats Summary</span><a class="self-link" href="#font-patch-formats-summary"></a></h3>
    <p>The following patch formats are defined by this specification:</p>
    <ul>
     <li data-md>
-     <p><a href="#table-keyed">§ 6.2 Table Keyed</a>: a collection of brotli encoded binary diffs that use tables from a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a> as bases.</p>
+     <p><a href="#table-keyed">§ 6.2 Table Keyed</a>: a collection of brotli encoded binary diffs that use tables from a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①①">font subset</a> as bases.</p>
     <li data-md>
      <p><a href="#glyph-keyed">§ 6.3 Glyph Keyed</a>: a collection of opaque binary blobs, each associated with a glyph id and table.</p>
    </ul>
@@ -3036,7 +2680,7 @@ encoding can make use of more than one patch format.</p>
 <a data-link-type="biblio" href="#biblio-rfc7932" title="Brotli Compressed Data Format">brotli compression</a> using the corresponding table from the input font file as a
 <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15#section-3.2">shared LZ77 dictionary</a>. A table keyed encoded patch consists of a short header followed
 by one or more brotli encoded patches. In addition to patching tables, patches may also replace (existing table data is not used)
-or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a>.</p>
+or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①②">font subset</a>.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="table-keyed-patch">Table keyed patch</dfn> encoding:</p>
    <table>
     <tbody>
@@ -3055,7 +2699,7 @@ or remove tables in a <a data-link-type="dfn" href="#font-subset" id="ref-for-fo
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Table keyed patch" data-dfn-type="dfn" data-noexport id="table-keyed-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
+      <td>The id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①③">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint16
       <td>patchesCount
@@ -3092,13 +2736,13 @@ of that <a data-link-type="dfn" href="#tablepatch" id="ref-for-tablepatch①">Ta
       <td>Brotli encoded byte stream.
    </table>
    <h4 class="algorithm client conform heading settled" data-algorithm="Applying Table Keyed Patches" data-level="6.2.1" id="apply-table-keyed"><span class="secno">6.2.1. </span><span class="content">Applying Table Keyed Patches</span><a class="self-link" href="#apply-table-keyed"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a table keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> to cover additional code points,
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm">patch application algorithm</a> is used to apply a table keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①④">font subset</a> to cover additional code points,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-table-keyed-patch">Apply table keyed patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑤">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#table-keyed-patch" id="ref-for-table-keyed-patch">table keyed patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -3107,7 +2751,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑥">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -3186,7 +2830,7 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Glyph keyed patch" data-dfn-type="dfn" data-noexport id="glyph-keyed-patch-compatibilityid">compatibilityId</dfn>[4]
-      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
+      <td>The compatibility id of the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑦">font subset</a> which this patch can be applied too. See <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a>.
      <tr>
       <td>uint32
       <td><dfn class="dfn-paneled" data-dfn-for="Glyph keyed patch" data-dfn-type="dfn" data-noexport id="glyph-keyed-patch-maxuncompressedlength">maxUncompressedLength</dfn>
@@ -3246,13 +2890,13 @@ the entries processed in step 5, add a copy of that table to <var>extended font 
    <p>The difference between two consecutive offsets in the <a data-link-type="dfn" href="#glyphpatches-glyphdataoffsets" id="ref-for-glyphpatches-glyphdataoffsets">glyphDataOffsets</a> array gives the size
 of that glyph data.</p>
    <h4 class="algorithm client conform heading settled" data-algorithm="Applying Glyph Keyed Patches" data-level="6.3.1" id="apply-glyph-keyed"><span class="secno">6.3.1. </span><span class="content">Applying Glyph Keyed Patches</span><a class="self-link" href="#apply-glyph-keyed"></a></h4>
-   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm①">patch application algorithm</a> is used to apply a glyph keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> to cover additional code points,
+   <p>This <a data-link-type="dfn" href="#patch-application-algorithm" id="ref-for-patch-application-algorithm①">patch application algorithm</a> is used to apply a glyph keyed patch to extend a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑧">font subset</a> to cover additional code points,
 features, and/or design-variation space.</p>
    <p><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</dfn></p>
    <p>The inputs to this algorithm are:</p>
    <ul>
     <li data-md>
-     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> which is to be extended.</p>
+     <p><var>base font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset①⑨">font subset</a> which is to be extended.</p>
     <li data-md>
      <p><var>patch</var>: a <a data-link-type="dfn" href="#glyph-keyed-patch" id="ref-for-glyph-keyed-patch">glyph keyed patch</a> to be applied to <var>base font subset</var>.</p>
     <li data-md>
@@ -3263,7 +2907,7 @@ features, and/or design-variation space.</p>
    <p>The algorithm outputs:</p>
    <ul>
     <li data-md>
-     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a> that has been extended by the <var>patch</var>.</p>
+     <p><var>extended font subset</var>: a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②⓪">font subset</a> that has been extended by the <var>patch</var>.</p>
    </ul>
    <p>The algorithm:</p>
    <ol>
@@ -3310,10 +2954,8 @@ failed. Return an error.</p>
        <p>Insert the synthesized table into <var>extended font subset</var>.</p>
      </ul>
     <li data-md>
-     <p>Locate the <a href="#patch-map-table">§ 5.3 Patch Map Table</a> which has the same <a data-link-type="dfn" href="#glyph-keyed-patch-compatibilityid" id="ref-for-glyph-keyed-patch-compatibilityid①">compatibilityId</a> as <var>compatibility id</var>. If it is a
-format 1 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-1-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a> with the patch map table and <var>patch URL string</var> as an
-input. Otherwise if it is a format 2 patch map then, invoke <a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-format-2-patch-map" id="ref-for-abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a> with the patch map table and
-<var>patch URL string</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.</p>
+     <p>Locate the <a href="#patch-map-table">§ 5.3 Patch Map Table</a> which has the same <a data-link-type="dfn" href="#glyph-keyed-patch-compatibilityid" id="ref-for-glyph-keyed-patch-compatibilityid①">compatibilityId</a> as <var>compatibility id</var>. Invoke
+<a data-link-type="abstract-op" href="#abstract-opdef-remove-entries-from-a-patch-map" id="ref-for-abstract-opdef-remove-entries-from-a-patch-map">Remove Entries from a Patch Map</a> with the patch map table and <var>patch URL string</var> as an input. Copy the modified patch map table into <var>extended font subset</var>.</p>
     <li data-md>
      <p>For each <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/otff#table-directory">table</a> in <var>base font subset</var> which has a tag that was not found in any of
 the entries processed in step 4 or 5, add a copy of that table to <var>extended font subset</var>.</p>
@@ -3331,13 +2973,13 @@ The <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-fon
     <li data-md>
      <p><span class="conform encoder" id="conform-encoding-must-meet-extensions-format">Must meet all of the requirements in <a href="#font-format-extensions">§ 5 Extensions to the Font Format</a> and <a href="#font-patch-formats">§ 6 Font Patch Formats</a>.</span></p>
     <li data-md>
-     <p><span class="conform encoder" id="conform-encoding-must-be-consistent">Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①⓪">Extend an Incremental Font Subset</a>
+     <p><span class="conform encoder" id="conform-encoding-must-be-consistent">Must be consistent, that is: for any possible <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①②">font subset definition</a> the result of invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①⓪">Extend an Incremental Font Subset</a>
 with that subset definition and the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①①">incremental font</a> must always be the same regardless of the particular order
 of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①①">Extend an Incremental Font Subset</a>.</span></p>
     <li data-md>
-     <p><span class="conform encoder" id="conform-encoding-must-respect-patch-invalidation-criteria">Must respect patch invalidation criteria.</span> <span class="conform encoder" id="conform-encoding-only-alter-compatibility-ids">Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a>
- must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map①⓪">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
- for the invalidation mode declared by the associated <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries①①">patch map entries</a>.</span></p>
+     <p><span class="conform encoder" id="conform-encoding-must-respect-patch-invalidation-criteria">Must respect patch invalidation criteria.</span> <span class="conform encoder" id="conform-encoding-only-alter-compatibility-ids">Any patch which is part of an IFT encoding when applied to a compatible <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②①">font subset</a>
+ must only make changes to the <a data-link-type="dfn" href="#patch-map" id="ref-for-patch-map⑨">patch map</a> compatibility IDs which are compliant with the <a href="#font-patch-invalidations">§ 4.1 Patch Invalidations</a> criteria
+ for the invalidation mode declared by the associated <a data-link-type="dfn" href="#patch-map-entries" id="ref-for-patch-map-entries⑥">patch map entries</a>.</span></p>
     <li data-md>
      <p>When an encoder is used to transform an existing font into an <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①②">incremental font</a> the associated
  <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset①">fully expanded font</a> should be equivalent to the existing font. An equivalent fully expanded font
@@ -3347,7 +2989,7 @@ of patch selection chosen in step 8 of <a data-link-type="abstract-op" href="#ab
     <li data-md>
      <p>Should preserve the functionality of the fully expanded font throughout the augmentation process, that is:
  given the <a data-link-type="abstract-op" href="#abstract-opdef-fully-expand-a-font-subset" id="ref-for-abstract-opdef-fully-expand-a-font-subset②">fully expanded font</a> derived from the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①③">incremental font</a>
- and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①②">Extend an Incremental Font Subset</a> with the
+ and any content, then the <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②②">font subset</a> produced by invoking <a data-link-type="abstract-op" href="#abstract-opdef-extend-an-incremental-font-subset" id="ref-for-abstract-opdef-extend-an-incremental-font-subset①②">Extend an Incremental Font Subset</a> with the
  <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①④">incremental font</a> and the minimal subset definition covering that content should
  render identically to the fully expanded font for that content.</p>
    </ol>
@@ -3483,7 +3125,7 @@ The next two subsections discuss maintaining functional equivalent using the dif
    <p>When preparing <a href="#table-keyed">§ 6.2 Table Keyed</a> patches, one means of achieving functional equivalence is to leverage an
 existing font subsetter implementation to produce font subsets that retain the functionality of the original font. The IFT patches
 can then be derived from these subsets.</p>
-   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②④">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①④">font subset definition</a>. The practice of reliably
+   <p>A font subsetter produces a <a data-link-type="dfn" href="#font-subset" id="ref-for-font-subset②③">font subset</a> from an input font based on a desired <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①③">font subset definition</a>. The practice of reliably
 subsetting a font is well understood and has multiple open-source implementations (a full formal description is
 beyond the scope of this document). It typically involves a reachability analysis, where the data in tables is examined
 relative to the font subset definition to see which portions can be reached by any possible content covered by the subset definition.
@@ -3529,17 +3171,17 @@ sections.</p>
    <p>Specifically because they are parameterized by code points and feature tags but can be applied independently of one another,
 <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches have additional requirements and cannot be directly derived by using a subsetter implementation.  However,
 such an implementation can help clarify what an encoder needs to do to maintain functional equivalence when producing this type
-of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑤">font subset definition</a>. We can define
-the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a> as the full set of glyphs included in the subset, which the
+of patch. Consider the result of producing the subset of a font relative to a given <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①④">font subset definition</a>. We can define
+the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="glyph-closure">glyph closure</dfn> of that <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑤">font subset definition</a> as the full set of glyphs included in the subset, which the
 subsetter has determined is needed to render any combination of the described code points and layout features.</p>
    <p>Using that definition, the <b>glyph closure requirement</b> on the full set <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches is:</p>
    <ul>
     <li data-md>
-     <p>The set of glyphs contained in the patches loaded for a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑦">font subset definition</a> through the patch map tables must be a superset
-of those in the <a data-link-type="dfn" href="#glyph-closure" id="ref-for-glyph-closure">glyph closure</a> of the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑧">font subset definition</a>.</p>
+     <p>The set of glyphs contained in the patches loaded for a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑥">font subset definition</a> through the patch map tables must be a superset
+of those in the <a data-link-type="dfn" href="#glyph-closure" id="ref-for-glyph-closure">glyph closure</a> of the <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑦">font subset definition</a>.</p>
    </ul>
    <p>Assuming the subsetter does its job accurately, the glyph closure requirement is a consequence of the requirement for equivalent
-behavior: Suppose there is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑨">font subset definition</a> such that the subsetter includes glyph *i* in its subset, but an encoder that
+behavior: Suppose there is a <a data-link-type="dfn" href="#font-subset-definition" id="ref-for-font-subset-definition①⑧">font subset definition</a> such that the subsetter includes glyph *i* in its subset, but an encoder that
 produces <a href="#glyph-keyed">§ 6.3 Glyph Keyed</a> patches omits glyph *i* from the set of patches that correspond to that definition. If the subsetter is
 right, that glyph must be present to retain equivalent behavior when rendering some combination of the code points and features in 
 the definition, which means that the <a data-link-type="dfn" href="#incremental-font" id="ref-for-incremental-font①⑨">incremental font</a> will not behave equivalently when rendering that combination.</p>
@@ -3557,7 +3199,7 @@ when loading the patches for two or more segments.  There are five main strategi
     <li data-md>
      <p>The common glyphs can be placed in their own patch and then mapping entries set up to trigger the load of that common patch along side
  any of the segments that will need it. For example if 'c' is a common segment needed by segments 'a' and 'b' then, you could
- have the following mapping entries (via a format 2 mapping table):</p>
+ have the following mapping entries:</p>
      <ul>
       <li data-md>
        <p>subset definition a → segment a</p>
@@ -3570,7 +3212,7 @@ when loading the patches for two or more segments.  There are five main strategi
      <p>In some cases, such as with <a href="https://learn.microsoft.com/en-us/typography/opentype/spec/cmap#format-14-unicode-variation-sequences">Unicode variation selectors</a>, there will be a
  modifier code point which triggers a glyph substitution when paired with many other code points. Given the large number of alternate
  glyphs it’s desirable to keep them in their own patches which are only loaded when both the modifier code point and appropriate base
- code point(s) are present. This can be achieved by using a <a href="#patch-map-format-2">Format 2 Patch Map</a> and multiple entry matching
+ code point(s) are present. This can be achieved by using multiple entry matching
  via <a data-link-type="dfn" href="#mapping-entry-childentryindices" id="ref-for-mapping-entry-childentryindices③">childEntryIndices</a>. See <a href="#appendix-b-example-2">Example 2: Glyph Keyed Patches with Child Entries</a> for an example of how this can be set up.</p>
     <li data-md>
      <p>Alternatively, the glyph can be included in more than one of the patches that correspond to those segments at the cost of duplicating
@@ -3605,11 +3247,11 @@ patch mapping prior to receiving all of the font data and potentially initiate r
 in any order in the patch file. So for the same reasons encoders should consider placing updates to the mapping tables plus any
 additional tables needed to decode the mapping tables as early as possible in the patch file.</p>
    <p><b>Choosing the input ID encoding</b></p>
-   <p>The specification supports two encodings for embedding patch IDs in the URL template. The first is <a href="https://www.rfc-editor.org/rfc/rfc4648#section-7">base32hex</a>,
+   <p>The specification supports two encodings for embedding patch IDs in the URL template. The first is <a href="https://www.rfc-editor.org/info/rfc4648/#section-7">base32hex</a>,
 which is a good match for pre-generated patches that will typically be stored in a filesystem. Base32hex encoding only uses the
 letters 0-9 and A-V, which are safe letters for a file name in every commonly used filesystem, with no risk of collisions due to
 case-insensitivity. Because the string is embedded without padding this format cannot be reliably decoded, so it may be a poor
-choice for dynamically generated patches. The other encoding is <a href="https://www.rfc-editor.org/rfc/rfc4648#section-5">base64url</a>, a variant of base64 encoding
+choice for dynamically generated patches. The other encoding is <a href="https://www.rfc-editor.org/info/rfc4648/#section-5">base64url</a>, a variant of base64 encoding
 appropriate for embedding in a URL or case-sensitive filesystem. When using this encoding the id is embedded with padding so that
 the value can be reliably decoded.</p>
    <p>The individual character selectors d1 through d4 are relative to the base32hex encoded id only. These are typically used to
@@ -4450,119 +4092,77 @@ content covered by the target subset definition.</p>
   <h2 class="heading no-num no-ref settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="heading no-num no-ref settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#format-1-patch-map-appliedentriesbitmap">appliedEntriesBitMap</a><span>, in § 5.3.1</span>
    <li><a href="#abstract-opdef-apply-glyph-keyed-patch">Apply glyph keyed patch</a><span>, in § 6.3.1</span>
    <li><a href="#abstract-opdef-apply-table-keyed-patch">Apply table keyed patch</a><span>, in § 6.2.1</span>
-   <li><a href="#mapping-entry-bias">bias</a><span>, in § 5.3.2</span>
-   <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 5.3.2.3</span>
+   <li><a href="#mapping-entry-bias">bias</a><span>, in § 5.3</span>
+   <li><a href="#branch-factor-encoding">Branch Factor Encoding</a><span>, in § 5.3.3</span>
    <li>
     brotliStream
     <ul>
      <li><a href="#glyph-keyed-patch-brotlistream">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
      <li><a href="#tablepatch-brotlistream">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
-   <li>
-    cff2CharStringsOffset
-    <ul>
-     <li><a href="#format-1-patch-map-cff2charstringsoffset">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#format-2-patch-map-cff2charstringsoffset">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
-    </ul>
-   <li>
-    cffCharStringsOffset
-    <ul>
-     <li><a href="#format-1-patch-map-cffcharstringsoffset">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#format-2-patch-map-cffcharstringsoffset">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
-    </ul>
+   <li><a href="#patch-map-table-cff2charstringsoffset">cff2CharStringsOffset</a><span>, in § 5.3</span>
+   <li><a href="#patch-map-table-cffcharstringsoffset">cffCharStringsOffset</a><span>, in § 5.3</span>
    <li><a href="#abstract-opdef-check-entry-intersection">Check entry intersection</a><span>, in § 4.3</span>
-   <li><a href="#mapping-entry-childentryindices">childEntryIndices</a><span>, in § 5.3.2</span>
-   <li><a href="#mapping-entry-childentrymatchmodeandcount">childEntryMatchModeAndCount</a><span>, in § 5.3.2</span>
-   <li><a href="#mapping-entry-codepoints">codePoints</a><span>, in § 5.3.2</span>
+   <li><a href="#mapping-entry-childentryindices">childEntryIndices</a><span>, in § 5.3</span>
+   <li><a href="#mapping-entry-childentrymatchmodeandcount">childEntryMatchModeAndCount</a><span>, in § 5.3</span>
+   <li><a href="#mapping-entry-codepoints">codePoints</a><span>, in § 5.3</span>
    <li>
     compatibilityId
     <ul>
-     <li><a href="#format-1-patch-map-compatibilityid">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#format-2-patch-map-compatibilityid">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
      <li><a href="#glyph-keyed-patch-compatibilityid">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
+     <li><a href="#patch-map-table-compatibilityid">dfn for Patch Map Table</a><span>, in § 5.3</span>
      <li><a href="#table-keyed-patch-compatibilityid">dfn for Table keyed patch</a><span>, in § 6.2</span>
     </ul>
-   <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 5.3.2.3</span>
-   <li><a href="#format-2-patch-map-defaultpatchformat">defaultPatchFormat</a><span>, in § 5.3.2</span>
-   <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 5.3.2</span>
-   <li><a href="#design-space-segment">Design Space Segment</a><span>, in § 5.3.2</span>
-   <li><a href="#mapping-entry-designspacesegments">designSpaceSegments</a><span>, in § 5.3.2</span>
-   <li><a href="#design-space-segment-end">end</a><span>, in § 5.3.2</span>
+   <li><a href="#abstract-opdef-decoding-sparse-bit-set-treedata">Decoding sparse bit set treeData</a><span>, in § 5.3.3</span>
+   <li><a href="#patch-map-table-defaultpatchformat">defaultPatchFormat</a><span>, in § 5.3</span>
+   <li><a href="#mapping-entry-designspacecount">designSpaceCount</a><span>, in § 5.3</span>
+   <li><a href="#design-space-segment">Design Space Segment</a><span>, in § 5.3</span>
+   <li><a href="#mapping-entry-designspacesegments">designSpaceSegments</a><span>, in § 5.3</span>
+   <li><a href="#design-space-segment-end">end</a><span>, in § 5.3</span>
    <li>
     entries
     <ul>
-     <li><a href="#format-2-patch-map-entries">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
-     <li><a href="#mapping-entries-entries">dfn for Mapping Entries</a><span>, in § 5.3.2</span>
+     <li><a href="#mapping-entries-entries">dfn for Mapping Entries</a><span>, in § 5.3</span>
+     <li><a href="#patch-map-table-entries">dfn for Patch Map Table</a><span>, in § 5.3</span>
     </ul>
-   <li><a href="#format-2-patch-map-entrycount">entryCount</a><span>, in § 5.3.2</span>
-   <li><a href="#mapping-entry-entryiddelta">entryIdDelta</a><span>, in § 5.3.2</span>
-   <li><a href="#format-2-patch-map-entryidstringdata">entryIdStringData</a><span>, in § 5.3.2</span>
-   <li><a href="#mapping-entry-entryidstringlength">entryIdStringLength</a><span>, in § 5.3.2</span>
-   <li><a href="#glyph-map-entryindex">entryIndex</a><span>, in § 5.3.1</span>
-   <li><a href="#featurerecord-entrymapcount">entryMapCount</a><span>, in § 5.3.1</span>
-   <li><a href="#entrymaprecord">EntryMapRecord</a><span>, in § 5.3.1</span>
-   <li><a href="#feature-map-entrymaprecords">entryMapRecords</a><span>, in § 5.3.1</span>
-   <li><a href="#abstract-opdef-expand-url-template">Expand URL Template</a><span>, in § 5.3.3</span>
+   <li><a href="#patch-map-table-entrycount">entryCount</a><span>, in § 5.3</span>
+   <li><a href="#mapping-entry-entryiddelta">entryIdDelta</a><span>, in § 5.3</span>
+   <li><a href="#patch-map-table-entryidstringdata">entryIdStringData</a><span>, in § 5.3</span>
+   <li><a href="#mapping-entry-entryidstringlength">entryIdStringLength</a><span>, in § 5.3</span>
+   <li><a href="#abstract-opdef-expand-url-template">Expand URL Template</a><span>, in § 5.3.4</span>
    <li><a href="#abstract-opdef-extend-an-incremental-font-subset">Extend an Incremental Font Subset</a><span>, in § 4.3</span>
-   <li><a href="#mapping-entry-featurecount">featureCount</a><span>, in § 5.3.2</span>
-   <li><a href="#feature-map">Feature Map</a><span>, in § 5.3.1</span>
-   <li><a href="#format-1-patch-map-featuremapoffset">featureMapOffset</a><span>, in § 5.3.1</span>
-   <li><a href="#featurerecord">FeatureRecord</a><span>, in § 5.3.1</span>
-   <li><a href="#feature-map-featurerecords">featureRecords</a><span>, in § 5.3.1</span>
-   <li><a href="#featurerecord-featuretag">featureTag</a><span>, in § 5.3.1</span>
-   <li><a href="#mapping-entry-featuretags">featureTags</a><span>, in § 5.3.2</span>
-   <li><a href="#entrymaprecord-firstentryindex">firstEntryIndex</a><span>, in § 5.3.1</span>
-   <li><a href="#glyph-map-firstmappedglyph">firstMappedGlyph</a><span>, in § 5.3.1</span>
-   <li><a href="#featurerecord-firstnewentryindex">firstNewEntryIndex</a><span>, in § 5.3.1</span>
+   <li><a href="#mapping-entry-featurecount">featureCount</a><span>, in § 5.3</span>
+   <li><a href="#mapping-entry-featuretags">featureTags</a><span>, in § 5.3</span>
    <li>
     flags
     <ul>
-     <li><a href="#format-1-patch-map-flags">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#format-2-patch-map-flags">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
      <li><a href="#glyph-keyed-patch-flags">dfn for Glyph keyed patch</a><span>, in § 6.3</span>
+     <li><a href="#patch-map-table-flags">dfn for Patch Map Table</a><span>, in § 5.3</span>
      <li><a href="#tablepatch-flags">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
    <li><a href="#font-patch">font patch</a><span>, in § 3.2</span>
    <li><a href="#font-subset">font subset</a><span>, in § 3.1</span>
    <li><a href="#font-subset-definition">font subset definition</a><span>, in § 3.1</span>
-   <li>
-    format
-    <ul>
-     <li><a href="#format-1-patch-map-format">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#format-2-patch-map-format">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
-    </ul>
-   <li><a href="#format-1-patch-map">Format 1 Patch Map</a><span>, in § 5.3.1</span>
-   <li><a href="#format-2-patch-map">Format 2 Patch Map</a><span>, in § 5.3.2</span>
-   <li><a href="#mapping-entry-formatflags">formatFlags</a><span>, in § 5.3.2</span>
+   <li><a href="#patch-map-table-format">format</a><span>, in § 5.3</span>
+   <li><a href="#mapping-entry-formatflags">formatFlags</a><span>, in § 5.3</span>
    <li><a href="#full-invalidation">Full Invalidation</a><span>, in § 4.1</span>
    <li><a href="#abstract-opdef-fully-expand-a-font-subset">Fully Expand a Font Subset</a><span>, in § 4.7</span>
    <li><a href="#glyph-closure">glyph closure</a><span>, in § 7.1</span>
-   <li>
-    glyphCount
-    <ul>
-     <li><a href="#format-1-patch-map-glyphcount">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#glyphpatches-glyphcount">dfn for GlyphPatches</a><span>, in § 6.3</span>
-    </ul>
+   <li><a href="#glyphpatches-glyphcount">glyphCount</a><span>, in § 6.3</span>
    <li><a href="#glyphpatches-glyphdata">glyphData</a><span>, in § 6.3</span>
    <li><a href="#glyphpatches-glyphdataoffsets">glyphDataOffsets</a><span>, in § 6.3</span>
    <li><a href="#glyphpatches-glyphids">glyphIds</a><span>, in § 6.3</span>
    <li><a href="#glyph-keyed-patch">Glyph keyed patch</a><span>, in § 6.3</span>
-   <li><a href="#glyph-map">Glyph Map</a><span>, in § 5.3.1</span>
    <li><a href="#glyphpatches">GlyphPatches</a><span>, in § 6.3</span>
    <li><a href="#abstract-opdef-handle-errors">Handle errors</a><span>, in § 4.3</span>
    <li><a href="#incremental-font">incremental font</a><span>, in § 1.2</span>
-   <li><a href="#abstract-opdef-interpret-format-1-patch-map">Interpret Format 1 Patch Map</a><span>, in § 5.3.1.1</span>
-   <li><a href="#abstract-opdef-interpret-format-2-patch-map">Interpret Format 2 Patch Map</a><span>, in § 5.3.2.1</span>
-   <li><a href="#abstract-opdef-interpret-format-2-patch-map-entry">Interpret Format 2 Patch Map Entry</a><span>, in § 5.3.2.1</span>
-   <li><a href="#entrymaprecord-lastentryindex">lastEntryIndex</a><span>, in § 5.3.1</span>
+   <li><a href="#abstract-opdef-interpret-patch-map">Interpret Patch Map</a><span>, in § 5.3.1</span>
+   <li><a href="#abstract-opdef-interpret-patch-map-entry">Interpret Patch Map Entry</a><span>, in § 5.3.1</span>
    <li><a href="#abstract-opdef-load-patch-file">Load patch file</a><span>, in § 4.3</span>
-   <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 5.3.2</span>
-   <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 5.3.2</span>
-   <li><a href="#format-1-patch-map-maxentryindex">maxEntryIndex</a><span>, in § 5.3.1</span>
-   <li><a href="#format-1-patch-map-maxglyphmapentryindex">maxGlyphMapEntryIndex</a><span>, in § 5.3.1</span>
+   <li><a href="#mapping-entries">Mapping Entries</a><span>, in § 5.3</span>
+   <li><a href="#mapping-entry">Mapping Entry</a><span>, in § 5.3</span>
    <li>
     maxUncompressedLength
     <ul>
@@ -4574,34 +4174,24 @@ content covered by the target subset definition.</p>
    <li><a href="#patch-application-algorithm">patch application algorithm</a><span>, in § 3.2</span>
    <li><a href="#table-keyed-patch-patches">patches</a><span>, in § 6.2</span>
    <li><a href="#patch-format">patch format</a><span>, in § 3.2</span>
-   <li>
-    patchFormat
-    <ul>
-     <li><a href="#format-1-patch-map-patchformat">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#mapping-entry-patchformat">dfn for Mapping Entry</a><span>, in § 5.3.2</span>
-    </ul>
+   <li><a href="#mapping-entry-patchformat">patchFormat</a><span>, in § 5.3</span>
    <li><a href="#patch-map">patch map</a><span>, in § 3.3</span>
    <li><a href="#patch-map-entries">patch map entries</a><span>, in § 3.3</span>
-   <li><a href="#abstract-opdef-remove-entries-from-format-1-patch-map">Remove Entries from Format 1 Patch Map</a><span>, in § 5.3.1.2</span>
-   <li><a href="#abstract-opdef-remove-entries-from-format-2-patch-map">Remove Entries from Format 2 Patch Map</a><span>, in § 5.3.2.2</span>
+   <li><a href="#patch-map-table-encoding">Patch Map Table</a><span>, in § 5.3</span>
+   <li><a href="#abstract-opdef-remove-entries-from-a-patch-map">Remove Entries from a Patch Map</a><span>, in § 5.3.2</span>
    <li><a href="#shaping-unit">shaping unit</a><span>, in § 4.5</span>
-   <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.3.2.3</span>
-   <li><a href="#design-space-segment-start">start</a><span>, in § 5.3.2</span>
+   <li><a href="#sparse-bit-set">Sparse Bit Set</a><span>, in § 5.3.3</span>
+   <li><a href="#design-space-segment-start">start</a><span>, in § 5.3</span>
    <li><a href="#table-keyed-patch">Table keyed patch</a><span>, in § 6.2</span>
    <li><a href="#tablepatch">TablePatch</a><span>, in § 6.2</span>
    <li><a href="#glyphpatches-tables">tables</a><span>, in § 6.3</span>
    <li>
     tag
     <ul>
-     <li><a href="#design-space-segment-tag">dfn for Design Space Segment</a><span>, in § 5.3.2</span>
+     <li><a href="#design-space-segment-tag">dfn for Design Space Segment</a><span>, in § 5.3</span>
      <li><a href="#tablepatch-tag">dfn for TablePatch</a><span>, in § 6.2</span>
     </ul>
-   <li>
-    urlTemplate
-    <ul>
-     <li><a href="#format-1-patch-map-urltemplate">dfn for Format 1 Patch Map</a><span>, in § 5.3.1</span>
-     <li><a href="#format-2-patch-map-urltemplate">dfn for Format 2 Patch Map</a><span>, in § 5.3.2</span>
-    </ul>
+   <li><a href="#patch-map-table-urltemplate">urlTemplate</a><span>, in § 5.3</span>
   </ul>
   <h3 class="heading no-num no-ref settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
@@ -4643,15 +4233,15 @@ content covered by the target subset definition.</p>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-rfc4648">[RFC4648]
-   <dd>S. Josefsson. <a href="https://www.rfc-editor.org/rfc/rfc4648"><cite>The Base16, Base32, and Base64 Data Encodings</cite></a>. October 2006. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc4648">https://www.rfc-editor.org/rfc/rfc4648</a>
+   <dd>S. Josefsson. <a href="https://www.rfc-editor.org/info/rfc4648/"><cite>The Base16, Base32, and Base64 Data Encodings</cite></a>. October 2006. Proposed Standard. URL: <a href="https://www.rfc-editor.org/info/rfc4648/">https://www.rfc-editor.org/info/rfc4648/</a>
    <dt id="biblio-rfc7932">[RFC7932]
-   <dd>J. Alakuijala; Z. Szabadka. <a href="https://www.rfc-editor.org/rfc/rfc7932"><cite>Brotli Compressed Data Format</cite></a>. July 2016. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc7932">https://www.rfc-editor.org/rfc/rfc7932</a>
+   <dd>J. Alakuijala; Z. Szabadka. <a href="https://www.rfc-editor.org/info/rfc7932/"><cite>Brotli Compressed Data Format</cite></a>. July 2016. Informational. URL: <a href="https://www.rfc-editor.org/info/rfc7932/">https://www.rfc-editor.org/info/rfc7932/</a>
    <dt id="biblio-shared-brotli">[Shared-Brotli]
    <dd>J. Alakuijala; et al. <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15"><cite>Shared Brotli Compressed Data Format</cite></a>. Feb 2025. Internet Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15">https://datatracker.ietf.org/doc/html/draft-vandevenne-shared-brotli-format-15</a>
    <dt id="biblio-unicode">[UNICODE]
    <dd><a href="https://www.unicode.org/versions/latest/"><cite>The Unicode Standard</cite></a>. URL: <a href="https://www.unicode.org/versions/latest/">https://www.unicode.org/versions/latest/</a>
    <dt id="biblio-utf-8">[UTF-8]
-   <dd>F. Yergeau. <a href="https://www.rfc-editor.org/rfc/rfc3629"><cite>UTF-8, a transformation format of ISO 10646</cite></a>. November 2003. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3629">https://www.rfc-editor.org/rfc/rfc3629</a>
+   <dd>F. Yergeau. <a href="https://www.rfc-editor.org/info/rfc3629/"><cite>UTF-8, a transformation format of ISO 10646</cite></a>. November 2003. Internet Standard. URL: <a href="https://www.rfc-editor.org/info/rfc3629/">https://www.rfc-editor.org/info/rfc3629/</a>
    <dt id="biblio-whatwg-url">[WHATWG-URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-woff2">[WOFF2]
@@ -4883,60 +4473,24 @@ let dfnPanelData = {
 "abstract-opdef-apply-table-keyed-patch": {"dfnID":"abstract-opdef-apply-table-keyed-patch","dfnText":"Apply table keyed patch","external":false,"refSections":[],"url":"#abstract-opdef-apply-table-keyed-patch"},
 "abstract-opdef-check-entry-intersection": {"dfnID":"abstract-opdef-check-entry-intersection","dfnText":"Check entry intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2461"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2462"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2463"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2464"}],"title":"Example 1: Table and Glyph Keyed Patches"},{"refs":[{"id":"ref-for-abstract-opdef-check-entry-intersection\u2465"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2466"},{"id":"ref-for-abstract-opdef-check-entry-intersection\u2467"}],"title":"Example 2: Glyph Keyed Patches with Child Entries"}],"url":"#abstract-opdef-check-entry-intersection"},
 "abstract-opdef-decoding-sparse-bit-set-treedata": {"dfnID":"abstract-opdef-decoding-sparse-bit-set-treedata","dfnText":"Decoding sparse bit set treeData","external":false,"refSections":[],"url":"#abstract-opdef-decoding-sparse-bit-set-treedata"},
-"abstract-opdef-expand-url-template": {"dfnID":"abstract-opdef-expand-url-template","dfnText":"Expand URL Template","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-expand-url-template"},{"id":"ref-for-abstract-opdef-expand-url-template\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-abstract-opdef-expand-url-template\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"},{"refs":[{"id":"ref-for-abstract-opdef-expand-url-template\u2462"},{"id":"ref-for-abstract-opdef-expand-url-template\u2463"},{"id":"ref-for-abstract-opdef-expand-url-template\u2464"},{"id":"ref-for-abstract-opdef-expand-url-template\u2465"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#abstract-opdef-expand-url-template"},
+"abstract-opdef-expand-url-template": {"dfnID":"abstract-opdef-expand-url-template","dfnText":"Expand URL Template","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-expand-url-template"},{"id":"ref-for-abstract-opdef-expand-url-template\u2460"},{"id":"ref-for-abstract-opdef-expand-url-template\u2461"},{"id":"ref-for-abstract-opdef-expand-url-template\u2462"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#abstract-opdef-expand-url-template"},
 "abstract-opdef-extend-an-incremental-font-subset": {"dfnID":"abstract-opdef-extend-an-incremental-font-subset","dfnText":"Extend an Incremental Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2461"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2462"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2463"}],"title":"4.5. Target Subset Definition"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2464"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2465"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2466"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2467"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2468"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u24ea"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u2460"},{"id":"ref-for-abstract-opdef-extend-an-incremental-font-subset\u2460\u2461"}],"title":"7. Encoding"}],"url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "abstract-opdef-fully-expand-a-font-subset": {"dfnID":"abstract-opdef-fully-expand-a-font-subset","dfnText":"Fully Expand a Font Subset","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset"}],"title":"2.1. Offline Usage"},{"refs":[{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2460"},{"id":"ref-for-abstract-opdef-fully-expand-a-font-subset\u2461"}],"title":"7. Encoding"}],"url":"#abstract-opdef-fully-expand-a-font-subset"},
 "abstract-opdef-handle-errors": {"dfnID":"abstract-opdef-handle-errors","dfnText":"Handle errors","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-handle-errors"},{"id":"ref-for-abstract-opdef-handle-errors\u2460"},{"id":"ref-for-abstract-opdef-handle-errors\u2461"},{"id":"ref-for-abstract-opdef-handle-errors\u2462"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-handle-errors"},
-"abstract-opdef-interpret-format-1-patch-map": {"dfnID":"abstract-opdef-interpret-format-1-patch-map","dfnText":"Interpret Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-1-patch-map"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"#abstract-opdef-interpret-format-1-patch-map"},
-"abstract-opdef-interpret-format-2-patch-map": {"dfnID":"abstract-opdef-interpret-format-2-patch-map","dfnText":"Interpret Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2460"},{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2461"},{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map\u2462"}],"title":"5.3.2.2. Remove Entries from Format 2"}],"url":"#abstract-opdef-interpret-format-2-patch-map"},
-"abstract-opdef-interpret-format-2-patch-map-entry": {"dfnID":"abstract-opdef-interpret-format-2-patch-map-entry","dfnText":"Interpret Format 2 Patch Map Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2460"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-format-2-patch-map-entry\u2461"}],"title":"5.3.2.2. Remove Entries from Format 2"}],"url":"#abstract-opdef-interpret-format-2-patch-map-entry"},
+"abstract-opdef-interpret-patch-map": {"dfnID":"abstract-opdef-interpret-patch-map","dfnText":"Interpret Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-patch-map"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-patch-map\u2460"},{"id":"ref-for-abstract-opdef-interpret-patch-map\u2461"},{"id":"ref-for-abstract-opdef-interpret-patch-map\u2462"}],"title":"5.3.2. Remove Entries from a Patch Map"}],"url":"#abstract-opdef-interpret-patch-map"},
+"abstract-opdef-interpret-patch-map-entry": {"dfnID":"abstract-opdef-interpret-patch-map-entry","dfnText":"Interpret Patch Map Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-interpret-patch-map-entry"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-patch-map-entry\u2460"}],"title":"5.3.1. Interpreting a Patch Map"},{"refs":[{"id":"ref-for-abstract-opdef-interpret-patch-map-entry\u2461"}],"title":"5.3.2. Remove Entries from a Patch Map"}],"url":"#abstract-opdef-interpret-patch-map-entry"},
 "abstract-opdef-load-patch-file": {"dfnID":"abstract-opdef-load-patch-file","dfnText":"Load patch file","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file"},{"id":"ref-for-abstract-opdef-load-patch-file\u2460"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-abstract-opdef-load-patch-file\u2461"}],"title":"9. Security Considerations"}],"url":"#abstract-opdef-load-patch-file"},
-"abstract-opdef-remove-entries-from-format-1-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-1-patch-map","dfnText":"Remove Entries from Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-1-patch-map"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-1-patch-map"},
-"abstract-opdef-remove-entries-from-format-2-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-format-2-patch-map","dfnText":"Remove Entries from Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-format-2-patch-map"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-format-2-patch-map"},
-"branch-factor-encoding": {"dfnID":"branch-factor-encoding","dfnText":"Branch Factor Encoding","external":false,"refSections":[{"refs":[{"id":"ref-for-branch-factor-encoding"},{"id":"ref-for-branch-factor-encoding\u2460"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#branch-factor-encoding"},
+"abstract-opdef-remove-entries-from-a-patch-map": {"dfnID":"abstract-opdef-remove-entries-from-a-patch-map","dfnText":"Remove Entries from a Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-remove-entries-from-a-patch-map"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#abstract-opdef-remove-entries-from-a-patch-map"},
+"branch-factor-encoding": {"dfnID":"branch-factor-encoding","dfnText":"Branch Factor Encoding","external":false,"refSections":[{"refs":[{"id":"ref-for-branch-factor-encoding"},{"id":"ref-for-branch-factor-encoding\u2460"}],"title":"5.3.3. Sparse Bit Set"}],"url":"#branch-factor-encoding"},
 "cb98f71f": {"dfnID":"cb98f71f","dfnText":"mode","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-request-mode"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"https://fetch.spec.whatwg.org/#concept-request-mode"},
 "dc1cd39b": {"dfnID":"dc1cd39b","dfnText":"URL","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-request-url"}],"title":"4.3. Incremental Font Extension Algorithm"}],"url":"https://fetch.spec.whatwg.org/#concept-request-url"},
-"design-space-segment": {"dfnID":"design-space-segment","dfnText":"Design Space Segment","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#design-space-segment"},
-"design-space-segment-end": {"dfnID":"design-space-segment-end","dfnText":"end","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-end"},{"id":"ref-for-design-space-segment-end\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#design-space-segment-end"},
-"design-space-segment-start": {"dfnID":"design-space-segment-start","dfnText":"start","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-start"},{"id":"ref-for-design-space-segment-start\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#design-space-segment-start"},
-"design-space-segment-tag": {"dfnID":"design-space-segment-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-tag"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#design-space-segment-tag"},
-"entrymaprecord": {"dfnID":"entrymaprecord","dfnText":"EntryMapRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord"},{"id":"ref-for-entrymaprecord\u2460"}],"title":"5.3.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-entrymaprecord\u2461"},{"id":"ref-for-entrymaprecord\u2462"},{"id":"ref-for-entrymaprecord\u2463"},{"id":"ref-for-entrymaprecord\u2464"},{"id":"ref-for-entrymaprecord\u2465"},{"id":"ref-for-entrymaprecord\u2466"},{"id":"ref-for-entrymaprecord\u2467"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#entrymaprecord"},
-"entrymaprecord-firstentryindex": {"dfnID":"entrymaprecord-firstentryindex","dfnText":"firstEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-firstentryindex"},{"id":"ref-for-entrymaprecord-firstentryindex\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-firstentryindex"},
-"entrymaprecord-lastentryindex": {"dfnID":"entrymaprecord-lastentryindex","dfnText":"lastEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-entrymaprecord-lastentryindex"},{"id":"ref-for-entrymaprecord-lastentryindex\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#entrymaprecord-lastentryindex"},
-"feature-map": {"dfnID":"feature-map","dfnText":"Feature Map","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map"}],"title":"5.3.1. Patch Map Table: Format 1"}],"url":"#feature-map"},
-"feature-map-entrymaprecords": {"dfnID":"feature-map-entrymaprecords","dfnText":"entryMapRecords","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map-entrymaprecords"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#feature-map-entrymaprecords"},
-"feature-map-featurerecords": {"dfnID":"feature-map-featurerecords","dfnText":"featureRecords","external":false,"refSections":[{"refs":[{"id":"ref-for-feature-map-featurerecords"},{"id":"ref-for-feature-map-featurerecords\u2460"}],"title":"5.3.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-feature-map-featurerecords\u2461"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#feature-map-featurerecords"},
-"featurerecord": {"dfnID":"featurerecord","dfnText":"FeatureRecord","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord"}],"title":"5.3.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord\u2460"},{"id":"ref-for-featurerecord\u2461"},{"id":"ref-for-featurerecord\u2462"},{"id":"ref-for-featurerecord\u2463"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#featurerecord"},
-"featurerecord-entrymapcount": {"dfnID":"featurerecord-entrymapcount","dfnText":"entryMapCount","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-entrymapcount"}],"title":"5.3.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-entrymapcount\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#featurerecord-entrymapcount"},
-"featurerecord-featuretag": {"dfnID":"featurerecord-featuretag","dfnText":"featureTag","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-featuretag"}],"title":"5.3.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-featurerecord-featuretag\u2460"},{"id":"ref-for-featurerecord-featuretag\u2461"},{"id":"ref-for-featurerecord-featuretag\u2462"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#featurerecord-featuretag"},
-"featurerecord-firstnewentryindex": {"dfnID":"featurerecord-firstnewentryindex","dfnText":"firstNewEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-featurerecord-firstnewentryindex"},{"id":"ref-for-featurerecord-firstnewentryindex\u2460"},{"id":"ref-for-featurerecord-firstnewentryindex\u2461"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#featurerecord-firstnewentryindex"},
+"design-space-segment": {"dfnID":"design-space-segment","dfnText":"Design Space Segment","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment"}],"title":"5.3. Patch Map Table"}],"url":"#design-space-segment"},
+"design-space-segment-end": {"dfnID":"design-space-segment-end","dfnText":"end","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-end"},{"id":"ref-for-design-space-segment-end\u2460"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#design-space-segment-end"},
+"design-space-segment-start": {"dfnID":"design-space-segment-start","dfnText":"start","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-start"},{"id":"ref-for-design-space-segment-start\u2460"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#design-space-segment-start"},
+"design-space-segment-tag": {"dfnID":"design-space-segment-tag","dfnText":"tag","external":false,"refSections":[{"refs":[{"id":"ref-for-design-space-segment-tag"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#design-space-segment-tag"},
 "font-patch": {"dfnID":"font-patch","dfnText":"font patch","external":false,"refSections":[{"refs":[{"id":"ref-for-font-patch"},{"id":"ref-for-font-patch\u2460"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-patch\u2461"}],"title":"7. Encoding"}],"url":"#font-patch"},
-"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2462"},{"id":"ref-for-font-subset\u2460\u2463"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2464"},{"id":"ref-for-font-subset\u2460\u2465"},{"id":"ref-for-font-subset\u2460\u2466"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2467"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2468"},{"id":"ref-for-font-subset\u2461\u24ea"},{"id":"ref-for-font-subset\u2461\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2461"},{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
-"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2461"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"},{"id":"ref-for-font-subset-definition\u2463"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2466"},{"id":"ref-for-font-subset-definition\u2467"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2468"},{"id":"ref-for-font-subset-definition\u2460\u24ea"},{"id":"ref-for-font-subset-definition\u2460\u2460"},{"id":"ref-for-font-subset-definition\u2460\u2461"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2462"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"},{"id":"ref-for-font-subset-definition\u2460\u2466"},{"id":"ref-for-font-subset-definition\u2460\u2467"},{"id":"ref-for-font-subset-definition\u2460\u2468"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
-"format-1-patch-map": {"dfnID":"format-1-patch-map","dfnText":"Format 1 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map\u2460"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map"},
-"format-1-patch-map-appliedentriesbitmap": {"dfnID":"format-1-patch-map-appliedentriesbitmap","dfnText":"appliedEntriesBitMap","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2460"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2461"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2462"},{"id":"ref-for-format-1-patch-map-appliedentriesbitmap\u2463"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-appliedentriesbitmap"},
-"format-1-patch-map-cff2charstringsoffset": {"dfnID":"format-1-patch-map-cff2charstringsoffset","dfnText":"cff2CharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-cff2charstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-format-1-patch-map-cff2charstringsoffset\u2460"}],"title":"5.3.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-cff2charstringsoffset"},
-"format-1-patch-map-cffcharstringsoffset": {"dfnID":"format-1-patch-map-cffcharstringsoffset","dfnText":"cffCharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-cffcharstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-format-1-patch-map-cffcharstringsoffset\u2460"}],"title":"5.3.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-cffcharstringsoffset"},
-"format-1-patch-map-compatibilityid": {"dfnID":"format-1-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-compatibilityid"},{"id":"ref-for-format-1-patch-map-compatibilityid\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-compatibilityid"},
-"format-1-patch-map-featuremapoffset": {"dfnID":"format-1-patch-map-featuremapoffset","dfnText":"featureMapOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-featuremapoffset"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-featuremapoffset"},
-"format-1-patch-map-flags": {"dfnID":"format-1-patch-map-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-flags"},{"id":"ref-for-format-1-patch-map-flags\u2460"}],"title":"5.3.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-flags"},
-"format-1-patch-map-format": {"dfnID":"format-1-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-format"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-format\u2460"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-format"},
-"format-1-patch-map-glyphcount": {"dfnID":"format-1-patch-map-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-glyphcount"},{"id":"ref-for-format-1-patch-map-glyphcount\u2460"}],"title":"5.3.1. Patch Map Table: Format 1"}],"url":"#format-1-patch-map-glyphcount"},
-"format-1-patch-map-maxentryindex": {"dfnID":"format-1-patch-map-maxentryindex","dfnText":"maxEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2461"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2462"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2463"}],"title":"5.3.1. Patch Map Table: Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-maxentryindex\u2464"},{"id":"ref-for-format-1-patch-map-maxentryindex\u2465"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxentryindex"},
-"format-1-patch-map-maxglyphmapentryindex": {"dfnID":"format-1-patch-map-maxglyphmapentryindex","dfnText":"maxGlyphMapEntryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2460"},{"id":"ref-for-format-1-patch-map-maxglyphmapentryindex\u2461"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-maxglyphmapentryindex"},
-"format-1-patch-map-patchformat": {"dfnID":"format-1-patch-map-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-patchformat"},{"id":"ref-for-format-1-patch-map-patchformat\u2460"}],"title":"5.3.1.1. Interpreting Format 1"}],"url":"#format-1-patch-map-patchformat"},
-"format-1-patch-map-urltemplate": {"dfnID":"format-1-patch-map-urltemplate","dfnText":"urlTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-1-patch-map-urltemplate"},{"id":"ref-for-format-1-patch-map-urltemplate\u2460"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-format-1-patch-map-urltemplate\u2461"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#format-1-patch-map-urltemplate"},
-"format-2-patch-map": {"dfnID":"format-2-patch-map","dfnText":"Format 2 Patch Map","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2460"}],"title":"5.3.2.2. Remove Entries from Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map\u2461"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#format-2-patch-map"},
-"format-2-patch-map-cff2charstringsoffset": {"dfnID":"format-2-patch-map-cff2charstringsoffset","dfnText":"cff2CharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-cff2charstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-format-2-patch-map-cff2charstringsoffset\u2460"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#format-2-patch-map-cff2charstringsoffset"},
-"format-2-patch-map-cffcharstringsoffset": {"dfnID":"format-2-patch-map-cffcharstringsoffset","dfnText":"cffCharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-cffcharstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-format-2-patch-map-cffcharstringsoffset\u2460"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#format-2-patch-map-cffcharstringsoffset"},
-"format-2-patch-map-compatibilityid": {"dfnID":"format-2-patch-map-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-compatibilityid"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-compatibilityid"},
-"format-2-patch-map-defaultpatchformat": {"dfnID":"format-2-patch-map-defaultpatchformat","dfnText":"defaultPatchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-defaultpatchformat\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-defaultpatchformat"},
-"format-2-patch-map-entries": {"dfnID":"format-2-patch-map-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entries"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entries"},
-"format-2-patch-map-entrycount": {"dfnID":"format-2-patch-map-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entrycount"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entrycount\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entrycount"},
-"format-2-patch-map-entryidstringdata": {"dfnID":"format-2-patch-map-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2460"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2461"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2462"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2463"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-format-2-patch-map-entryidstringdata\u2464"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2465"},{"id":"ref-for-format-2-patch-map-entryidstringdata\u2466"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-entryidstringdata"},
-"format-2-patch-map-flags": {"dfnID":"format-2-patch-map-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-flags"},{"id":"ref-for-format-2-patch-map-flags\u2460"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#format-2-patch-map-flags"},
-"format-2-patch-map-format": {"dfnID":"format-2-patch-map-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-format"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-format"},
-"format-2-patch-map-urltemplate": {"dfnID":"format-2-patch-map-urltemplate","dfnText":"urlTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-format-2-patch-map-urltemplate"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#format-2-patch-map-urltemplate"},
+"font-subset": {"dfnID":"font-subset","dfnText":"font subset","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset"}],"title":"3.1. Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2460"},{"id":"ref-for-font-subset\u2461"},{"id":"ref-for-font-subset\u2462"},{"id":"ref-for-font-subset\u2463"}],"title":"3.2. Font Patch"},{"refs":[{"id":"ref-for-font-subset\u2464"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-font-subset\u2465"}],"title":"4.1. Patch Invalidations"},{"refs":[{"id":"ref-for-font-subset\u2466"},{"id":"ref-for-font-subset\u2467"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset\u2468"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-font-subset\u2460\u24ea"}],"title":"6. Font Patch Formats"},{"refs":[{"id":"ref-for-font-subset\u2460\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-font-subset\u2460\u2461"},{"id":"ref-for-font-subset\u2460\u2462"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2463"},{"id":"ref-for-font-subset\u2460\u2464"},{"id":"ref-for-font-subset\u2460\u2465"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2460\u2466"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-font-subset\u2460\u2467"},{"id":"ref-for-font-subset\u2460\u2468"},{"id":"ref-for-font-subset\u2461\u24ea"}],"title":"6.3.1. Applying Glyph Keyed Patches"},{"refs":[{"id":"ref-for-font-subset\u2461\u2460"},{"id":"ref-for-font-subset\u2461\u2461"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset\u2461\u2462"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset"},
+"font-subset-definition": {"dfnID":"font-subset-definition","dfnText":"font subset definition","external":false,"refSections":[{"refs":[{"id":"ref-for-font-subset-definition"},{"id":"ref-for-font-subset-definition\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2461"}],"title":"4.2. Default Layout Features"},{"refs":[{"id":"ref-for-font-subset-definition\u2462"},{"id":"ref-for-font-subset-definition\u2463"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-font-subset-definition\u2464"}],"title":"4.6. Determining what Content a Font can Render"},{"refs":[{"id":"ref-for-font-subset-definition\u2465"},{"id":"ref-for-font-subset-definition\u2466"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-font-subset-definition\u2467"},{"id":"ref-for-font-subset-definition\u2468"},{"id":"ref-for-font-subset-definition\u2460\u24ea"},{"id":"ref-for-font-subset-definition\u2460\u2460"}],"title":"5.3.1. Interpreting a Patch Map"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2461"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-font-subset-definition\u2460\u2462"},{"id":"ref-for-font-subset-definition\u2460\u2463"},{"id":"ref-for-font-subset-definition\u2460\u2464"},{"id":"ref-for-font-subset-definition\u2460\u2465"},{"id":"ref-for-font-subset-definition\u2460\u2466"},{"id":"ref-for-font-subset-definition\u2460\u2467"}],"title":"7.1. Encoding Considerations"}],"url":"#font-subset-definition"},
 "full-invalidation": {"dfnID":"full-invalidation","dfnText":"Full Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-full-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-full-invalidation\u2460"}],"title":"6.1. Formats Summary"}],"url":"#full-invalidation"},
 "glyph-closure": {"dfnID":"glyph-closure","dfnText":"glyph closure","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-closure"}],"title":"7.1. Encoding Considerations"}],"url":"#glyph-closure"},
 "glyph-keyed-patch": {"dfnID":"glyph-keyed-patch","dfnText":"Glyph keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch"},
@@ -4944,9 +4498,6 @@ let dfnPanelData = {
 "glyph-keyed-patch-compatibilityid": {"dfnID":"glyph-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-compatibilityid"},{"id":"ref-for-glyph-keyed-patch-compatibilityid\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-compatibilityid"},
 "glyph-keyed-patch-flags": {"dfnID":"glyph-keyed-patch-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-flags"}],"title":"6.3. Glyph Keyed"}],"url":"#glyph-keyed-patch-flags"},
 "glyph-keyed-patch-maxuncompressedlength": {"dfnID":"glyph-keyed-patch-maxuncompressedlength","dfnText":"maxUncompressedLength","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-keyed-patch-maxuncompressedlength"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyph-keyed-patch-maxuncompressedlength"},
-"glyph-map": {"dfnID":"glyph-map","dfnText":"Glyph Map","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map"},{"id":"ref-for-glyph-map\u2460"},{"id":"ref-for-glyph-map\u2461"}],"title":"5.3.1. Patch Map Table: Format 1"}],"url":"#glyph-map"},
-"glyph-map-entryindex": {"dfnID":"glyph-map-entryindex","dfnText":"entryIndex","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-entryindex"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-glyph-map-entryindex\u2460"}],"title":"5.3.1.2. Remove Entries from Format 1"}],"url":"#glyph-map-entryindex"},
-"glyph-map-firstmappedglyph": {"dfnID":"glyph-map-firstmappedglyph","dfnText":"firstMappedGlyph","external":false,"refSections":[{"refs":[{"id":"ref-for-glyph-map-firstmappedglyph"}],"title":"5.3.1. Patch Map Table: Format 1"}],"url":"#glyph-map-firstmappedglyph"},
 "glyphpatches": {"dfnID":"glyphpatches","dfnText":"GlyphPatches","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches"},{"id":"ref-for-glyphpatches\u2460"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches"},
 "glyphpatches-glyphcount": {"dfnID":"glyphpatches-glyphcount","dfnText":"glyphCount","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphcount"},{"id":"ref-for-glyphpatches-glyphcount\u2460"}],"title":"6.3. Glyph Keyed"}],"url":"#glyphpatches-glyphcount"},
 "glyphpatches-glyphdata": {"dfnID":"glyphpatches-glyphdata","dfnText":"glyphData","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphdata"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphdata"},
@@ -4954,29 +4505,40 @@ let dfnPanelData = {
 "glyphpatches-glyphids": {"dfnID":"glyphpatches-glyphids","dfnText":"glyphIds","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-glyphids"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-glyphids\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-glyphids"},
 "glyphpatches-tables": {"dfnID":"glyphpatches-tables","dfnText":"tables","external":false,"refSections":[{"refs":[{"id":"ref-for-glyphpatches-tables"},{"id":"ref-for-glyphpatches-tables\u2460"}],"title":"6.3. Glyph Keyed"},{"refs":[{"id":"ref-for-glyphpatches-tables\u2461"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#glyphpatches-tables"},
 "incremental-font": {"dfnID":"incremental-font","dfnText":"incremental font","external":false,"refSections":[{"refs":[{"id":"ref-for-incremental-font"}],"title":"1.2. Overview"},{"refs":[{"id":"ref-for-incremental-font\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-incremental-font\u2461"}],"title":"4. Extending a Font Subset"},{"refs":[{"id":"ref-for-incremental-font\u2462"},{"id":"ref-for-incremental-font\u2463"},{"id":"ref-for-incremental-font\u2464"},{"id":"ref-for-incremental-font\u2465"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-incremental-font\u2466"}],"title":"4.7. Fully Expanding a Font"},{"refs":[{"id":"ref-for-incremental-font\u2467"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-incremental-font\u2468"},{"id":"ref-for-incremental-font\u2460\u24ea"},{"id":"ref-for-incremental-font\u2460\u2460"},{"id":"ref-for-incremental-font\u2460\u2461"},{"id":"ref-for-incremental-font\u2460\u2462"},{"id":"ref-for-incremental-font\u2460\u2463"},{"id":"ref-for-incremental-font\u2460\u2464"}],"title":"7. Encoding"},{"refs":[{"id":"ref-for-incremental-font\u2460\u2465"},{"id":"ref-for-incremental-font\u2460\u2466"},{"id":"ref-for-incremental-font\u2460\u2467"},{"id":"ref-for-incremental-font\u2460\u2468"},{"id":"ref-for-incremental-font\u2461\u24ea"}],"title":"7.1. Encoding Considerations"}],"url":"#incremental-font"},
-"mapping-entries": {"dfnID":"mapping-entries","dfnText":"Mapping Entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#mapping-entries"},
-"mapping-entries-entries": {"dfnID":"mapping-entries-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries-entries"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2460"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2461"},{"id":"ref-for-mapping-entries-entries\u2462"}],"title":"5.3.2. Patch Map Table: Format 2"}],"url":"#mapping-entries-entries"},
-"mapping-entry": {"dfnID":"mapping-entry","dfnText":"Mapping Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry"},{"id":"ref-for-mapping-entry\u2460"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry\u2461"},{"id":"ref-for-mapping-entry\u2462"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry"},
-"mapping-entry-bias": {"dfnID":"mapping-entry-bias","dfnText":"bias","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-bias"},{"id":"ref-for-mapping-entry-bias\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-bias"},
-"mapping-entry-childentryindices": {"dfnID":"mapping-entry-childentryindices","dfnText":"childEntryIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-childentryindices"},{"id":"ref-for-mapping-entry-childentryindices\u2460"},{"id":"ref-for-mapping-entry-childentryindices\u2461"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-childentryindices\u2462"}],"title":"7.1. Encoding Considerations"}],"url":"#mapping-entry-childentryindices"},
-"mapping-entry-childentrymatchmodeandcount": {"dfnID":"mapping-entry-childentrymatchmodeandcount","dfnText":"childEntryMatchModeAndCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-childentrymatchmodeandcount"},{"id":"ref-for-mapping-entry-childentrymatchmodeandcount\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-childentrymatchmodeandcount"},
-"mapping-entry-codepoints": {"dfnID":"mapping-entry-codepoints","dfnText":"codePoints","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-codepoints"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-codepoints"},
-"mapping-entry-designspacecount": {"dfnID":"mapping-entry-designspacecount","dfnText":"designSpaceCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacecount"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacecount"},
-"mapping-entry-designspacesegments": {"dfnID":"mapping-entry-designspacesegments","dfnText":"designSpaceSegments","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacesegments"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-designspacesegments"},
-"mapping-entry-entryiddelta": {"dfnID":"mapping-entry-entryiddelta","dfnText":"entryIdDelta","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryiddelta"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-entryiddelta\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-entryiddelta"},
-"mapping-entry-entryidstringlength": {"dfnID":"mapping-entry-entryidstringlength","dfnText":"entryIdStringLength","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryidstringlength"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-entryidstringlength"},
-"mapping-entry-featurecount": {"dfnID":"mapping-entry-featurecount","dfnText":"featureCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featurecount"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featurecount"},
-"mapping-entry-featuretags": {"dfnID":"mapping-entry-featuretags","dfnText":"featureTags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featuretags"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-featuretags"},
-"mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2461\u24ea"}],"title":"5.3.2.2. Remove Entries from Format 2"}],"url":"#mapping-entry-formatflags"},
-"mapping-entry-patchformat": {"dfnID":"mapping-entry-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchformat"},{"id":"ref-for-mapping-entry-patchformat\u2460"}],"title":"5.3.2.1. Interpreting Format 2"}],"url":"#mapping-entry-patchformat"},
+"mapping-entries": {"dfnID":"mapping-entries","dfnText":"Mapping Entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries"}],"title":"5.3. Patch Map Table"}],"url":"#mapping-entries"},
+"mapping-entries-entries": {"dfnID":"mapping-entries-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entries-entries"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2460"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-mapping-entries-entries\u2461"},{"id":"ref-for-mapping-entries-entries\u2462"}],"title":"5.3. Patch Map Table"}],"url":"#mapping-entries-entries"},
+"mapping-entry": {"dfnID":"mapping-entry","dfnText":"Mapping Entry","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry"},{"id":"ref-for-mapping-entry\u2460"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-mapping-entry\u2461"},{"id":"ref-for-mapping-entry\u2462"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry"},
+"mapping-entry-bias": {"dfnID":"mapping-entry-bias","dfnText":"bias","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-bias"},{"id":"ref-for-mapping-entry-bias\u2460"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-bias"},
+"mapping-entry-childentryindices": {"dfnID":"mapping-entry-childentryindices","dfnText":"childEntryIndices","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-childentryindices"},{"id":"ref-for-mapping-entry-childentryindices\u2460"},{"id":"ref-for-mapping-entry-childentryindices\u2461"}],"title":"5.3.1. Interpreting a Patch Map"},{"refs":[{"id":"ref-for-mapping-entry-childentryindices\u2462"}],"title":"7.1. Encoding Considerations"}],"url":"#mapping-entry-childentryindices"},
+"mapping-entry-childentrymatchmodeandcount": {"dfnID":"mapping-entry-childentrymatchmodeandcount","dfnText":"childEntryMatchModeAndCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-childentrymatchmodeandcount"},{"id":"ref-for-mapping-entry-childentrymatchmodeandcount\u2460"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-childentrymatchmodeandcount"},
+"mapping-entry-codepoints": {"dfnID":"mapping-entry-codepoints","dfnText":"codePoints","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-codepoints"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-codepoints"},
+"mapping-entry-designspacecount": {"dfnID":"mapping-entry-designspacecount","dfnText":"designSpaceCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacecount"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-designspacecount"},
+"mapping-entry-designspacesegments": {"dfnID":"mapping-entry-designspacesegments","dfnText":"designSpaceSegments","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-designspacesegments"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-designspacesegments"},
+"mapping-entry-entryiddelta": {"dfnID":"mapping-entry-entryiddelta","dfnText":"entryIdDelta","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryiddelta"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-mapping-entry-entryiddelta\u2460"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-entryiddelta"},
+"mapping-entry-entryidstringlength": {"dfnID":"mapping-entry-entryidstringlength","dfnText":"entryIdStringLength","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-entryidstringlength"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-entryidstringlength"},
+"mapping-entry-featurecount": {"dfnID":"mapping-entry-featurecount","dfnText":"featureCount","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featurecount"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-featurecount"},
+"mapping-entry-featuretags": {"dfnID":"mapping-entry-featuretags","dfnText":"featureTags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-featuretags"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-featuretags"},
+"mapping-entry-formatflags": {"dfnID":"mapping-entry-formatflags","dfnText":"formatFlags","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-formatflags"},{"id":"ref-for-mapping-entry-formatflags\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2468"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2460\u24ea"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2460"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2461"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2462"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2463"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2464"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2465"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2466"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2467"},{"id":"ref-for-mapping-entry-formatflags\u2460\u2468"}],"title":"5.3.1. Interpreting a Patch Map"},{"refs":[{"id":"ref-for-mapping-entry-formatflags\u2461\u24ea"}],"title":"5.3.2. Remove Entries from a Patch Map"}],"url":"#mapping-entry-formatflags"},
+"mapping-entry-patchformat": {"dfnID":"mapping-entry-patchformat","dfnText":"patchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-mapping-entry-patchformat"},{"id":"ref-for-mapping-entry-patchformat\u2460"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#mapping-entry-patchformat"},
 "no-invalidation": {"dfnID":"no-invalidation","dfnText":"No Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-no-invalidation"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-no-invalidation\u2460"}],"title":"7.1. Encoding Considerations"}],"url":"#no-invalidation"},
 "partial-invalidation": {"dfnID":"partial-invalidation","dfnText":"Partial Invalidation","external":false,"refSections":[{"refs":[{"id":"ref-for-partial-invalidation"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-partial-invalidation\u2460"}],"title":"6.1. Formats Summary"},{"refs":[{"id":"ref-for-partial-invalidation\u2461"},{"id":"ref-for-partial-invalidation\u2462"},{"id":"ref-for-partial-invalidation\u2463"}],"title":"7.1. Encoding Considerations"}],"url":"#partial-invalidation"},
 "patch-application-algorithm": {"dfnID":"patch-application-algorithm","dfnText":"patch application algorithm","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-application-algorithm"}],"title":"6.2.1. Applying Table Keyed Patches"},{"refs":[{"id":"ref-for-patch-application-algorithm\u2460"}],"title":"6.3.1. Applying Glyph Keyed Patches"}],"url":"#patch-application-algorithm"},
 "patch-format": {"dfnID":"patch-format","dfnText":"patch format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-format"},{"id":"ref-for-patch-format\u2460"}],"title":"3.2. Font Patch"}],"url":"#patch-format"},
-"patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"},{"id":"ref-for-patch-map\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-patch-map\u2464"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2465"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-patch-map\u2466"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2467"},{"id":"ref-for-patch-map\u2468"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map\u2460\u24ea"}],"title":"7. Encoding"}],"url":"#patch-map"},
-"patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"},{"id":"ref-for-patch-map-entries\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2462"},{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"},{"id":"ref-for-patch-map-entries\u2465"},{"id":"ref-for-patch-map-entries\u2466"}],"title":"5.3.1.1. Interpreting Format 1"},{"refs":[{"id":"ref-for-patch-map-entries\u2467"},{"id":"ref-for-patch-map-entries\u2468"},{"id":"ref-for-patch-map-entries\u2460\u24ea"}],"title":"5.3.2.1. Interpreting Format 2"},{"refs":[{"id":"ref-for-patch-map-entries\u2460\u2460"}],"title":"7. Encoding"}],"url":"#patch-map-entries"},
+"patch-map": {"dfnID":"patch-map","dfnText":"patch map","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2460"},{"id":"ref-for-patch-map\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map\u2462"},{"id":"ref-for-patch-map\u2463"}],"title":"4.4. Selecting Invalidating Patches"},{"refs":[{"id":"ref-for-patch-map\u2464"}],"title":"5. Extensions to the Font Format"},{"refs":[{"id":"ref-for-patch-map\u2465"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-patch-map\u2466"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map\u2467"}],"title":"5.3.1. Interpreting a Patch Map"},{"refs":[{"id":"ref-for-patch-map\u2468"}],"title":"7. Encoding"}],"url":"#patch-map"},
+"patch-map-entries": {"dfnID":"patch-map-entries","dfnText":"patch map entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-entries"},{"id":"ref-for-patch-map-entries\u2460"}],"title":"3.3. Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2461"}],"title":"4.3. Incremental Font Extension Algorithm"},{"refs":[{"id":"ref-for-patch-map-entries\u2462"},{"id":"ref-for-patch-map-entries\u2463"},{"id":"ref-for-patch-map-entries\u2464"}],"title":"5.3.1. Interpreting a Patch Map"},{"refs":[{"id":"ref-for-patch-map-entries\u2465"}],"title":"7. Encoding"}],"url":"#patch-map-entries"},
+"patch-map-table-cff2charstringsoffset": {"dfnID":"patch-map-table-cff2charstringsoffset","dfnText":"cff2CharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-cff2charstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-patch-map-table-cff2charstringsoffset\u2460"}],"title":"5.3. Patch Map Table"}],"url":"#patch-map-table-cff2charstringsoffset"},
+"patch-map-table-cffcharstringsoffset": {"dfnID":"patch-map-table-cffcharstringsoffset","dfnText":"cffCharStringsOffset","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-cffcharstringsoffset"}],"title":"5.2. CFF and CFF2 Incremental Fonts"},{"refs":[{"id":"ref-for-patch-map-table-cffcharstringsoffset\u2460"}],"title":"5.3. Patch Map Table"}],"url":"#patch-map-table-cffcharstringsoffset"},
+"patch-map-table-compatibilityid": {"dfnID":"patch-map-table-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-compatibilityid"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#patch-map-table-compatibilityid"},
+"patch-map-table-defaultpatchformat": {"dfnID":"patch-map-table-defaultpatchformat","dfnText":"defaultPatchFormat","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-defaultpatchformat"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map-table-defaultpatchformat\u2460"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#patch-map-table-defaultpatchformat"},
+"patch-map-table-encoding": {"dfnID":"patch-map-table-encoding","dfnText":"Patch Map Table","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-encoding"}],"title":"5.3.1. Interpreting a Patch Map"},{"refs":[{"id":"ref-for-patch-map-table-encoding\u2460"}],"title":"5.3.2. Remove Entries from a Patch Map"},{"refs":[{"id":"ref-for-patch-map-table-encoding\u2461"}],"title":"5.3.3. Sparse Bit Set"}],"url":"#patch-map-table-encoding"},
+"patch-map-table-entries": {"dfnID":"patch-map-table-entries","dfnText":"entries","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-entries"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#patch-map-table-entries"},
+"patch-map-table-entrycount": {"dfnID":"patch-map-table-entrycount","dfnText":"entryCount","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-entrycount"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map-table-entrycount\u2460"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#patch-map-table-entrycount"},
+"patch-map-table-entryidstringdata": {"dfnID":"patch-map-table-entryidstringdata","dfnText":"entryIdStringData","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-entryidstringdata"},{"id":"ref-for-patch-map-table-entryidstringdata\u2460"},{"id":"ref-for-patch-map-table-entryidstringdata\u2461"},{"id":"ref-for-patch-map-table-entryidstringdata\u2462"},{"id":"ref-for-patch-map-table-entryidstringdata\u2463"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-patch-map-table-entryidstringdata\u2464"},{"id":"ref-for-patch-map-table-entryidstringdata\u2465"},{"id":"ref-for-patch-map-table-entryidstringdata\u2466"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#patch-map-table-entryidstringdata"},
+"patch-map-table-flags": {"dfnID":"patch-map-table-flags","dfnText":"flags","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-flags"},{"id":"ref-for-patch-map-table-flags\u2460"}],"title":"5.3. Patch Map Table"}],"url":"#patch-map-table-flags"},
+"patch-map-table-format": {"dfnID":"patch-map-table-format","dfnText":"format","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-format"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#patch-map-table-format"},
+"patch-map-table-urltemplate": {"dfnID":"patch-map-table-urltemplate","dfnText":"urlTemplate","external":false,"refSections":[{"refs":[{"id":"ref-for-patch-map-table-urltemplate"}],"title":"5.3.1. Interpreting a Patch Map"}],"url":"#patch-map-table-urltemplate"},
 "shaping-unit": {"dfnID":"shaping-unit","dfnText":"shaping unit","external":false,"refSections":[{"refs":[{"id":"ref-for-shaping-unit"},{"id":"ref-for-shaping-unit\u2460"},{"id":"ref-for-shaping-unit\u2461"}],"title":"4.6. Determining what Content a Font can Render"}],"url":"#shaping-unit"},
-"sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.3.2. Patch Map Table: Format 2"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.3.2.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
+"sparse-bit-set": {"dfnID":"sparse-bit-set","dfnText":"Sparse Bit Set","external":false,"refSections":[{"refs":[{"id":"ref-for-sparse-bit-set"}],"title":"5.3. Patch Map Table"},{"refs":[{"id":"ref-for-sparse-bit-set\u2460"}],"title":"5.3.3. Sparse Bit Set"}],"url":"#sparse-bit-set"},
 "table-keyed-patch": {"dfnID":"table-keyed-patch","dfnText":"Table keyed patch","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch"},
 "table-keyed-patch-compatibilityid": {"dfnID":"table-keyed-patch-compatibilityid","dfnText":"compatibilityId","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-compatibilityid"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-compatibilityid"},
 "table-keyed-patch-patches": {"dfnID":"table-keyed-patch-patches","dfnText":"patches","external":false,"refSections":[{"refs":[{"id":"ref-for-table-keyed-patch-patches"}],"title":"6.2. Table Keyed"},{"refs":[{"id":"ref-for-table-keyed-patch-patches\u2460"},{"id":"ref-for-table-keyed-patch-patches\u2461"},{"id":"ref-for-table-keyed-patch-patches\u2462"},{"id":"ref-for-table-keyed-patch-patches\u2463"},{"id":"ref-for-table-keyed-patch-patches\u2464"}],"title":"6.2.1. Applying Table Keyed Patches"}],"url":"#table-keyed-patch-patches"},
@@ -5378,54 +4940,18 @@ let refsData = {
 "#abstract-opdef-extend-an-incremental-font-subset": {"displayText":"Extend an Incremental Font Subset","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Extend an Incremental Font Subset","type":"abstract-op","url":"#abstract-opdef-extend-an-incremental-font-subset"},
 "#abstract-opdef-fully-expand-a-font-subset": {"displayText":"Fully Expand a Font Subset","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Fully Expand a Font Subset","type":"abstract-op","url":"#abstract-opdef-fully-expand-a-font-subset"},
 "#abstract-opdef-handle-errors": {"displayText":"Handle errors","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Handle errors","type":"abstract-op","url":"#abstract-opdef-handle-errors"},
-"#abstract-opdef-interpret-format-1-patch-map": {"displayText":"Interpret Format 1 Patch Map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Interpret Format 1 Patch Map","type":"abstract-op","url":"#abstract-opdef-interpret-format-1-patch-map"},
-"#abstract-opdef-interpret-format-2-patch-map": {"displayText":"Interpret Format 2 Patch Map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Interpret Format 2 Patch Map","type":"abstract-op","url":"#abstract-opdef-interpret-format-2-patch-map"},
-"#abstract-opdef-interpret-format-2-patch-map-entry": {"displayText":"Interpret Format 2 Patch Map Entry","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Interpret Format 2 Patch Map Entry","type":"abstract-op","url":"#abstract-opdef-interpret-format-2-patch-map-entry"},
+"#abstract-opdef-interpret-patch-map": {"displayText":"Interpret Patch Map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Interpret Patch Map","type":"abstract-op","url":"#abstract-opdef-interpret-patch-map"},
+"#abstract-opdef-interpret-patch-map-entry": {"displayText":"Interpret Patch Map Entry","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Interpret Patch Map Entry","type":"abstract-op","url":"#abstract-opdef-interpret-patch-map-entry"},
 "#abstract-opdef-load-patch-file": {"displayText":"Load patch file","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Load patch file","type":"abstract-op","url":"#abstract-opdef-load-patch-file"},
-"#abstract-opdef-remove-entries-from-format-1-patch-map": {"displayText":"Remove Entries from Format 1 Patch Map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Remove Entries from Format 1 Patch Map","type":"abstract-op","url":"#abstract-opdef-remove-entries-from-format-1-patch-map"},
-"#abstract-opdef-remove-entries-from-format-2-patch-map": {"displayText":"Remove Entries from Format 2 Patch Map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Remove Entries from Format 2 Patch Map","type":"abstract-op","url":"#abstract-opdef-remove-entries-from-format-2-patch-map"},
+"#abstract-opdef-remove-entries-from-a-patch-map": {"displayText":"Remove Entries from a Patch Map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"Remove Entries from a Patch Map","type":"abstract-op","url":"#abstract-opdef-remove-entries-from-a-patch-map"},
 "#branch-factor-encoding": {"displayText":"branch factor encoding","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"branch factor encoding","type":"dfn","url":"#branch-factor-encoding"},
 "#design-space-segment": {"displayText":"design space segment","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"design space segment","type":"dfn","url":"#design-space-segment"},
 "#design-space-segment-end": {"displayText":"end","export":true,"for_":["Design Space Segment"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"end","type":"dfn","url":"#design-space-segment-end"},
 "#design-space-segment-start": {"displayText":"start","export":true,"for_":["Design Space Segment"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"start","type":"dfn","url":"#design-space-segment-start"},
 "#design-space-segment-tag": {"displayText":"tag","export":true,"for_":["Design Space Segment"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"tag","type":"dfn","url":"#design-space-segment-tag"},
-"#entrymaprecord": {"displayText":"entrymaprecord","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrymaprecord","type":"dfn","url":"#entrymaprecord"},
-"#entrymaprecord-firstentryindex": {"displayText":"firstentryindex","export":true,"for_":["EntryMapRecord"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"firstentryindex","type":"dfn","url":"#entrymaprecord-firstentryindex"},
-"#entrymaprecord-lastentryindex": {"displayText":"lastentryindex","export":true,"for_":["EntryMapRecord"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"lastentryindex","type":"dfn","url":"#entrymaprecord-lastentryindex"},
-"#feature-map": {"displayText":"feature map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"feature map","type":"dfn","url":"#feature-map"},
-"#feature-map-entrymaprecords": {"displayText":"entrymaprecords","export":true,"for_":["Feature Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrymaprecords","type":"dfn","url":"#feature-map-entrymaprecords"},
-"#feature-map-featurerecords": {"displayText":"featurerecords","export":true,"for_":["Feature Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featurerecords","type":"dfn","url":"#feature-map-featurerecords"},
-"#featurerecord": {"displayText":"featurerecord","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featurerecord","type":"dfn","url":"#featurerecord"},
-"#featurerecord-entrymapcount": {"displayText":"entrymapcount","export":true,"for_":["FeatureRecord"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrymapcount","type":"dfn","url":"#featurerecord-entrymapcount"},
-"#featurerecord-featuretag": {"displayText":"featuretag","export":true,"for_":["FeatureRecord"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featuretag","type":"dfn","url":"#featurerecord-featuretag"},
-"#featurerecord-firstnewentryindex": {"displayText":"firstnewentryindex","export":true,"for_":["FeatureRecord"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"firstnewentryindex","type":"dfn","url":"#featurerecord-firstnewentryindex"},
 "#font-patch": {"displayText":"font patch","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"font patch","type":"dfn","url":"#font-patch"},
 "#font-subset": {"displayText":"font subset","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"font subset","type":"dfn","url":"#font-subset"},
 "#font-subset-definition": {"displayText":"font subset definition","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"font subset definition","type":"dfn","url":"#font-subset-definition"},
-"#format-1-patch-map": {"displayText":"format 1 patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 1 patch map","type":"dfn","url":"#format-1-patch-map"},
-"#format-1-patch-map-appliedentriesbitmap": {"displayText":"appliedentriesbitmap","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"appliedentriesbitmap","type":"dfn","url":"#format-1-patch-map-appliedentriesbitmap"},
-"#format-1-patch-map-cff2charstringsoffset": {"displayText":"cff2charstringsoffset","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cff2charstringsoffset","type":"dfn","url":"#format-1-patch-map-cff2charstringsoffset"},
-"#format-1-patch-map-cffcharstringsoffset": {"displayText":"cffcharstringsoffset","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cffcharstringsoffset","type":"dfn","url":"#format-1-patch-map-cffcharstringsoffset"},
-"#format-1-patch-map-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#format-1-patch-map-compatibilityid"},
-"#format-1-patch-map-featuremapoffset": {"displayText":"featuremapoffset","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"featuremapoffset","type":"dfn","url":"#format-1-patch-map-featuremapoffset"},
-"#format-1-patch-map-flags": {"displayText":"flags","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"flags","type":"dfn","url":"#format-1-patch-map-flags"},
-"#format-1-patch-map-format": {"displayText":"format","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#format-1-patch-map-format"},
-"#format-1-patch-map-glyphcount": {"displayText":"glyphcount","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyphcount","type":"dfn","url":"#format-1-patch-map-glyphcount"},
-"#format-1-patch-map-maxentryindex": {"displayText":"maxentryindex","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxentryindex","type":"dfn","url":"#format-1-patch-map-maxentryindex"},
-"#format-1-patch-map-maxglyphmapentryindex": {"displayText":"maxglyphmapentryindex","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxglyphmapentryindex","type":"dfn","url":"#format-1-patch-map-maxglyphmapentryindex"},
-"#format-1-patch-map-patchformat": {"displayText":"patchformat","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patchformat","type":"dfn","url":"#format-1-patch-map-patchformat"},
-"#format-1-patch-map-urltemplate": {"displayText":"urltemplate","export":true,"for_":["Format 1 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"urltemplate","type":"dfn","url":"#format-1-patch-map-urltemplate"},
-"#format-2-patch-map": {"displayText":"format 2 patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format 2 patch map","type":"dfn","url":"#format-2-patch-map"},
-"#format-2-patch-map-cff2charstringsoffset": {"displayText":"cff2charstringsoffset","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cff2charstringsoffset","type":"dfn","url":"#format-2-patch-map-cff2charstringsoffset"},
-"#format-2-patch-map-cffcharstringsoffset": {"displayText":"cffcharstringsoffset","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cffcharstringsoffset","type":"dfn","url":"#format-2-patch-map-cffcharstringsoffset"},
-"#format-2-patch-map-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#format-2-patch-map-compatibilityid"},
-"#format-2-patch-map-defaultpatchformat": {"displayText":"defaultpatchformat","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"defaultpatchformat","type":"dfn","url":"#format-2-patch-map-defaultpatchformat"},
-"#format-2-patch-map-entries": {"displayText":"entries","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entries","type":"dfn","url":"#format-2-patch-map-entries"},
-"#format-2-patch-map-entrycount": {"displayText":"entrycount","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrycount","type":"dfn","url":"#format-2-patch-map-entrycount"},
-"#format-2-patch-map-entryidstringdata": {"displayText":"entryidstringdata","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entryidstringdata","type":"dfn","url":"#format-2-patch-map-entryidstringdata"},
-"#format-2-patch-map-flags": {"displayText":"flags","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"flags","type":"dfn","url":"#format-2-patch-map-flags"},
-"#format-2-patch-map-format": {"displayText":"format","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#format-2-patch-map-format"},
-"#format-2-patch-map-urltemplate": {"displayText":"urltemplate","export":true,"for_":["Format 2 Patch Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"urltemplate","type":"dfn","url":"#format-2-patch-map-urltemplate"},
 "#full-invalidation": {"displayText":"full invalidation","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"full invalidation","type":"dfn","url":"#full-invalidation"},
 "#glyph-closure": {"displayText":"glyph closure","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyph closure","type":"dfn","url":"#glyph-closure"},
 "#glyph-keyed-patch": {"displayText":"glyph keyed patch","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyph keyed patch","type":"dfn","url":"#glyph-keyed-patch"},
@@ -5433,9 +4959,6 @@ let refsData = {
 "#glyph-keyed-patch-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Glyph keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#glyph-keyed-patch-compatibilityid"},
 "#glyph-keyed-patch-flags": {"displayText":"flags","export":true,"for_":["Glyph keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"flags","type":"dfn","url":"#glyph-keyed-patch-flags"},
 "#glyph-keyed-patch-maxuncompressedlength": {"displayText":"maxuncompressedlength","export":true,"for_":["Glyph keyed patch"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"maxuncompressedlength","type":"dfn","url":"#glyph-keyed-patch-maxuncompressedlength"},
-"#glyph-map": {"displayText":"glyph map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyph map","type":"dfn","url":"#glyph-map"},
-"#glyph-map-entryindex": {"displayText":"entryindex","export":true,"for_":["Glyph Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entryindex","type":"dfn","url":"#glyph-map-entryindex"},
-"#glyph-map-firstmappedglyph": {"displayText":"firstmappedglyph","export":true,"for_":["Glyph Map"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"firstmappedglyph","type":"dfn","url":"#glyph-map-firstmappedglyph"},
 "#glyphpatches": {"displayText":"glyphpatches","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyphpatches","type":"dfn","url":"#glyphpatches"},
 "#glyphpatches-glyphcount": {"displayText":"glyphcount","export":true,"for_":["GlyphPatches"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyphcount","type":"dfn","url":"#glyphpatches-glyphcount"},
 "#glyphpatches-glyphdata": {"displayText":"glyphdata","export":true,"for_":["GlyphPatches"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"glyphdata","type":"dfn","url":"#glyphpatches-glyphdata"},
@@ -5464,6 +4987,17 @@ let refsData = {
 "#patch-format": {"displayText":"patch format","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch format","type":"dfn","url":"#patch-format"},
 "#patch-map": {"displayText":"patch map","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map","type":"dfn","url":"#patch-map"},
 "#patch-map-entries": {"displayText":"patch map entries","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map entries","type":"dfn","url":"#patch-map-entries"},
+"#patch-map-table-cff2charstringsoffset": {"displayText":"cff2charstringsoffset","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cff2charstringsoffset","type":"dfn","url":"#patch-map-table-cff2charstringsoffset"},
+"#patch-map-table-cffcharstringsoffset": {"displayText":"cffcharstringsoffset","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"cffcharstringsoffset","type":"dfn","url":"#patch-map-table-cffcharstringsoffset"},
+"#patch-map-table-compatibilityid": {"displayText":"compatibilityid","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"compatibilityid","type":"dfn","url":"#patch-map-table-compatibilityid"},
+"#patch-map-table-defaultpatchformat": {"displayText":"defaultpatchformat","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"defaultpatchformat","type":"dfn","url":"#patch-map-table-defaultpatchformat"},
+"#patch-map-table-encoding": {"displayText":"patch map table","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"patch map table","type":"dfn","url":"#patch-map-table-encoding"},
+"#patch-map-table-entries": {"displayText":"entries","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entries","type":"dfn","url":"#patch-map-table-entries"},
+"#patch-map-table-entrycount": {"displayText":"entrycount","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entrycount","type":"dfn","url":"#patch-map-table-entrycount"},
+"#patch-map-table-entryidstringdata": {"displayText":"entryidstringdata","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"entryidstringdata","type":"dfn","url":"#patch-map-table-entryidstringdata"},
+"#patch-map-table-flags": {"displayText":"flags","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"flags","type":"dfn","url":"#patch-map-table-flags"},
+"#patch-map-table-format": {"displayText":"format","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"format","type":"dfn","url":"#patch-map-table-format"},
+"#patch-map-table-urltemplate": {"displayText":"urltemplate","export":true,"for_":["Patch Map Table"],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"urltemplate","type":"dfn","url":"#patch-map-table-urltemplate"},
 "#shaping-unit": {"displayText":"shaping unit","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"shaping unit","type":"dfn","url":"#shaping-unit"},
 "#sparse-bit-set": {"displayText":"sparse bit set","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"sparse bit set","type":"dfn","url":"#sparse-bit-set"},
 "#table-keyed-patch": {"displayText":"table keyed patch","export":true,"for_":[],"level":"","normative":true,"shortname":"ift","spec":"ift","status":"local","text":"table keyed patch","type":"dfn","url":"#table-keyed-patch"},


### PR DESCRIPTION
Now that the encoder is much more developed, we've found that encodings rarely are eligible to use format 1. As a result it's unlikely format 1 would be used in practice. So drop format 1 from the specification with format 2 becoming the sole patch map format.

Format 2 is a superset of format 1's functionality, so this does not cause any loss of functionality.

Discussed removal on the mailing list: https://lists.w3.org/Archives/Public/public-webfonts-wg/2026Jul/0011.html


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 31, 2026, 11:52 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2FIFT%2Fe8f8a36eb983ea2f3a0c0918a20fd03446134191%2FOverview.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "2824:1",
        "messageType": "fatal",
        "text": "Couldn't find include file 'feature-registry.html'."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/IFT%23311.)._

</details>
